### PR TITLE
Remove target folder filters

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548345277498</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548343623908</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548245266579</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.pcm2java/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548245599870</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344742589</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java/.project
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344638146</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/.project
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344691874</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/.project
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.pcm2uml/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344782701</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm/.project
+++ b/bundles/pcmumlcomponents/tools.vitruv.applications.pcmumlcomponents.uml2pcm/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344795048</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp/.project
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.class2comp/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344807700</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/.project
+++ b/bundles/umlclassumlcomponents/tools.vitruv.applications.umlclassumlcomponents.comp2class/.project
@@ -31,15 +31,4 @@
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344820046</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/.project
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>org.emftext.language.java.resource.java.nature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344834018</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/.project
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/.project
@@ -37,15 +37,4 @@
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 		<nature>org.emftext.language.java.resource.java.nature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1548344852812</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-target</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
This PR removes outdated project filters for the `target` folder, which led to compile errors, because Eclipse projects are now defined to also use the `target` folder of Maven builds.