### PR TITLE
Correct UML model correspondence claims

### DIFF
--- a/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/AbstractUmlPcmTest.xtend
+++ b/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/AbstractUmlPcmTest.xtend
@@ -15,6 +15,12 @@ import tools.vitruv.domains.pcm.PcmDomainProvider
 import tools.vitruv.domains.uml.UmlDomainProvider
 import tools.vitruv.testutils.VitruviusApplicationTest
 import org.eclipse.emf.common.util.BasicEList
+import org.palladiosimulator.pcm.repository.Repository
+import org.eclipse.emf.ecore.EClass
+import org.eclipse.emf.ecore.EcorePackage
+
+import static org.junit.Assert.assertEquals
+import org.eclipse.uml2.uml.UMLPackage
 
 abstract class AbstractUmlPcmTest extends VitruviusApplicationTest {
 	protected static val MODEL_FILE_EXTENSION = "uml";
@@ -84,6 +90,16 @@ abstract class AbstractUmlPcmTest extends VitruviusApplicationTest {
 		val eList = new BasicEList<T>()
 		eList.addAll(elements)
 		return eList
+	}
+	
+	protected def Repository claimCorrespondingRepository(EObject rootElement) {
+		rootElement.correspondingElements.size == 2
+		val potentialRepositories = rootElement.correspondingElements.filter(Repository)
+		val potentialClasses = rootElement.correspondingElements.filter(EClass)
+		assertEquals(1, potentialRepositories.size)
+		assertEquals(1, potentialClasses.size)
+		assertEquals(UMLPackage.eINSTANCE.model, potentialClasses.get(0))
+		return potentialRepositories.get(0);
 	}
 
 }

--- a/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/ImportedDataTypesTest.xtend
+++ b/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/ImportedDataTypesTest.xtend
@@ -1,18 +1,17 @@
 package tools.vitruv.applications.pcmumlcomponents.uml2pcm
 
+import org.eclipse.emf.common.util.BasicEList
+import org.eclipse.uml2.uml.DataType
+import org.eclipse.uml2.uml.PrimitiveType
+import org.eclipse.uml2.uml.Type
+import org.eclipse.uml2.uml.UMLFactory
 import org.junit.Test
+import org.palladiosimulator.pcm.repository.CompositeDataType
+import org.palladiosimulator.pcm.repository.OperationInterface
 import org.palladiosimulator.pcm.repository.PrimitiveDataType
 import org.palladiosimulator.pcm.repository.PrimitiveTypeEnum
 
 import static org.junit.Assert.*
-import org.eclipse.uml2.uml.UMLFactory
-import org.eclipse.uml2.uml.PrimitiveType
-import org.eclipse.emf.common.util.BasicEList
-import org.eclipse.uml2.uml.Type
-import org.palladiosimulator.pcm.repository.OperationInterface
-import org.eclipse.uml2.uml.DataType
-import org.palladiosimulator.pcm.repository.Repository
-import org.palladiosimulator.pcm.repository.CompositeDataType
 
 class ImportedDataTypesTest extends AbstractUmlPcmTest {
 	
@@ -26,7 +25,7 @@ class ImportedDataTypesTest extends AbstractUmlPcmTest {
 		val umlTypes = importPrimitiveTypes()
 		assertNotNull(umlTypes.getOwnedMember(UMLTYPE_BOOL))
 		val umlType = umlTypes.getOwnedMember(UMLTYPE_BOOL) as DataType
-		val pcmRepository = rootElement.correspondingElements.head as Repository
+		val pcmRepository = rootElement.claimCorrespondingRepository
 		saveAndSynchronizeChanges(rootElement)
 		val pcmType = UmlToPcmTypesUtil.retrieveCorrespondingPcmType(umlType, pcmRepository, false, null, correspondenceModel)
 		assertNotNull(pcmType)
@@ -43,7 +42,7 @@ class ImportedDataTypesTest extends AbstractUmlPcmTest {
 		userInteractor.addNextSingleSelection(PrimitiveTypeEnum.BYTE_VALUE)
 		rootElement.packagedElements += umlType
 		saveAndSynchronizeChanges(rootElement)
-		val pcmRepository = rootElement.correspondingElements.head as Repository
+		val pcmRepository = rootElement.claimCorrespondingRepository
 		val pcmType = UmlToPcmTypesUtil.retrieveCorrespondingPcmType(umlType, pcmRepository, false, null, correspondenceModel) as PrimitiveDataType
 		assertEquals(PrimitiveTypeEnum.BYTE, pcmType.type)
 	}

--- a/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/ModelTest.xtend
+++ b/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/ModelTest.xtend
@@ -1,7 +1,6 @@
 package tools.vitruv.applications.pcmumlcomponents.uml2pcm
 
 import org.junit.Test
-import org.palladiosimulator.pcm.repository.Repository
 
 import static org.junit.Assert.*
 
@@ -10,12 +9,8 @@ class ModelTest extends AbstractUmlPcmTest {
 	@Test
 	public def void testRepositoryCreation() {
 		assertModelExists("repository/" + MODEL_NAME + ".repository");
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[rootElement]).flatten
-		assertEquals(2, correspondingElements.size); // repository AND model tag
-		val correspondingRepositories = correspondingElements.filter[it instanceof Repository].toList
-		assertEquals(1, correspondingRepositories.size); // but should be only one repository
-		val pcmRepository = correspondingRepositories.get(0);
-		assertEquals(MODEL_NAME, (pcmRepository as Repository).entityName);
+		val pcmRepository = rootElement.claimCorrespondingRepository
+		assertEquals(MODEL_NAME, pcmRepository.entityName);
 	}
 
 	@Test
@@ -23,8 +18,7 @@ class ModelTest extends AbstractUmlPcmTest {
 		val newName = 'foo';
 		rootElement.name = newName;
 		saveAndSynchronizeChanges(rootElement);
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[rootElement]).flatten
-		val pcmRepository = correspondingElements.get(0);
-		assertEquals(newName, (pcmRepository as Repository).entityName);
+		val pcmRepository = rootElement.claimCorrespondingRepository
+		assertEquals(newName, pcmRepository.entityName);
 	}
 }

--- a/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/MultiplicityTest.xtend
+++ b/tests/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm.tests/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/MultiplicityTest.xtend
@@ -35,7 +35,7 @@ class MultiplicityTest extends AbstractUmlPcmTest {
 		umlDataType.createOwnedAttribute(PARAMETER_NAME, innerDataType, 0, UnlimitedNaturalLiteralExp.UNLIMITED)
 		saveAndSynchronizeChanges(rootElement)
 
-		val pcmRepository = rootElement.correspondingElements.head as Repository
+		val pcmRepository = rootElement.claimCorrespondingRepository
 		assertEquals(3, pcmRepository.dataTypes__Repository.length)
 
 		val collectionType = pcmRepository.dataTypes__Repository.findFirst[t|t instanceof CollectionDataType]
@@ -64,7 +64,7 @@ class MultiplicityTest extends AbstractUmlPcmTest {
 		umlParameter.upper = 2
 		saveAndSynchronizeChanges(rootElement)
 
-		val pcmRepository = rootElement.correspondingElements.head as Repository
+		val pcmRepository = rootElement.claimCorrespondingRepository
 		assertEquals(2, pcmRepository.dataTypes__Repository.length)
 
 		val pcmParameter = umlParameter.correspondingElements.head as Parameter
@@ -85,7 +85,7 @@ class MultiplicityTest extends AbstractUmlPcmTest {
 		umlParameter.lower = 0
 		saveAndSynchronizeChanges(rootElement)
 
-		val pcmRepository = rootElement.correspondingElements.head as Repository
+		val pcmRepository = rootElement.claimCorrespondingRepository
 		val collectionType = pcmRepository.dataTypes__Repository.findFirst[t|t instanceof CompositeDataType]
 		val pcmOperation = umlOperation.correspondingElements.head as OperationSignature
 		assertEquals(collectionType, pcmOperation.returnType__OperationSignature)
@@ -121,7 +121,7 @@ class MultiplicityTest extends AbstractUmlPcmTest {
 	public def void deleteMultiplicityType() {
 		val innerDataType = createInnerDataType()
 		saveAndSynchronizeChanges(rootElement)
-		var pcmRepository = rootElement.correspondingElements.head as Repository
+		var pcmRepository = rootElement.claimCorrespondingRepository
 		assertEquals(1, pcmRepository.dataTypes__Repository.length)
 		
 		val umlDataType = UMLFactory.eINSTANCE.createDataType()
@@ -129,17 +129,17 @@ class MultiplicityTest extends AbstractUmlPcmTest {
 		rootElement.packagedElements += umlDataType
 		umlDataType.createOwnedAttribute(PARAMETER_NAME, innerDataType, 1, UnlimitedNaturalLiteralExp.UNLIMITED)
 		saveAndSynchronizeChanges(rootElement)
-		pcmRepository = rootElement.correspondingElements.head as Repository
+		pcmRepository = rootElement.claimCorrespondingRepository
 		assertEquals(3, pcmRepository.dataTypes__Repository.length)
 		
 		rootElement.packagedElements -= umlDataType
 		saveAndSynchronizeChanges(rootElement)
-		pcmRepository = rootElement.correspondingElements.head as Repository
+		pcmRepository = rootElement.claimCorrespondingRepository
 		assertEquals(2, pcmRepository.dataTypes__Repository.length)
 		
 		rootElement.packagedElements -= innerDataType
 		saveAndSynchronizeChanges(rootElement)
-		pcmRepository = rootElement.correspondingElements.head as Repository
+		pcmRepository = rootElement.claimCorrespondingRepository
 		assertEquals(0, pcmRepository.dataTypes__Repository.length)
 	}
 


### PR DESCRIPTION
Due to recent changes in #53, a UML `Model` correspondences not only to a PCM `Repository` but also to the UML `Model` `EClass`. This PR adapts the correspondence claims in tests, which only performed well in recent builds by accident.