### PR TITLE
Fixed problem that led to duplicated UML interfaces 

### DIFF
--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/reactions/javaToUmlClassifier/JavaInterfaceCreatedReaction.java
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/reactions/javaToUmlClassifier/JavaInterfaceCreatedReaction.java
@@ -112,7 +112,7 @@ public class JavaInterfaceCreatedReaction extends AbstractReactionRealization {
     public void callRoutine1(final InsertEReference insertChange, final CompilationUnit affectedEObject, final EReference affectedFeature, final Interface newValue, final int index, @Extension final RoutinesFacade _routinesFacade) {
       _routinesFacade.detectOrCreateUmlModel(affectedEObject);
       UmlJavaTypePropagationHelper.registerPredefinedUmlPrimitiveTypes(this.correspondenceModel, affectedEObject.eResource().getResourceSet());
-      _routinesFacade.createUmlInterface(newValue, affectedEObject);
+      _routinesFacade.createOrFindUmlInterface(newValue, affectedEObject);
     }
   }
 }

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/AddInterfaceCorrespondenceRoutine.java
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/AddInterfaceCorrespondenceRoutine.java
@@ -1,0 +1,64 @@
+package mir.routines.javaToUmlClassifier;
+
+import java.io.IOException;
+import mir.routines.javaToUmlClassifier.RoutinesFacade;
+import org.eclipse.emf.ecore.EObject;
+import org.emftext.language.java.classifiers.Interface;
+import org.emftext.language.java.containers.CompilationUnit;
+import tools.vitruv.extensions.dslsruntime.reactions.AbstractRepairRoutineRealization;
+import tools.vitruv.extensions.dslsruntime.reactions.ReactionExecutionState;
+import tools.vitruv.extensions.dslsruntime.reactions.structure.CallHierarchyHaving;
+
+@SuppressWarnings("all")
+public class AddInterfaceCorrespondenceRoutine extends AbstractRepairRoutineRealization {
+  private AddInterfaceCorrespondenceRoutine.ActionUserExecution userExecution;
+  
+  private static class ActionUserExecution extends AbstractRepairRoutineRealization.UserExecution {
+    public ActionUserExecution(final ReactionExecutionState reactionExecutionState, final CallHierarchyHaving calledBy) {
+      super(reactionExecutionState);
+    }
+    
+    public EObject getElement1(final Interface jInterface, final org.eclipse.uml2.uml.Interface uInterface, final CompilationUnit jCompUnit) {
+      return uInterface;
+    }
+    
+    public EObject getElement4(final Interface jInterface, final org.eclipse.uml2.uml.Interface uInterface, final CompilationUnit jCompUnit) {
+      return jCompUnit;
+    }
+    
+    public EObject getElement2(final Interface jInterface, final org.eclipse.uml2.uml.Interface uInterface, final CompilationUnit jCompUnit) {
+      return jInterface;
+    }
+    
+    public EObject getElement3(final Interface jInterface, final org.eclipse.uml2.uml.Interface uInterface, final CompilationUnit jCompUnit) {
+      return uInterface;
+    }
+  }
+  
+  public AddInterfaceCorrespondenceRoutine(final RoutinesFacade routinesFacade, final ReactionExecutionState reactionExecutionState, final CallHierarchyHaving calledBy, final Interface jInterface, final org.eclipse.uml2.uml.Interface uInterface, final CompilationUnit jCompUnit) {
+    super(routinesFacade, reactionExecutionState, calledBy);
+    this.userExecution = new mir.routines.javaToUmlClassifier.AddInterfaceCorrespondenceRoutine.ActionUserExecution(getExecutionState(), this);
+    this.jInterface = jInterface;this.uInterface = uInterface;this.jCompUnit = jCompUnit;
+  }
+  
+  private Interface jInterface;
+  
+  private org.eclipse.uml2.uml.Interface uInterface;
+  
+  private CompilationUnit jCompUnit;
+  
+  protected boolean executeRoutine() throws IOException {
+    getLogger().debug("Called routine AddInterfaceCorrespondenceRoutine with input:");
+    getLogger().debug("   jInterface: " + this.jInterface);
+    getLogger().debug("   uInterface: " + this.uInterface);
+    getLogger().debug("   jCompUnit: " + this.jCompUnit);
+    
+    addCorrespondenceBetween(userExecution.getElement1(jInterface, uInterface, jCompUnit), userExecution.getElement2(jInterface, uInterface, jCompUnit), "");
+    
+    addCorrespondenceBetween(userExecution.getElement3(jInterface, uInterface, jCompUnit), userExecution.getElement4(jInterface, uInterface, jCompUnit), "");
+    
+    postprocessElements();
+    
+    return true;
+  }
+}

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/CreateOrFindUmlInterfaceRoutine.java
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/CreateOrFindUmlInterfaceRoutine.java
@@ -1,0 +1,84 @@
+package mir.routines.javaToUmlClassifier;
+
+import java.io.IOException;
+import mir.routines.javaToUmlClassifier.RoutinesFacade;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.uml2.uml.Model;
+import org.eclipse.uml2.uml.UMLPackage;
+import org.eclipse.xtext.xbase.lib.Extension;
+import org.eclipse.xtext.xbase.lib.IterableExtensions;
+import org.emftext.language.java.classifiers.Interface;
+import org.emftext.language.java.containers.CompilationUnit;
+import tools.vitruv.applications.umljava.java2uml.JavaToUmlHelper;
+import tools.vitruv.extensions.dslsruntime.reactions.AbstractRepairRoutineRealization;
+import tools.vitruv.extensions.dslsruntime.reactions.ReactionExecutionState;
+import tools.vitruv.extensions.dslsruntime.reactions.structure.CallHierarchyHaving;
+
+@SuppressWarnings("all")
+public class CreateOrFindUmlInterfaceRoutine extends AbstractRepairRoutineRealization {
+  private CreateOrFindUmlInterfaceRoutine.ActionUserExecution userExecution;
+  
+  private static class ActionUserExecution extends AbstractRepairRoutineRealization.UserExecution {
+    public ActionUserExecution(final ReactionExecutionState reactionExecutionState, final CallHierarchyHaving calledBy) {
+      super(reactionExecutionState);
+    }
+    
+    public EObject getCorrepondenceSourceUModel(final Interface jInterface, final CompilationUnit jCompUnit) {
+      return UMLPackage.Literals.MODEL;
+    }
+    
+    public EObject getCorrepondenceSource1(final Interface jInterface, final CompilationUnit jCompUnit, final Model uModel) {
+      return jInterface;
+    }
+    
+    public void callRoutine1(final Interface jInterface, final CompilationUnit jCompUnit, final Model uModel, @Extension final RoutinesFacade _routinesFacade) {
+      final org.eclipse.uml2.uml.Interface uInterface = JavaToUmlHelper.findUmlInterface(uModel, jInterface.getName(), IterableExtensions.<String>last(jCompUnit.getNamespaces()));
+      if ((uInterface == null)) {
+        _routinesFacade.createUmlInterface(jInterface, jCompUnit);
+      } else {
+        _routinesFacade.addInterfaceCorrespondence(jInterface, uInterface, jCompUnit);
+      }
+    }
+  }
+  
+  public CreateOrFindUmlInterfaceRoutine(final RoutinesFacade routinesFacade, final ReactionExecutionState reactionExecutionState, final CallHierarchyHaving calledBy, final Interface jInterface, final CompilationUnit jCompUnit) {
+    super(routinesFacade, reactionExecutionState, calledBy);
+    this.userExecution = new mir.routines.javaToUmlClassifier.CreateOrFindUmlInterfaceRoutine.ActionUserExecution(getExecutionState(), this);
+    this.jInterface = jInterface;this.jCompUnit = jCompUnit;
+  }
+  
+  private Interface jInterface;
+  
+  private CompilationUnit jCompUnit;
+  
+  protected boolean executeRoutine() throws IOException {
+    getLogger().debug("Called routine CreateOrFindUmlInterfaceRoutine with input:");
+    getLogger().debug("   jInterface: " + this.jInterface);
+    getLogger().debug("   jCompUnit: " + this.jCompUnit);
+    
+    org.eclipse.uml2.uml.Model uModel = getCorrespondingElement(
+    	userExecution.getCorrepondenceSourceUModel(jInterface, jCompUnit), // correspondence source supplier
+    	org.eclipse.uml2.uml.Model.class,
+    	(org.eclipse.uml2.uml.Model _element) -> true, // correspondence precondition checker
+    	null, 
+    	false // asserted
+    	);
+    if (uModel == null) {
+    	return false;
+    }
+    registerObjectUnderModification(uModel);
+    if (!getCorrespondingElements(
+    	userExecution.getCorrepondenceSource1(jInterface, jCompUnit, uModel), // correspondence source supplier
+    	org.eclipse.uml2.uml.Interface.class,
+    	(org.eclipse.uml2.uml.Interface _element) -> true, // correspondence precondition checker
+    	null
+    ).isEmpty()) {
+    	return false;
+    }
+    userExecution.callRoutine1(jInterface, jCompUnit, uModel, this.getRoutinesFacade());
+    
+    postprocessElements();
+    
+    return true;
+  }
+}

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/CreateUmlInterfaceRoutine.java
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/CreateUmlInterfaceRoutine.java
@@ -2,7 +2,6 @@ package mir.routines.javaToUmlClassifier;
 
 import java.io.IOException;
 import mir.routines.javaToUmlClassifier.RoutinesFacade;
-import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.xbase.lib.Extension;
 import org.emftext.language.java.classifiers.Interface;
 import org.emftext.language.java.containers.CompilationUnit;
@@ -19,31 +18,12 @@ public class CreateUmlInterfaceRoutine extends AbstractRepairRoutineRealization 
       super(reactionExecutionState);
     }
     
-    public EObject getElement1(final Interface jInterface, final CompilationUnit jCompUnit, final org.eclipse.uml2.uml.Interface uInterface) {
-      return uInterface;
-    }
-    
-    public EObject getCorrepondenceSource1(final Interface jInterface, final CompilationUnit jCompUnit) {
-      return jInterface;
-    }
-    
-    public EObject getElement4(final Interface jInterface, final CompilationUnit jCompUnit, final org.eclipse.uml2.uml.Interface uInterface) {
-      return jCompUnit;
-    }
-    
-    public EObject getElement2(final Interface jInterface, final CompilationUnit jCompUnit, final org.eclipse.uml2.uml.Interface uInterface) {
-      return jInterface;
-    }
-    
-    public EObject getElement3(final Interface jInterface, final CompilationUnit jCompUnit, final org.eclipse.uml2.uml.Interface uInterface) {
-      return uInterface;
-    }
-    
     public void updateUInterfaceElement(final Interface jInterface, final CompilationUnit jCompUnit, final org.eclipse.uml2.uml.Interface uInterface) {
       uInterface.setName(jInterface.getName());
     }
     
     public void callRoutine1(final Interface jInterface, final CompilationUnit jCompUnit, final org.eclipse.uml2.uml.Interface uInterface, @Extension final RoutinesFacade _routinesFacade) {
+      _routinesFacade.addInterfaceCorrespondence(jInterface, uInterface, jCompUnit);
       _routinesFacade.addUmlElementToModelOrPackage(jCompUnit, uInterface);
     }
   }
@@ -63,21 +43,9 @@ public class CreateUmlInterfaceRoutine extends AbstractRepairRoutineRealization 
     getLogger().debug("   jInterface: " + this.jInterface);
     getLogger().debug("   jCompUnit: " + this.jCompUnit);
     
-    if (!getCorrespondingElements(
-    	userExecution.getCorrepondenceSource1(jInterface, jCompUnit), // correspondence source supplier
-    	org.eclipse.uml2.uml.Interface.class,
-    	(org.eclipse.uml2.uml.Interface _element) -> true, // correspondence precondition checker
-    	null
-    ).isEmpty()) {
-    	return false;
-    }
     org.eclipse.uml2.uml.Interface uInterface = org.eclipse.uml2.uml.internal.impl.UMLFactoryImpl.eINSTANCE.createInterface();
     notifyObjectCreated(uInterface);
     userExecution.updateUInterfaceElement(jInterface, jCompUnit, uInterface);
-    
-    addCorrespondenceBetween(userExecution.getElement1(jInterface, jCompUnit, uInterface), userExecution.getElement2(jInterface, jCompUnit, uInterface), "");
-    
-    addCorrespondenceBetween(userExecution.getElement3(jInterface, jCompUnit, uInterface), userExecution.getElement4(jInterface, jCompUnit, uInterface), "");
     
     userExecution.callRoutine1(jInterface, jCompUnit, uInterface, this.getRoutinesFacade());
     

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/RoutinesFacade.java
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/RoutinesFacade.java
@@ -2,12 +2,16 @@ package mir.routines.javaToUmlClassifier;
 
 import mir.routines.javaToUmlClassifier.AddGeneralizationCorrespondenceRoutine;
 import mir.routines.javaToUmlClassifier.AddImplementsCorrespondenceRoutine;
+import mir.routines.javaToUmlClassifier.AddInterfaceCorrespondenceRoutine;
+import mir.routines.javaToUmlClassifier.AddPackageCorrespondenceRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlClassImplementRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlElementToModelOrPackageRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlElementToPackageRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlPackageOfClassRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlSuperClassGeneralizationRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlSuperinterfacesRoutine;
+import mir.routines.javaToUmlClassifier.CreateOrFindUmlInterfaceRoutine;
+import mir.routines.javaToUmlClassifier.CreateOrFindUmlPackageRoutine;
 import mir.routines.javaToUmlClassifier.CreateUmlClassRoutine;
 import mir.routines.javaToUmlClassifier.CreateUmlEnumLiteralRoutine;
 import mir.routines.javaToUmlClassifier.CreateUmlEnumRoutine;
@@ -154,11 +158,27 @@ public class RoutinesFacade extends AbstractRepairRoutinesFacade {
     return routine.applyRoutine();
   }
   
+  public boolean createOrFindUmlInterface(final Interface jInterface, final CompilationUnit jCompUnit) {
+    RoutinesFacade _routinesFacade = this;
+    ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
+    CallHierarchyHaving _caller = this._getExecutionState().getCaller();
+    CreateOrFindUmlInterfaceRoutine routine = new CreateOrFindUmlInterfaceRoutine(_routinesFacade, _reactionExecutionState, _caller, jInterface, jCompUnit);
+    return routine.applyRoutine();
+  }
+  
   public boolean createUmlInterface(final Interface jInterface, final CompilationUnit jCompUnit) {
     RoutinesFacade _routinesFacade = this;
     ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
     CallHierarchyHaving _caller = this._getExecutionState().getCaller();
     CreateUmlInterfaceRoutine routine = new CreateUmlInterfaceRoutine(_routinesFacade, _reactionExecutionState, _caller, jInterface, jCompUnit);
+    return routine.applyRoutine();
+  }
+  
+  public boolean addInterfaceCorrespondence(final Interface jInterface, final org.eclipse.uml2.uml.Interface uInterface, final CompilationUnit jCompUnit) {
+    RoutinesFacade _routinesFacade = this;
+    ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
+    CallHierarchyHaving _caller = this._getExecutionState().getCaller();
+    AddInterfaceCorrespondenceRoutine routine = new AddInterfaceCorrespondenceRoutine(_routinesFacade, _reactionExecutionState, _caller, jInterface, uInterface, jCompUnit);
     return routine.applyRoutine();
   }
   
@@ -186,11 +206,27 @@ public class RoutinesFacade extends AbstractRepairRoutinesFacade {
     return routine.applyRoutine();
   }
   
-  public boolean createUmlPackage(final org.emftext.language.java.containers.Package jPackage) {
+  public boolean createOrFindUmlPackage(final org.emftext.language.java.containers.Package jPackage) {
     RoutinesFacade _routinesFacade = this;
     ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
     CallHierarchyHaving _caller = this._getExecutionState().getCaller();
-    CreateUmlPackageRoutine routine = new CreateUmlPackageRoutine(_routinesFacade, _reactionExecutionState, _caller, jPackage);
+    CreateOrFindUmlPackageRoutine routine = new CreateOrFindUmlPackageRoutine(_routinesFacade, _reactionExecutionState, _caller, jPackage);
+    return routine.applyRoutine();
+  }
+  
+  public boolean addPackageCorrespondence(final org.emftext.language.java.containers.Package jPackage, final org.eclipse.uml2.uml.Package uPackage) {
+    RoutinesFacade _routinesFacade = this;
+    ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
+    CallHierarchyHaving _caller = this._getExecutionState().getCaller();
+    AddPackageCorrespondenceRoutine routine = new AddPackageCorrespondenceRoutine(_routinesFacade, _reactionExecutionState, _caller, jPackage, uPackage);
+    return routine.applyRoutine();
+  }
+  
+  public boolean createUmlPackage(final org.emftext.language.java.containers.Package jPackage, final Model uModel) {
+    RoutinesFacade _routinesFacade = this;
+    ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
+    CallHierarchyHaving _caller = this._getExecutionState().getCaller();
+    CreateUmlPackageRoutine routine = new CreateUmlPackageRoutine(_routinesFacade, _reactionExecutionState, _caller, jPackage, uModel);
     return routine.applyRoutine();
   }
   

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/RoutinesFacade.java
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src-gen/mir/routines/javaToUmlClassifier/RoutinesFacade.java
@@ -3,7 +3,6 @@ package mir.routines.javaToUmlClassifier;
 import mir.routines.javaToUmlClassifier.AddGeneralizationCorrespondenceRoutine;
 import mir.routines.javaToUmlClassifier.AddImplementsCorrespondenceRoutine;
 import mir.routines.javaToUmlClassifier.AddInterfaceCorrespondenceRoutine;
-import mir.routines.javaToUmlClassifier.AddPackageCorrespondenceRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlClassImplementRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlElementToModelOrPackageRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlElementToPackageRoutine;
@@ -11,7 +10,6 @@ import mir.routines.javaToUmlClassifier.AddUmlPackageOfClassRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlSuperClassGeneralizationRoutine;
 import mir.routines.javaToUmlClassifier.AddUmlSuperinterfacesRoutine;
 import mir.routines.javaToUmlClassifier.CreateOrFindUmlInterfaceRoutine;
-import mir.routines.javaToUmlClassifier.CreateOrFindUmlPackageRoutine;
 import mir.routines.javaToUmlClassifier.CreateUmlClassRoutine;
 import mir.routines.javaToUmlClassifier.CreateUmlEnumLiteralRoutine;
 import mir.routines.javaToUmlClassifier.CreateUmlEnumRoutine;
@@ -206,27 +204,11 @@ public class RoutinesFacade extends AbstractRepairRoutinesFacade {
     return routine.applyRoutine();
   }
   
-  public boolean createOrFindUmlPackage(final org.emftext.language.java.containers.Package jPackage) {
+  public boolean createUmlPackage(final org.emftext.language.java.containers.Package jPackage) {
     RoutinesFacade _routinesFacade = this;
     ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
     CallHierarchyHaving _caller = this._getExecutionState().getCaller();
-    CreateOrFindUmlPackageRoutine routine = new CreateOrFindUmlPackageRoutine(_routinesFacade, _reactionExecutionState, _caller, jPackage);
-    return routine.applyRoutine();
-  }
-  
-  public boolean addPackageCorrespondence(final org.emftext.language.java.containers.Package jPackage, final org.eclipse.uml2.uml.Package uPackage) {
-    RoutinesFacade _routinesFacade = this;
-    ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
-    CallHierarchyHaving _caller = this._getExecutionState().getCaller();
-    AddPackageCorrespondenceRoutine routine = new AddPackageCorrespondenceRoutine(_routinesFacade, _reactionExecutionState, _caller, jPackage, uPackage);
-    return routine.applyRoutine();
-  }
-  
-  public boolean createUmlPackage(final org.emftext.language.java.containers.Package jPackage, final Model uModel) {
-    RoutinesFacade _routinesFacade = this;
-    ReactionExecutionState _reactionExecutionState = this._getExecutionState().getReactionExecutionState();
-    CallHierarchyHaving _caller = this._getExecutionState().getCaller();
-    CreateUmlPackageRoutine routine = new CreateUmlPackageRoutine(_routinesFacade, _reactionExecutionState, _caller, jPackage, uModel);
+    CreateUmlPackageRoutine routine = new CreateUmlPackageRoutine(_routinesFacade, _reactionExecutionState, _caller, jPackage);
     return routine.applyRoutine();
   }
   

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -292,26 +292,46 @@ routine removeUmlClassImplement(java::Class jClass, java::TypeReference jReferen
 reaction JavaInterfaceCreated {
     after element java::Interface created and inserted in java::CompilationUnit[classifiers]
     call {
-    	detectOrCreateUmlModel(affectedEObject)
+		detectOrCreateUmlModel(affectedEObject)
 		registerPredefinedUmlPrimitiveTypes(correspondenceModel, affectedEObject.eResource.resourceSet)
-    	createUmlInterface(newValue, affectedEObject)
+		createOrFindUmlInterface(newValue, affectedEObject)
+	}
+}
+
+routine createOrFindUmlInterface(java::Interface jInterface, java::CompilationUnit jCompUnit) {
+	match {
+        val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
+		require absence of uml::Interface corresponding to jInterface
+	}
+	action {
+		call {
+			val uInterface = findUmlInterface(uModel, jInterface.name, jCompUnit.namespaces.last)
+			if(uInterface === null) {
+				createUmlInterface(jInterface, jCompUnit)
+			} else {
+				addInterfaceCorrespondence(jInterface, uInterface, jCompUnit)
+			}
+		}
 	}
 }
 
 routine createUmlInterface(java::Interface jInterface, java::CompilationUnit jCompUnit) {
-	match {
-		require absence of uml::Interface corresponding to jInterface
-	}
     action {
         val uInterface = create uml::Interface and initialize {
             uInterface.name = jInterface.name;
         }
-        add correspondence between uInterface and jInterface
+		call {
+			addInterfaceCorrespondence(jInterface, uInterface, jCompUnit)
+			addUmlElementToModelOrPackage(jCompUnit, uInterface)
+		}
+	}
+}
+
+routine addInterfaceCorrespondence(java::Interface jInterface, uml::Interface uInterface, java::CompilationUnit jCompUnit) {
+	action {
+		add correspondence between uInterface and jInterface
         add correspondence between uInterface and jCompUnit
-        call {
-            addUmlElementToModelOrPackage(jCompUnit, uInterface)
-        }   
-    }
+	}
 }
 
 reaction JavaSuperInterfaceAdded {

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlHelper.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlHelper.xtend
@@ -2,11 +2,11 @@ package tools.vitruv.applications.umljava.java2uml
 
 import java.util.Set
 import org.apache.log4j.Logger
-import org.eclipse.uml2.uml.Package
-import tools.vitruv.framework.userinteraction.UserInteractor
-
-import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
+import org.eclipse.uml2.uml.Interface
 import org.eclipse.uml2.uml.Model
+import org.eclipse.uml2.uml.Package
+import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
+import tools.vitruv.framework.userinteraction.UserInteractor
 
 /**
  * Helper class for the Java2Uml reactions. Contains functions who depends on
@@ -28,8 +28,7 @@ class JavaToUmlHelper {
      */
     def static Package findUmlPackage(Model umlModel, String packageName) {
         val Set<Package> allPackages = umlModel.eAllContents.filter(Package).toSet
-        
-        val packages = allPackages.filter[name.equals(packageName)]
+        val packages = allPackages.filter[name == packageName]
         if (packages.nullOrEmpty) {
             logger.warn("The UML-Package with the name " + packageName + " does not exist in the correspondence model")
             return null
@@ -39,7 +38,32 @@ class JavaToUmlHelper {
         }
         return packages.head
     }
-    
+
+    /**
+     * Searches and retrieves the UML interface located in a specific package of a UML model that has an equal name as the given package name.
+     * If there is more than one package with the given name or the package can not be located, an {@link IllegalStateException} is thrown.
+     * 
+     * @param umlModel the UML model Model in which the UML packages should be searched
+     * @param interfaceName the interface name for which a fitting UML interface should be retrieved
+     * @param packageName the package name in which the UML interface should be located.
+     * @return the UML interface or null if none could be found
+     */
+    def static Interface findUmlInterface(Model umlModel, String interfaceName, String packageName) {
+		val uPackage = findUmlPackage(umlModel, packageName)
+		if (uPackage === null) {
+			throw new IllegalStateException("Could not locate the package " + packageName + " in the UMl model " + umlModel)
+		}
+		val interfaces = uPackage.ownedTypes.filter[it instanceof Interface].filter[name == interfaceName].toSet
+		if (interfaces.nullOrEmpty) {
+			logger.warn("The UML interface with the name " + interfaceName + " does not exist in the package " + uPackage)
+			return null
+		}
+		if (interfaces.size > 1) {
+			throw new IllegalStateException("There is more than one interface with name " + interfaceName + " in the package " + uPackage)
+		}
+		return interfaces.head as Interface
+	}
+
     /**
      * Displays a text message for the user.
      * 


### PR DESCRIPTION
Similar to [PR54](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/54).

Duplicated UML interfaces were created due to the UML interface already existing but missing the correspondence to the correlating Java interface. This has been fixed by checking if the UML interface can be found by name when it is absent. If that is the case, the missing correspondence is added. If that is not the case, only then is a new interface created.