### PR TITLE
Travis Configuration Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: java
 jdk:
   - openjdk8
-env:  
-  global:  
-    - DISPLAY=:99.0  
 cache:
   directories:
    - $HOME/.m2
+# Enable UI
+services:
+  - xvfb
 
 notifications:
   email:
@@ -17,7 +17,6 @@ notifications:
 
 # Enable UI
 before_install:
-    - sh -e /etc/init.d/xvfb start - sleep 10
     - git clone --depth 1 https://github.com/kit-sdq/BuildUtilities.git /tmp/BuildUtilities
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:  
   global:  
     - DISPLAY=:99.0  


### PR DESCRIPTION
Travis does not support Oracle JDK 8 anymore. For that reason we switch to Open JDK.
Additionally, the way to enable UI (xvfb) changed on Travis servers, so we adapt the script appropriately.
