### PR TITLE
Configuration Update - Java 9 - License File

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,277 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Application PCM-Java Common Reactions
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.common
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.common
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.vitruv.applications.pcmjava.common.pcm2java,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: PCM 2 Java Dependency Injection
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java
 Bundle-Version: 0.1.0.qualifier
 Export-Package: tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java
 Require-Bundle: com.google.guava,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/PcmJamoppUtilsGuice.xtend
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/PcmJamoppUtilsGuice.xtend
@@ -66,10 +66,8 @@ public class PcmJamoppUtilsGuice {
 
 	def public static createConfigureMethodForAssemblyContext(AssemblyContext assemblyContext,
 		RepositoryComponent component, CorrespondenceModel correspondenceModel, UserInteractor userInteractor) {
-		var Class jaMoPPClass = null
 		var Class jaMoPPCompositeClass = null
 		try {
-			jaMoPPClass = correspondenceModel.getCorrespondingEObjectsByType(component, Class).claimOne
 			jaMoPPCompositeClass = correspondenceModel.getCorrespondingEObjectsByType(
 				assemblyContext.parentStructure__AssemblyContext, Class).claimOne
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java EJB Transformations Java -> PCM
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm;singleton:=true
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm
 Bundle-Version: 0.1.0.qualifier
 Export-Package: tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm.change2commandtransforming
 Require-Bundle: org.apache.log4j,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java EJB Transformations PCM -> Java
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java
 Bundle-Version: 0.1.0.qualifier
 Export-Package: tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java
 Require-Bundle: org.eclipse.emf.ecore,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java EJB Transformations
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ejbtransformations;singleton:=true
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.ejbtransformations
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm,
  tools.vitruv.framework.applications
-

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java POJO Transformations Java -> PCM
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations.java2pcm
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations.java2pcm
 Bundle-Version: 0.1.0.qualifier
 Require-Bundle: org.eclipse.emf.ecore,
  com.google.guava,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java POJO Transformations PCM -> Java
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations.pcm2java;singleton:=true
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations.pcm2java
 Bundle-Version: 0.1.0.qualifier
 Export-Package: tools.vitruv.applications.pcmjava.pojotransformations.pcm2java
 Require-Bundle: org.eclipse.emf.ecore,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java POJO Transformations
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations;singleton:=true
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations
 Bundle-Version: 0.1.0.qualifier
 Require-Bundle: org.eclipse.emf.ecore,
  org.apache.log4j,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ui/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ui/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java UI Integration
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ui;singleton:=true
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.ui
 Bundle-Version: 0.1.0.qualifier
 Bundle-Activator: tools.vitruv.applications.pcmjava.ui.Activator
 Require-Bundle: org.eclipse.core.runtime,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Application PCM-Java Utilities
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.util
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.util
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/META-INF/MANIFEST.MF
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/META-INF/MANIFEST.MF
@@ -28,4 +28,6 @@ Require-Bundle: com.google.guava,
   org.palladiosimulator.pcm,
   org.eclipse.uml2.uml,
   org.emftext.language.java,
-  org.apache.commons.io;bundle-version="2.2.0"
+  org.apache.commons.io;bundle-version="2.2.0",
+  org.palladiosimulator.pcm.resources
+Comment: Do not remove org.palladiosimulator.pcm.resources dependency. It is needed because the PCM primitive types repo is provided by this plugin, which is loaded using the URI string and, thus, does not induce a statically checked dependency

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/META-INF/MANIFEST.MF
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-UML Components Transformations PCM -> UML
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents.pcm2uml
+Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents.pcm2uml
 Bundle-Version: 0.1.0.qualifier
 Eclipse-ExtensibleAPI: true
 Export-Package: tools.vitruv.applications.pcmumlcomponents.pcm2uml

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm/META-INF/MANIFEST.MF
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-UML Components Transformations UML -> PCM
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents.uml2pcm
+Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents.uml2pcm
 Bundle-Version: 0.1.0.qualifier
 Eclipse-ExtensibleAPI: true
 Require-Bundle: com.google.guava,

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents/META-INF/MANIFEST.MF
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Componenst Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents;singleton:=true
+Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: tools.vitruv.framework.applications,

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp/META-INF/MANIFEST.MF
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Class2comp
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.class2comp
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.class2comp
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Export-Package: tools.vitruv.applications.umlclassumlcomponents.class2comp
 Require-Bundle: org.eclipse.uml2.uml,
  org.apache.log4j,

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp/META-INF/MANIFEST.MF
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Class2comp
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.class2comp
+Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.class2comp
 Bundle-Version: 1.0.0.qualifier
 Export-Package: tools.vitruv.applications.umlclassumlcomponents.class2comp
 Require-Bundle: org.eclipse.uml2.uml,

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/META-INF/MANIFEST.MF
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Comp2Class
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.comp2class
+Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.comp2class
 Bundle-Version: 1.0.0.qualifier
 Export-Package: tools.vitruv.applications.umlclassumlcomponents.comp2class
 Require-Bundle: org.eclipse.uml2.uml,

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/META-INF/MANIFEST.MF
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Comp2Class
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.comp2class
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.comp2class
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Export-Package: tools.vitruv.applications.umlclassumlcomponents.comp2class
 Require-Bundle: org.eclipse.uml2.uml,
  org.apache.log4j,

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.sharedutil/META-INF/MANIFEST.MF
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.sharedutil/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SharedUtil
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.sharedutil
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.sharedutil
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Export-Package: tools.vitruv.applications.umlclassumlcomponents.sharedutil
 Require-Bundle: org.eclipse.uml2.uml,
  org.apache.log4j,

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.sharedutil/META-INF/MANIFEST.MF
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.sharedutil/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: SharedUtil
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.sharedutil
+Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.sharedutil
 Bundle-Version: 1.0.0.qualifier
 Export-Package: tools.vitruv.applications.umlclassumlcomponents.sharedutil
 Require-Bundle: org.eclipse.uml2.uml,

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/.project
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/.project
@@ -30,17 +30,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>org.emftext.language.java.resource.java.nature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/META-INF/MANIFEST.MF
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius UML-Java Transformations Java -> Uml
 Bundle-SymbolicName: tools.vitruv.applications.umljava.java2uml
+Automatic-Module-Name: tools.vitruv.applications.umljava.java2uml
 Bundle-Version: 0.1.0.qualifier
 Eclipse-ExtensibleAPI: true
 Require-Bundle: com.google.guava,
@@ -28,4 +29,3 @@ Require-Bundle: com.google.guava,
  org.apache.commons.io;bundle-version="2.2.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: tools.vitruv.applications.umljava.java2uml
-

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/.project
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/.project
@@ -30,17 +30,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>org.emftext.language.java.resource.java.nature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/META-INF/MANIFEST.MF
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius UML-Java Transformations UML -> Java
 Bundle-SymbolicName: tools.vitruv.applications.umljava.uml2java
+Automatic-Module-Name: tools.vitruv.applications.umljava.uml2java
 Bundle-Version: 0.1.0.qualifier
 Eclipse-ExtensibleAPI: true
 Require-Bundle: com.google.guava,

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/.project
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/.project
@@ -30,17 +30,11 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>org.emftext.language.java.resource.java.nature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/META-INF/MANIFEST.MF
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius UML-Java Transformations Utils
 Bundle-SymbolicName: tools.vitruv.applications.umljava.util
+Automatic-Module-Name: tools.vitruv.applications.umljava.util
 Bundle-Version: 0.1.0.qualifier
 Require-Bundle: com.google.guava,
  org.eclipse.xtext.xbase.lib,

--- a/bundles/umljava/tools.vitruv.applications.umljava/META-INF/MANIFEST.MF
+++ b/bundles/umljava/tools.vitruv.applications.umljava/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML-Java Application
 Bundle-SymbolicName: tools.vitruv.applications.umljava;singleton:=true
+Automatic-Module-Name: tools.vitruv.applications.umljava
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: 

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java EJB Transformations Tests Java -> PCM
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm.tests
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm.tests
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java POJO Transformations Tests Java -> PCM
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java POJO Transformations Tests PCM -> Java
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.tests
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.tests
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java Tests Utilities
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.tests.util
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.tests.util
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.tests
+Automatic-Module-Name: tools.vitruv.applications.pcmjava.tests
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/pcmumlclass/tools.vitruv.applications.pcmumlclass.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmumlclass/tools.vitruv.applications.pcmumlclass.tests/META-INF/MANIFEST.MF
@@ -16,6 +16,5 @@ Require-Bundle: tools.vitruv.testutils;bundle-version="0.2.0",
  org.eclipse.jdt.ui;bundle-version="3.12.2",
  org.eclipse.core.resources;bundle-version="3.11.1",
  org.eclipse.text;bundle-version="3.6.0",
- org.eclipse.emf.compare,
- org.palladiosimulator.pcm.resources
+ org.eclipse.emf.compare
 Export-Package: tools.vitruv.applications.pcmumlclass.tests

--- a/tests/pcmumlclass/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlClassTestSuite.xtend
+++ b/tests/pcmumlclass/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlClassTestSuite.xtend
@@ -1,0 +1,23 @@
+package tools.vitruv.applications.pcmumlclass.tests
+
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+@RunWith(Suite)
+
+@Suite.SuiteClasses(
+    AssemblyContextConceptTest,
+    AttributeConceptTest,
+    CompositeDataTypeConceptTest,
+    InterfaceConceptTest,
+    MediaStoreRepositoryCreationTest,
+    ParameterConceptTest,
+    ProvidedRoleTest,
+    RepositoryComponentConceptTest,
+    RepositoryConceptTest,
+    RequiredRoleConceptTest,
+    SignatureConceptTest,
+    SystemConceptTest)
+class PcmUmlClassTestSuite {
+	
+}

--- a/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-UML Components Transformations Tests PCM -> UML
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents.pcm2uml.tests
+Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents.pcm2uml.tests
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: tools.vitruv.applications.pcmumlcomponents.pcm2uml;bundle-version="0.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-UML Components Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents.tests
+Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents.tests
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-UML Components Transformations Tests UML -> PCm
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests
+Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: tools.vitruv.applications.pcmumlcomponents.uml2pcm;bundle-version="0.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/tools.vitruv.applications.cbs.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.cbs.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Tests for Component-based Systems
 Bundle-SymbolicName: tools.vitruv.applications.cbs.tests
+Automatic-Module-Name: tools.vitruv.applications.cbs.tests
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp.tests/META-INF/MANIFEST.MF
+++ b/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Applications UMLClass-UMLComp Tests
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.class2comp.tests
+Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.class2comp.tests
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,

--- a/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp.tests/META-INF/MANIFEST.MF
+++ b/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Applications UMLClass-UMLComp Tests
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.class2comp.tests
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.class2comp.tests
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,
  org.apache.log4j,

--- a/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class.tests/META-INF/MANIFEST.MF
+++ b/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Applications UMLComp-UMLClass Tests
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.comp2class.tests
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.comp2class.tests
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,
  org.apache.log4j,

--- a/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class.tests/META-INF/MANIFEST.MF
+++ b/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Applications UMLComp-UMLClass Tests
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.comp2class.tests
+Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.comp2class.tests
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: com.google.guava,

--- a/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.tests/META-INF/MANIFEST.MF
+++ b/tests/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius UML Class-UML Components Tests
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.tests
+Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.tests
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/umljava/tools.vitruv.applications.umljava.java2uml.tests/.project
+++ b/tests/umljava/tools.vitruv.applications.umljava.java2uml.tests/.project
@@ -25,16 +25,10 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
-		<buildCommand>
-			<name>net.sf.eclipsecs.core.CheckstyleBuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
-		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
 </projectDescription>

--- a/tests/umljava/tools.vitruv.applications.umljava.java2uml.tests/META-INF/MANIFEST.MF
+++ b/tests/umljava/tools.vitruv.applications.umljava.java2uml.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius UML-Java Transformations Tests Java -> UML
 Bundle-SymbolicName: tool.vitruv.applications.umljava.java2uml.tests
+Automatic-Module-Name: tool.vitruv.applications.umljava.java2uml.tests
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: tools.vitruv.applications.umljava.java2uml
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8

--- a/tests/umljava/tools.vitruv.applications.umljava.tests/META-INF/MANIFEST.MF
+++ b/tests/umljava/tools.vitruv.applications.umljava.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius UML-Java Tests
 Bundle-SymbolicName: tools.vitruv.applications.umljava.tests
+Automatic-Module-Name: tools.vitruv.applications.umljava.tests
 Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit,

--- a/tests/umljava/tools.vitruv.applications.umljava.uml2java.tests/META-INF/MANIFEST.MF
+++ b/tests/umljava/tools.vitruv.applications.umljava.uml2java.tests/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius UML-Java Transformations Tests UML -> Java
 Bundle-SymbolicName: tool.vitruv.applications.umljava.uml2java.tests
+Automatic-Module-Name: tool.vitruv.applications.umljava.uml2java.tests
 Bundle-Version: 0.1.0.qualifier
 Fragment-Host: tools.vitruv.applications.umljava.uml2java
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8


### PR DESCRIPTION
This PR adds automatic module names for Java 9 compatibility, fixes some configuration bugs and cleans up unsued code. It corrects some dependency placements and adds the missing license file.