### PR TITLE
Fixed bug in TestUtil.assertTypeEquals()

### DIFF
--- a/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/testutil/TestUtil.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/testutil/TestUtil.xtend
@@ -203,6 +203,10 @@ class TestUtil {
 		throw new IllegalArgumentException("The java TypeReference " + jTypeReference + " is neither a PrimitiveType nor a NamespaceClassifierReference")
 	}
 	
+	def static dispatch void assertTypeEquals(org.eclipse.uml2.uml.Interface uInterface, NamespaceClassifierReference namespaceRef) {
+		assertEquals(uInterface.name, getInterfaceFromTypeReference(namespaceRef).name)
+	}
+	
 	def static dispatch void assertTypeEquals(org.eclipse.uml2.uml.Class uClass, NamespaceClassifierReference namespaceRef) {
 	    assertEquals(uClass.name, getClassifierFromTypeReference(namespaceRef).name)
 	}

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/testutil/TestUtil.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/testutil/TestUtil.xtend
@@ -214,6 +214,14 @@ class TestUtil {
 	def static dispatch void assertTypeEquals(java.lang.Void nullReference, Void voidType) {
         //umlType is null, javaType is void -> Do nothing, assertion passed.
     }
+    
+    // IMPORTANT EXCEPTION: String is NOT a primitive in the Java model, which means this dispatch case needs to exist:
+    def static dispatch void assertTypeEquals(org.eclipse.uml2.uml.PrimitiveType uPrimType, NamespaceClassifierReference namespaceRef) {
+		assertNotNull(uPrimType)
+		val jTypeMapped = UmlJavaTypePropagationHelper.mapUmlPrimitiveToJavaPrimitive(uPrimType)
+		assertFalse(jTypeMapped instanceof Void) // if the uml type is non null and supported by the transformations, then it should not be mapped to void
+		assertEquals(getClassifierFromTypeReference(jTypeMapped).name, getClassifierFromTypeReference(namespaceRef).name)
+    }
 	
 	def static dispatch void assertTypeEquals(org.eclipse.uml2.uml.PrimitiveType uPrimType, org.emftext.language.java.types.PrimitiveType jPrimType) {
 		assertNotNull(uPrimType)

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/util/java/JavaTypeUtil.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/util/java/JavaTypeUtil.xtend
@@ -6,6 +6,7 @@ import org.eclipse.emf.common.util.BasicEList
 import org.eclipse.emf.common.util.EList
 import org.emftext.language.java.classifiers.Classifier
 import org.emftext.language.java.classifiers.ConcreteClassifier
+import org.emftext.language.java.classifiers.Interface
 import org.emftext.language.java.generics.GenericsFactory
 import org.emftext.language.java.generics.QualifiedTypeArgument
 import org.emftext.language.java.types.ClassifierReference
@@ -63,9 +64,7 @@ class JavaTypeUtil {
     }
     
     /**
-     * 
-     * @return the classifier that is wrapped in the typeref. Returns null if the type reference does not contain
-     *          any classifier
+     * @return the classifier that is wrapped in the typeref. Returns null if the type reference does not contain any classifier
      */
     def static Classifier getClassifierFromTypeReference(TypeReference typeRef) {
         val type = getJavaTypeFromTypeReference(typeRef)
@@ -73,6 +72,19 @@ class JavaTypeUtil {
             return type
         } else {
             logger.warn("The TypeReference " + typeRef + " does not contain a Classifier. Returning null.")
+            return null
+        }
+    }
+    
+    /**
+     * @return the interface that is wrapped in the typeref. Returns null if the type reference does not contain any interfaces
+     */
+    def static Interface getInterfaceFromTypeReference(TypeReference typeRef) {
+        val type = getJavaTypeFromTypeReference(typeRef)
+        if (type instanceof Interface) {
+            return type
+        } else {
+            logger.warn("The TypeReference " + typeRef + " does not contain a Interface. Returning null.")
             return null
         }
     }


### PR DESCRIPTION
I fixed bug in the method `TestUtil.assertTypeEquals()` that lead to an unexpected exception during parameter type comparison, because in `assertTypeEquals()` only classes and not interfaces were considered as possible UML types during dynamic dispatch.

I added the missing dispatch method and a method in `JavaTypeUtil` to retrieve the Interface wrapped in a `TypeReference`.