### PR TITLE
Fixed deletion order problem in PcmRepository.reactions

### DIFF
--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmRepository.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmRepository.reactions
@@ -169,9 +169,9 @@ routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 					.message(DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
 													
 			if (deleteCorrespondingUmlRepository) {// DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL_YES
-				umlRepositoryPkg.destroy
 				if(umlContractsPkg.present) umlContractsPkg.get.destroy
 				if(umlDatatypesPkg.present) umlDatatypesPkg.get.destroy
+				umlRepositoryPkg.destroy // delete parent package last to allow the recorder to notice the child package deletion
 			}
 		}
 	}


### PR DESCRIPTION
Fixed a problem with the deletion order in `PcmRepository.reactions` that leads to unnoticed package deletions, since the recorders are not able to record changes to packages whose parent packages are already deleted.