### PR TITLE
Update to Reactions syntax changes

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548345277498</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/AddParameterAndAssignmentToConstructorRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/AddParameterAndAssignmentToConstructorRoutine.java
@@ -2,11 +2,13 @@ package mir.routines.pcm2javaCommon;
 
 import java.io.IOException;
 import mir.routines.pcm2javaCommon.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emftext.language.java.members.Constructor;
 import org.emftext.language.java.members.Field;
 import org.emftext.language.java.parameters.OrdinaryParameter;
+import org.emftext.language.java.parameters.Parameter;
 import org.emftext.language.java.statements.Statement;
 import org.emftext.language.java.types.NamespaceClassifierReference;
 import org.palladiosimulator.pcm.core.entity.NamedElement;
@@ -29,9 +31,11 @@ public class AddParameterAndAssignmentToConstructorRoutine extends AbstractRepai
     }
     
     public void update0Element(final NamedElement parameterCorrespondenceSource, final Constructor constructor, final NamespaceClassifierReference typeReference, final Field fieldToBeAssigned, final String parameterName, final OrdinaryParameter newParameter) {
-      constructor.getParameters().add(newParameter);
+      EList<Parameter> _parameters = constructor.getParameters();
+      _parameters.add(newParameter);
       final Statement asssignment = JavaModificationUtil.createAssignmentFromParameterToField(fieldToBeAssigned, newParameter);
-      constructor.getStatements().add(asssignment);
+      EList<Statement> _statements = constructor.getStatements();
+      _statements.add(asssignment);
     }
     
     public void updateNewParameterElement(final NamedElement parameterCorrespondenceSource, final Constructor constructor, final NamespaceClassifierReference typeReference, final Field fieldToBeAssigned, final String parameterName, final OrdinaryParameter newParameter) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/AddProvidedRoleRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/AddProvidedRoleRoutine.java
@@ -2,10 +2,12 @@ package mir.routines.pcm2javaCommon;
 
 import java.io.IOException;
 import mir.routines.pcm2javaCommon.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.classifiers.Interface;
 import org.emftext.language.java.imports.ClassifierImport;
 import org.emftext.language.java.types.NamespaceClassifierReference;
+import org.emftext.language.java.types.TypeReference;
 import org.palladiosimulator.pcm.core.entity.InterfaceProvidingEntity;
 import org.palladiosimulator.pcm.repository.OperationInterface;
 import org.palladiosimulator.pcm.repository.OperationProvidedRole;
@@ -28,7 +30,8 @@ public class AddProvidedRoleRoutine extends AbstractRepairRoutineRealization {
     }
     
     public void update0Element(final OperationProvidedRole providedRole, final Interface operationProvidingInterface, final org.emftext.language.java.classifiers.Class javaClass, final ClassifierImport interfaceImport, final NamespaceClassifierReference namespaceClassifierReference) {
-      javaClass.getImplements().add(namespaceClassifierReference);
+      EList<TypeReference> _implements = javaClass.getImplements();
+      _implements.add(namespaceClassifierReference);
     }
     
     public EObject getCorrepondenceSourceJavaClass(final OperationProvidedRole providedRole, final Interface operationProvidingInterface) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/CreateCollectionDataTypeImplementationRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/CreateCollectionDataTypeImplementationRoutine.java
@@ -66,7 +66,8 @@ public class CreateCollectionDataTypeImplementationRoutine extends AbstractRepai
       int _size = collectionDataTypes.size();
       final List<String> collectionDataTypeNames = new ArrayList<String>(_size);
       for (final Class<?> collectionDataType : collectionDataTypes) {
-        collectionDataTypeNames.add(collectionDataType.getName());
+        String _name = collectionDataType.getName();
+        collectionDataTypeNames.add(_name);
       }
       final String selectTypeMsg = "Please select type (or interface) that should be used for the type";
       final int selectedType = (this.userInteractor.getSingleSelectionDialogBuilder().message(selectTypeMsg).choices(collectionDataTypeNames).windowModality(UserInteractionOptions.WindowModality.MODAL).startInteraction()).intValue();

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/CreateCompilationUnitRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/CreateCompilationUnitRoutine.java
@@ -36,7 +36,8 @@ public class CreateCompilationUnitRoutine extends AbstractRepairRoutineRealizati
       String _name_1 = classifier.getName();
       String _plus = (_name_1 + ".java");
       compilationUnit.setName(_plus);
-      compilationUnit.getClassifiers().add(classifier);
+      EList<ConcreteClassifier> _classifiers = compilationUnit.getClassifiers();
+      _classifiers.add(classifier);
       this.persistProjectRelative(sourceElementMappedToClass, compilationUnit, JavaPersistenceHelper.buildJavaFilePath(compilationUnit));
     }
     

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/CreateSEFFRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/CreateSEFFRoutine.java
@@ -2,9 +2,11 @@ package mir.routines.pcm2javaCommon;
 
 import java.io.IOException;
 import mir.routines.pcm2javaCommon.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.members.ClassMethod;
 import org.emftext.language.java.members.InterfaceMethod;
+import org.emftext.language.java.members.Member;
 import org.palladiosimulator.pcm.repository.BasicComponent;
 import org.palladiosimulator.pcm.repository.OperationSignature;
 import org.palladiosimulator.pcm.repository.Signature;
@@ -30,7 +32,8 @@ public class CreateSEFFRoutine extends AbstractRepairRoutineRealization {
     public void update0Element(final ServiceEffectSpecification seff, final org.emftext.language.java.classifiers.Class componentClass, final InterfaceMethod interfaceMethod, final ClassMethod classMethod) {
       ClassMethod correspondingClassMethod = Pcm2JavaHelper.findMethodInClass(componentClass, classMethod);
       if ((null == correspondingClassMethod)) {
-        componentClass.getMembers().add(classMethod);
+        EList<Member> _members = componentClass.getMembers();
+        _members.add(classMethod);
         correspondingClassMethod = classMethod;
       } else {
         correspondingClassMethod.setName(interfaceMethod.getName());

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/RemoveParameterToFieldAssignmentFromConstructorRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/RemoveParameterToFieldAssignmentFromConstructorRoutine.java
@@ -46,7 +46,8 @@ public class RemoveParameterToFieldAssignmentFromConstructorRoutine extends Abst
                 if ((field instanceof Field)) {
                   boolean _equals = ((Field)field).getName().equals(fieldName);
                   if (_equals) {
-                    ctor.getStatements().remove(statement);
+                    EList<Statement> _statements_1 = ctor.getStatements();
+                    _statements_1.remove(((ExpressionStatement)statement));
                     return;
                   }
                 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/RenameMethodForOperationSignatureRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src-gen/mir/routines/pcm2javaCommon/RenameMethodForOperationSignatureRoutine.java
@@ -55,7 +55,8 @@ public class RenameMethodForOperationSignatureRoutine extends AbstractRepairRout
           return Boolean.valueOf(Objects.equal(_id, _id_1));
         };
         final Consumer<OperationProvidedRole> _function_2 = (OperationProvidedRole opProRole) -> {
-          implementingComponents.add(opProRole.getProvidingEntity_ProvidedRole());
+          InterfaceProvidingEntity _providingEntity_ProvidedRole = opProRole.getProvidingEntity_ProvidedRole();
+          implementingComponents.add(_providingEntity_ProvidedRole);
         };
         IterableExtensions.<OperationProvidedRole>filter(opProvRoles, _function_1).forEach(_function_2);
       };

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -344,7 +344,7 @@ routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType)
 			collectionDataTypes += #[ArrayList, LinkedList, Vector, Stack, HashSet];
 			val List<String> collectionDataTypeNames = new ArrayList<String>(collectionDataTypes.size);
 			for (collectionDataType : collectionDataTypes) {
-				collectionDataTypeNames.add(collectionDataType.name);
+				collectionDataTypeNames += collectionDataType.name;
 			}
 			val String selectTypeMsg = "Please select type (or interface) that should be used for the type";
 			val int selectedType = userInteractor.singleSelectionDialogBuilder.message(selectTypeMsg)
@@ -589,7 +589,7 @@ routine createCompilationUnit(pcm::NamedElement sourceElementMappedToClass, java
 			compilationUnit.namespaces += containingPackage.namespaces;
 			compilationUnit.namespaces += containingPackage.name;
 			compilationUnit.name = classifier.name + ".java";
-			compilationUnit.classifiers.add(classifier);
+			compilationUnit.classifiers += classifier;
 			persistProjectRelative(sourceElementMappedToClass, compilationUnit, buildJavaFilePath(compilationUnit));
 		}
 		add correspondence between compilationUnit and sourceElementMappedToClass
@@ -651,7 +651,7 @@ routine addProvidedRole(pcm::OperationProvidedRole providedRole) {
 		}
 		add correspondence between namespaceClassifierReference and providedRole
 		update javaClass {
-			javaClass.implements.add(namespaceClassifierReference);
+			javaClass.implements += namespaceClassifierReference;
 		}
 	}
 }
@@ -749,9 +749,9 @@ routine addParameterAndAssignmentToConstructor(pcm::NamedElement parameterCorres
 		}
 		add correspondence between newParameter and parameterCorrespondenceSource
 		update constructor {
-			constructor.parameters.add(newParameter);
+			constructor.parameters += newParameter;
 			val asssignment = createAssignmentFromParameterToField(fieldToBeAssigned, newParameter);
-			constructor.statements.add(asssignment);
+			constructor.statements += asssignment;
 		}
 	}
 }
@@ -795,7 +795,7 @@ routine removeParameterToFieldAssignmentFromConstructor(java::Constructor ctor, 
 								val field = fieldReference.target;
 								if (field instanceof Field) {
 									if (field.name.equals(fieldName)) {
-										ctor.statements.remove(statement);
+										ctor.statements -= statement;
 										return;
 									}
 								}
@@ -882,7 +882,7 @@ routine renameMethodForOperationSignature(pcm::OperationSignature operationSigna
 			operationInterface.repository__Interface.components__Repository.forEach [ comp |
 				val opProvRoles = comp.providedRoles_InterfaceProvidingEntity.filter(OperationProvidedRole);
 				opProvRoles.filter[it.providedInterface__OperationProvidedRole.id == operationInterface.id].forEach [ opProRole |
-					implementingComponents.add(opProRole.providingEntity_ProvidedRole);
+					implementingComponents += opProRole.providingEntity_ProvidedRole;
 				]
 			]
 			val basicComponents = implementingComponents.filter(BasicComponent);
@@ -1091,7 +1091,7 @@ routine createSEFF(pcm::ServiceEffectSpecification seff) {
 		update componentClass {
 			var correspondingClassMethod = componentClass.findMethodInClass(classMethod);
 			if (null === correspondingClassMethod) {
-				componentClass.members.add(classMethod);
+				componentClass.members += classMethod;
 				correspondingClassMethod = classMethod;
 			} else {
 				correspondingClassMethod.name = interfaceMethod.name;

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548343623908</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/src-gen/mir/routines/pcm2depInjectJava/AddedProvidedDelegationConnectorRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/src-gen/mir/routines/pcm2depInjectJava/AddedProvidedDelegationConnectorRoutine.java
@@ -55,7 +55,8 @@ public class AddedProvidedDelegationConnectorRoutine extends AbstractRepairRouti
           return;
         }
       }
-      systemClass.getImplements().add(namespaceClassifierRef);
+      EList<TypeReference> _implements_1 = systemClass.getImplements();
+      _implements_1.add(namespaceClassifierRef);
       final Import classifierImport = JavaModificationUtil.addImportToCompilationUnitOfClassifier(systemClass, jaMoPPInterface);
       this.correspondenceModel.createAndAddCorrespondence(CollectionBridge.<EObject>toList(pcmSystem), Collections.<EObject>unmodifiableList(CollectionLiterals.<EObject>newArrayList(namespaceClassifierRef, classifierImport)));
     }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
@@ -14,7 +14,7 @@ import static tools.vitruv.applications.pcmjava.util.pcm2java.Pcm2JavaHelper.*
 import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
-import static extension tools.vitruv.framework.correspondence.CorrespondenceModelUtil.*
+import static extension tools.vitruv.framework.^correspondence.CorrespondenceModelUtil.*
 import static extension tools.vitruv.framework.util.bridges.CollectionBridge.*
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
@@ -122,7 +122,7 @@ routine addedProvidedDelegationConnector(pcm::ProvidedDelegationConnector provid
 					return;
 				}
 			}
-			systemClass.implements.add(namespaceClassifierRef);
+			systemClass.implements += namespaceClassifierRef;
 			val classifierImport = addImportToCompilationUnitOfClassifier(systemClass, jaMoPPInterface);
 			correspondenceModel.createAndAddCorrespondence(pcmSystem.toList, #[namespaceClassifierRef, classifierImport]);
 		}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548245266579</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreateBasicComponentRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreateBasicComponentRoutine.java
@@ -2,10 +2,12 @@ package mir.routines.ejbjava2pcm;
 
 import java.io.IOException;
 import mir.routines.ejbjava2pcm.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.commons.NamedElement;
 import org.palladiosimulator.pcm.repository.BasicComponent;
 import org.palladiosimulator.pcm.repository.Repository;
+import org.palladiosimulator.pcm.repository.RepositoryComponent;
 import tools.vitruv.extensions.dslsruntime.reactions.AbstractRepairRoutineRealization;
 import tools.vitruv.extensions.dslsruntime.reactions.ReactionExecutionState;
 import tools.vitruv.extensions.dslsruntime.reactions.structure.CallHierarchyHaving;
@@ -24,7 +26,8 @@ public class CreateBasicComponentRoutine extends AbstractRepairRoutineRealizatio
     }
     
     public void update0Element(final Repository repo, final NamedElement namedElement, final BasicComponent basicComponent) {
-      repo.getComponents__Repository().add(basicComponent);
+      EList<RepositoryComponent> _components__Repository = repo.getComponents__Repository();
+      _components__Repository.add(basicComponent);
     }
     
     public void updateBasicComponentElement(final Repository repo, final NamedElement namedElement, final BasicComponent basicComponent) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreateOperationInterfaceRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreateOperationInterfaceRoutine.java
@@ -2,8 +2,10 @@ package mir.routines.ejbjava2pcm;
 
 import java.io.IOException;
 import mir.routines.ejbjava2pcm.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.commons.NamedElement;
+import org.palladiosimulator.pcm.repository.Interface;
 import org.palladiosimulator.pcm.repository.OperationInterface;
 import org.palladiosimulator.pcm.repository.Repository;
 import tools.vitruv.extensions.dslsruntime.reactions.AbstractRepairRoutineRealization;
@@ -24,7 +26,8 @@ public class CreateOperationInterfaceRoutine extends AbstractRepairRoutineRealiz
     }
     
     public void update0Element(final Repository repo, final NamedElement namedElement, final OperationInterface operationInterface) {
-      repo.getInterfaces__Repository().add(operationInterface);
+      EList<Interface> _interfaces__Repository = repo.getInterfaces__Repository();
+      _interfaces__Repository.add(operationInterface);
     }
     
     public EObject getElement2(final Repository repo, final NamedElement namedElement, final OperationInterface operationInterface) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreateOperationSignatureRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreateOperationSignatureRoutine.java
@@ -3,6 +3,7 @@ package mir.routines.ejbjava2pcm;
 import java.io.IOException;
 import java.util.function.Consumer;
 import mir.routines.ejbjava2pcm.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.emftext.language.java.members.InterfaceMethod;
@@ -32,7 +33,8 @@ public class CreateOperationSignatureRoutine extends AbstractRepairRoutineRealiz
     
     public void callRoutine1(final InterfaceMethod interfaceMethod, final OperationInterface opInterface, final OperationSignature opSignature, @Extension final RoutinesFacade _routinesFacade) {
       opSignature.setEntityName(interfaceMethod.getName());
-      opInterface.getSignatures__OperationInterface().add(opSignature);
+      EList<OperationSignature> _signatures__OperationInterface = opInterface.getSignatures__OperationInterface();
+      _signatures__OperationInterface.add(opSignature);
       final Consumer<Parameter> _function = (Parameter it) -> {
         _routinesFacade.createPCMParameter(it, opSignature);
       };

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreatePCMParameterRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreatePCMParameterRoutine.java
@@ -2,6 +2,7 @@ package mir.routines.ejbjava2pcm;
 
 import java.io.IOException;
 import mir.routines.ejbjava2pcm.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.parameters.Parameter;
 import org.palladiosimulator.pcm.repository.OperationSignature;
@@ -25,7 +26,8 @@ public class CreatePCMParameterRoutine extends AbstractRepairRoutineRealization 
     }
     
     public void update0Element(final Parameter jaMoPPParam, final OperationSignature opSignature, final org.palladiosimulator.pcm.repository.Parameter pcmParameter) {
-      opSignature.getParameters__OperationSignature().add(pcmParameter);
+      EList<org.palladiosimulator.pcm.repository.Parameter> _parameters__OperationSignature = opSignature.getParameters__OperationSignature();
+      _parameters__OperationSignature.add(pcmParameter);
     }
     
     public EObject getElement2(final Parameter jaMoPPParam, final OperationSignature opSignature, final org.palladiosimulator.pcm.repository.Parameter pcmParameter) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreateSEFFForClassMethodRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreateSEFFForClassMethodRoutine.java
@@ -2,11 +2,13 @@ package mir.routines.ejbjava2pcm;
 
 import java.io.IOException;
 import mir.routines.ejbjava2pcm.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.members.ClassMethod;
 import org.palladiosimulator.pcm.repository.BasicComponent;
 import org.palladiosimulator.pcm.repository.OperationSignature;
 import org.palladiosimulator.pcm.seff.ResourceDemandingSEFF;
+import org.palladiosimulator.pcm.seff.ServiceEffectSpecification;
 import tools.vitruv.extensions.dslsruntime.reactions.AbstractRepairRoutineRealization;
 import tools.vitruv.extensions.dslsruntime.reactions.ReactionExecutionState;
 import tools.vitruv.extensions.dslsruntime.reactions.structure.CallHierarchyHaving;
@@ -25,7 +27,8 @@ public class CreateSEFFForClassMethodRoutine extends AbstractRepairRoutineRealiz
     }
     
     public void update0Element(final BasicComponent basicComponent, final OperationSignature opSignature, final ClassMethod classMethod, final ResourceDemandingSEFF seff) {
-      basicComponent.getServiceEffectSpecifications__BasicComponent().add(seff);
+      EList<ServiceEffectSpecification> _serviceEffectSpecifications__BasicComponent = basicComponent.getServiceEffectSpecifications__BasicComponent();
+      _serviceEffectSpecifications__BasicComponent.add(seff);
     }
     
     public EObject getElement2(final BasicComponent basicComponent, final OperationSignature opSignature, final ClassMethod classMethod, final ResourceDemandingSEFF seff) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreatedFieldInDatatypeClassRoutine.java
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src-gen/mir/routines/ejbjava2pcm/CreatedFieldInDatatypeClassRoutine.java
@@ -2,6 +2,7 @@ package mir.routines.ejbjava2pcm;
 
 import java.io.IOException;
 import mir.routines.ejbjava2pcm.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.members.Field;
 import org.palladiosimulator.pcm.repository.CompositeDataType;
@@ -25,7 +26,8 @@ public class CreatedFieldInDatatypeClassRoutine extends AbstractRepairRoutineRea
     }
     
     public void update0Element(final org.emftext.language.java.classifiers.Class clazz, final Field field, final CompositeDataType compositeDataType, final InnerDeclaration innerDec) {
-      compositeDataType.getInnerDeclaration_CompositeDataType().add(innerDec);
+      EList<InnerDeclaration> _innerDeclaration_CompositeDataType = compositeDataType.getInnerDeclaration_CompositeDataType();
+      _innerDeclaration_CompositeDataType.add(innerDec);
     }
     
     public EObject getCorrepondenceSourceCompositeDataType(final org.emftext.language.java.classifiers.Class clazz, final Field field) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src/tools/vitruv/applications/pcmjava/ejbtransformations/java2pcm/EjbJava2Pcm.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/src/tools/vitruv/applications/pcmjava/ejbtransformations/java2pcm/EjbJava2Pcm.reactions
@@ -11,7 +11,7 @@ import org.palladiosimulator.pcm.repository.Repository
 import java.util.Collections
 import org.palladiosimulator.pcm.repository.OperationInterface
 import org.palladiosimulator.pcm.repository.OperationSignature
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
+import tools.vitruv.framework.^correspondence.CorrespondenceModelUtil
 import tools.vitruv.applications.pcmjava.util.PcmJavaUtils
 
 import "http://www.emftext.org/java" as java
@@ -25,7 +25,7 @@ execute actions in PCM
 // ################ create Repository for first package################
 reaction CreatedFirstPackage {
 	after element java::Package inserted as root 
-	call createRepositoryForFirstPackage(newValue)  
+	call createRepositoryForFirstPackage(newValue)
 }
 
 routine createRepositoryForFirstPackage(java::Package javaPackage) {
@@ -69,7 +69,7 @@ routine createBasicComponent(pcm::Repository repo, java::NamedElement namedEleme
 		}
 		add correspondence between basicComponent and namedElement
 		update repo {
-			repo.components__Repository.add(basicComponent);		
+			repo.components__Repository += basicComponent;		
 		}
 	}
 }
@@ -102,7 +102,7 @@ routine createOperationInterface(pcm::Repository repo, java::NamedElement namedE
 		}
 		add correspondence between operationInterface and namedElement
 		update operationInterface {
-			repo.interfaces__Repository.add(operationInterface);		
+			repo.interfaces__Repository += operationInterface;		
 		}
 	}
 }
@@ -213,7 +213,7 @@ routine createOperationSignature(java::InterfaceMethod interfaceMethod, pcm::Ope
 		add correspondence between opSignature and interfaceMethod
 		call {
 			opSignature.entityName = interfaceMethod.name
-			opInterface.signatures__OperationInterface.add(opSignature)
+			opInterface.signatures__OperationInterface += opSignature
 			interfaceMethod.parameters.forEach[createPCMParameter(opSignature)]
 			interfaceMethod.typeReference.createPCMReturnType(opSignature, interfaceMethod)
 		}
@@ -244,7 +244,7 @@ routine createPCMParameter(java::Parameter jaMoPPParam, pcm::OperationSignature 
 				correspondenceModel, userInteractor, opSignature.interface__OperationSignature.repository__Interface, jaMoPPParam.arrayDimension)
 		}
 		update opSignature {
-			opSignature.parameters__OperationSignature.add(pcmParameter)
+			opSignature.parameters__OperationSignature += pcmParameter
 		}
 		add correspondence between pcmParameter and jaMoPPParam
 	}
@@ -298,7 +298,7 @@ routine createdFieldInDatatypeClass(java::Class clazz, java::Field field) {
 		}
 		add correspondence between innerDec and field
 		update compositeDataType {
-			compositeDataType.innerDeclaration_CompositeDataType.add(innerDec)
+			compositeDataType.innerDeclaration_CompositeDataType += innerDec
 		}
 	}
 }
@@ -337,7 +337,7 @@ routine createSEFFForClassMethod(pcm::BasicComponent basicComponent, pcm::Operat
 		}
 		add correspondence between seff and classMethod
 		update basicComponent {
-			basicComponent.serviceEffectSpecifications__BasicComponent.add(seff)
+			basicComponent.serviceEffectSpecifications__BasicComponent += seff
 		}	
 	}
 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548245599870</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344742589</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344638146</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/.project
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344691874</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/.project
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344782701</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/src-gen/mir/routines/pcmToUml/DeleteInnerDeclarationRoutine.java
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/src-gen/mir/routines/pcmToUml/DeleteInnerDeclarationRoutine.java
@@ -2,6 +2,7 @@ package mir.routines.pcmToUml;
 
 import java.io.IOException;
 import mir.routines.pcmToUml.RoutinesFacade;
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.uml2.uml.DataType;
 import org.eclipse.uml2.uml.Property;
@@ -30,7 +31,8 @@ public class DeleteInnerDeclarationRoutine extends AbstractRepairRoutineRealizat
     }
     
     public void callRoutine1(final CompositeDataType dataType, final InnerDeclaration innerDeclaration, final DataType compositeType, final Property umlProperty, @Extension final RoutinesFacade _routinesFacade) {
-      compositeType.getOwnedAttributes().remove(umlProperty);
+      EList<Property> _ownedAttributes = compositeType.getOwnedAttributes();
+      _ownedAttributes.remove(umlProperty);
     }
   }
   

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/src/tools/vitruv/applications/pcmumlcomponents/pcm2uml/PcmToUml.reactions
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/src/tools/vitruv/applications/pcmumlcomponents/pcm2uml/PcmToUml.reactions
@@ -180,7 +180,7 @@ routine deleteInnerDeclaration(pcm::CompositeDataType dataType, pcm::InnerDeclar
 		val umlProperty = retrieve asserted uml::Property corresponding to innerDeclaration
 	}
 	action {
-		call compositeType.ownedAttributes.remove(umlProperty)
+		call compositeType.ownedAttributes -= umlProperty
 	}
 }
 

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm/.project
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344795048</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp/.project
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344807700</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/.project
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/.project
@@ -31,4 +31,15 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344820046</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/src/tools/vitruv/applications/umlclassumlcomponents/comp2class/comp2class.reactions
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/src/tools/vitruv/applications/umlclassumlcomponents/comp2class/comp2class.reactions
@@ -199,7 +199,7 @@ routine deleteClass(umlcomp::Component umlComp) {
 				if (userInteractor.modalTextYesNoUserInteractor(question)) {
 					for (val Iterator<PackageableElement> iter = classPackage.packagedElements.iterator; iter.hasNext; ) {						
 						val classElement = iter.next
-						iter.remove
+						iter.^remove
 						classElement.destroy
 					}					
 					classPackage.destroy

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/.project
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/.project
@@ -37,4 +37,15 @@
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>org.emftext.language.java.resource.java.nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344834018</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/.project
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/.project
@@ -37,4 +37,15 @@
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>org.emftext.language.java.resource.java.nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1548344852812</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-target</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -156,7 +156,7 @@ routine addJavaSuperClass(uml::Class uClass, uml::Generalization uGeneralization
     action {
         execute {
         	if (uClass.generals.size == 1) {
-	            var typeReference = createTypeReference(uGeneralization.general as Class, Optional.of(jSuperClass), null, userInteractor)
+	            var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null, userInteractor)
 	            addJavaImport(jClass.containingCompilationUnit, typeReference)
 	            jClass.extends = typeReference
 	            addGeneralizationCorrespondence(uGeneralization, typeReference)
@@ -210,7 +210,7 @@ routine createJavaClassImplementsReference(uml::InterfaceRealization uRealizatio
 	}
 	action {
 		execute { // Should actually be split into execute and call
-            var typeReference = createTypeReference(uRealization.contract, Optional.of(jInterface), null, userInteractor)
+            var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null, userInteractor)
             addJavaImport(jClass.containingCompilationUnit, typeReference)
             jClass.implements += typeReference
             addImplementsCorrespondence(uRealization, typeReference)
@@ -307,7 +307,7 @@ routine addJavaSuperInterface(uml::Interface uInterface, uml::Generalization uGe
     }
     action {
         execute{
-            var typeReference = createTypeReference(uGeneralization.general as Interface, Optional.of(jSuperInterface), null, userInteractor)
+            var typeReference = createTypeReference(uGeneralization.general as Interface, Optional.^of(jSuperInterface), null, userInteractor)
             addJavaImport(jInterface.containingCompilationUnit, typeReference)
             jInterface.extends += typeReference
             addGeneralizationCorrespondence(uGeneralization, typeReference)

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -18,7 +18,7 @@ import "http://www.emftext.org/java" as java
 
 reactions: umlToJavaMethod
 in reaction to changes in UML
-execute actions inJava
+execute actions in Java
 
 import routines umlToJavaTypePropagation using qualified names
 
@@ -358,7 +358,7 @@ routine adaptJavaParametertoDirectionChange(uml::Operation uOperation, uml::Para
         }
         call {
             if (newDirection == ParameterDirectionKind.RETURN_LITERAL && jParam.present) {
-                EcoreUtil.remove(jParam.get)
+                EcoreUtil.^remove(jParam.get)
             } else if (newDirection == ParameterDirectionKind.IN_LITERAL && !jParam.isPresent) {
                 createJavaParameter(uOperation, uParam)
             }


### PR DESCRIPTION
This PR makes minor updates to Reactions according to the slightly modified Reactions syntax or, more specifically, the addition of new keywords due to the separation of multi-word keywords.
It also ignores `target` folders within Eclipse in all projects using Reations to avoid that the Reactions generator interprets files in the `target` folder as conflicting.