### PR TITLE
Fixed broken Java package file deletion

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -18,6 +18,7 @@ import org.emftext.language.java.references.SelfReference
 import org.emftext.language.java.statements.ExpressionStatement
 import org.emftext.language.java.types.PrimitiveType
 import org.emftext.language.java.types.TypeReference
+import org.emftext.language.java.containers.ContainersPackage
 import org.palladiosimulator.pcm.repository.BasicComponent
 import org.palladiosimulator.pcm.repository.CollectionDataType
 import org.palladiosimulator.pcm.repository.CompositeDataType
@@ -56,7 +57,7 @@ routine createRepositoryPackages(pcm::Repository repository) {
 	}
 	action {
 		call {
-			createJavaPackage(repository, null, repository.entityName, "repository_root");
+			createOrFindJavaPackage(repository, null, repository.entityName, "repository_root");
 			createRepositorySubPackages(repository);
 		} 
 	}
@@ -68,8 +69,8 @@ routine createRepositorySubPackages(pcm::Repository repository) {
 	}
 	action {
 		call {
-			createJavaPackage(repository, repositoryPackage, "datatypes", "datatypes");
-			createJavaPackage(repository, repositoryPackage, "contracts", "contracts");
+			createOrFindJavaPackage(repository, repositoryPackage, "datatypes", "datatypes");
+			createOrFindJavaPackage(repository, repositoryPackage, "contracts", "contracts");
 		}
 	}
 }
@@ -110,7 +111,7 @@ reaction CreatedSystem {
 	after element pcm::System created and inserted as root
 	call {
 		val system = newValue;
-		createJavaPackage(system, null, system.entityName, "root_system");
+		createOrFindJavaPackage(system, null, system.entityName, "root_system");
 		createImplementationForSystem(system);
 	}
 }
@@ -507,6 +508,33 @@ routine changeInnerDeclarationType(pcm::InnerDeclaration innerDeclaration, java:
 // ######################################################
 // ################ JAVA PACKAGE ROUTINES ################
 
+routine createOrFindJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
+	match {
+		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
+		val allPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+	}
+	action {
+		call {
+			var matchingPackages = allPackages.filter[name == packageName.toFirstLower]
+			if(parentPackage !== null) { // checks full package namespace for non-root packages:
+				matchingPackages = matchingPackages.filter[namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + "."]
+			}
+			if(matchingPackages.empty) {
+				createJavaPackage(sourceElementMappedToPackage, parentPackage, packageName, newTag)
+			} else {
+				addPackageCorrespondence(sourceElementMappedToPackage, matchingPackages.head, newTag)
+			}
+		}
+	}
+}
+
+routine addPackageCorrespondence(EObject sourceElementMappedToPackage, java::Package javaPackage, String newTag) {
+	action {
+		add correspondence between javaPackage and sourceElementMappedToPackage
+			tagged with newTag
+	}
+}
+
 routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
@@ -520,6 +548,7 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 			javaPackage.name = packageName.toFirstLower;
 			persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage));
 		}
+		add correspondence between javaPackage and javaPackage.eClass
 		add correspondence between javaPackage and sourceElementMappedToPackage
 			tagged with newTag
 	}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -511,14 +511,12 @@ routine changeInnerDeclarationType(pcm::InnerDeclaration innerDeclaration, java:
 routine createOrFindJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
-		val allPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+		with matchingPackages.name == packageName.toFirstLower && (parentPackage === null || 
+			matchingPackages.namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + ".")
 	}
 	action {
 		call {
-			var matchingPackages = allPackages.filter[name == packageName.toFirstLower]
-			if(parentPackage !== null) { // checks full package namespace for non-root packages:
-				matchingPackages = matchingPackages.filter[namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + "."]
-			}
 			if(matchingPackages.empty) {
 				createJavaPackage(sourceElementMappedToPackage, parentPackage, packageName, newTag)
 			} else {
@@ -550,7 +548,7 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 		}
 		add correspondence between javaPackage and sourceElementMappedToPackage tagged with newTag
 		// Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
-		add correspondence between javaPackage and javaPackage.eClass
+		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE
 	}
 }
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -548,9 +548,9 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 			javaPackage.name = packageName.toFirstLower;
 			persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage));
 		}
+		add correspondence between javaPackage and sourceElementMappedToPackage tagged with newTag
+		// Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
 		add correspondence between javaPackage and javaPackage.eClass
-		add correspondence between javaPackage and sourceElementMappedToPackage
-			tagged with newTag
 	}
 }
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -24,9 +24,9 @@ reaction PackageCreated {
 	with !newValue.name.contains("contracts") && !newValue.name.contains("datatypes")
 		
 	call {
-		createPackageEClassCorrespondence(newValue)
 		createArchitecturalElement(newValue, getLastPackageName(newValue.name), getRootPackageName(newValue.name))
 		createRepository(newValue, newValue.name, "package_root")
+		createPackageEClassCorrespondence(newValue)
 	}
 }
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -24,9 +24,23 @@ reaction PackageCreated {
 	with !newValue.name.contains("contracts") && !newValue.name.contains("datatypes")
 		
 	call {
+		createPackageEClassCorrespondence(newValue)
 		createArchitecturalElement(newValue, getLastPackageName(newValue.name), getRootPackageName(newValue.name))
 		createRepository(newValue, newValue.name, "package_root")
 	}
+}
+
+/**
+ * Required to enable locating existing packages with missing correspondences when keeping more than two models consistent.
+ */
+routine createPackageEClassCorrespondence(java::Package jPackage) {
+	match {
+		val allPackages = retrieve many java::Package corresponding to jPackage.eClass
+		check !allPackages.contains(jPackage)
+	}
+    action {
+        add correspondence between jPackage and jPackage.eClass
+    }
 }
 
 /**

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -393,9 +393,23 @@ routine removeUmlSuperInterface(java::Interface jInterface, java::TypeReference 
 reaction JavaPackageCreated {
     after element java::Package inserted as root
     call {
+    	createPackageEClassCorrespondence(newValue)
     	detectOrCreateUmlModel(newValue)
 		registerPredefinedUmlPrimitiveTypes(correspondenceModel, newValue.eResource.resourceSet)
 	    createOrFindUmlPackage(newValue)
+    }
+}
+
+/**
+ * Required to enable locating existing packages with missing correspondences when keeping more than two models consistent.
+ */
+routine createPackageEClassCorrespondence(java::Package jPackage) {
+	match {
+		val allPackages = retrieve many java::Package corresponding to jPackage.eClass
+		check !allPackages.contains(jPackage)
+	}
+    action {
+        add correspondence between jPackage and jPackage.eClass
     }
 }
 

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -493,6 +493,7 @@ routine createJavaPackage(uml::Package uPackage, uml::Package uSuperPackage) {
             persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
         }
         add correspondence between jPackage and uPackage
+        // Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
         add correspondence between jPackage and jPackage.eClass
     }
 }

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -454,11 +454,11 @@ reaction UmlPackageCreated {
 routine createOrFindJavaPackage(uml::Package uPackage, uml::Package uSuperPackage) {
 	match {
 		require absence of java::Package corresponding to uPackage
-		val allPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+		with matchingPackages.namespacesAsString + matchingPackages.name == getUmlNamespaceAsString(uPackage)
 	}
 	action {
 		call {
-			val matchingPackages = allPackages.filter[namespacesAsString + name == getUmlNamespaceAsString(uPackage)]
 			if(matchingPackages.empty) {
 				createJavaPackage(uPackage, uSuperPackage)
 			} else {
@@ -494,7 +494,7 @@ routine createJavaPackage(uml::Package uPackage, uml::Package uSuperPackage) {
         }
         add correspondence between jPackage and uPackage
         // Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
-        add correspondence between jPackage and jPackage.eClass
+        add correspondence between jPackage and ContainersPackage.Literals.PACKAGE
     }
 }
 

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -5,6 +5,7 @@ import org.eclipse.uml2.uml.Interface
 import org.eclipse.uml2.uml.Model
 import org.eclipse.uml2.uml.PrimitiveType
 import org.eclipse.uml2.uml.UMLPackage
+import org.emftext.language.java.containers.ContainersPackage
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.NotificationType
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
@@ -447,7 +448,30 @@ routine addUmlModelCorrespondence(uml::Model newModel){
 
 reaction UmlPackageCreated {
     after element uml::Package created and inserted in uml::Package[packagedElement]
-    call createJavaPackage(newValue, affectedEObject)
+    call createOrFindJavaPackage(newValue, affectedEObject)
+}
+
+routine createOrFindJavaPackage(uml::Package uPackage, uml::Package uSuperPackage) {
+	match {
+		require absence of java::Package corresponding to uPackage
+		val allPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+	}
+	action {
+		call {
+			val matchingPackages = allPackages.filter[namespacesAsString + name == getUmlNamespaceAsString(uPackage)]
+			if(matchingPackages.empty) {
+				createJavaPackage(uPackage, uSuperPackage)
+			} else {
+				addPackageCorrespondence(uPackage, matchingPackages.head)
+			}
+		}
+	}
+}
+
+routine addPackageCorrespondence(uml::Package uPackage, java::Package jPackage) {
+	action {
+		add correspondence between jPackage and uPackage
+	}
 }
 
 routine createJavaPackage(uml::Package uPackage, uml::Package uSuperPackage) {
@@ -469,6 +493,7 @@ routine createJavaPackage(uml::Package uPackage, uml::Package uSuperPackage) {
             persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
         }
         add correspondence between jPackage and uPackage
+        add correspondence between jPackage and jPackage.eClass
     }
 }
 

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/META-INF/MANIFEST.MF
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/META-INF/MANIFEST.MF
@@ -25,7 +25,8 @@ Require-Bundle: com.google.guava,
  org.emftext.language.java,
  org.junit;bundle-version="4.12.0",
  tools.vitruv.domains.java.util.jamoppparser;bundle-version="0.2.0",
- tools.vitruv.testutils;bundle-version="0.2.0"
+ tools.vitruv.testutils;bundle-version="0.2.0",
+ edu.kit.ipd.sdq.activextendannotations
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: tools.vitruv.applications.umljava.testutil,
  tools.vitruv.applications.umljava.util,

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/util/uml/UmlClassifierAndPackageUtil.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/util/uml/UmlClassifierAndPackageUtil.xtend
@@ -327,6 +327,17 @@ class UmlClassifierAndPackageUtil {
         return buildNamespaceStringList(uNamespace, new ArrayList<String>)
     }
     
+     /**
+     * Converts the namespace of the given namespace into a String
+     * and appends the name of the given namespace to the end of the String
+     * 
+     * org.example.test.test2 --> "org.example.test.test2"
+     * 
+     */
+    def static String getUmlNamespaceAsString(Namespace uNamespace) {
+        return uNamespace.getUmlNamespaceAsStringList.join(".")
+    } 
+    
     def private static List<String> buildNamespaceStringList(Namespace uNamespace, List<String> namespace) {
         namespace += uNamespace?.name
         if (uNamespace?.namespace !== null && !(uNamespace?.namespace instanceof Model)) {

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/util/uml/UmlClassifierAndPackageUtil.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/util/uml/UmlClassifierAndPackageUtil.xtend
@@ -1,6 +1,7 @@
 package tools.vitruv.applications.umljava.util.uml
 
 import java.util.ArrayList
+import java.util.Collections
 import java.util.List
 import org.eclipse.emf.common.util.EList
 import org.eclipse.uml2.uml.Classifier
@@ -18,7 +19,7 @@ import org.eclipse.uml2.uml.Package
 import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.BehavioredClassifier
 import org.eclipse.uml2.uml.DataType
-import java.util.Collections
+import edu.kit.ipd.sdq.activextendannotations.Utility
 
 /**
  * Util class for classifier and package functions.
@@ -26,12 +27,8 @@ import java.util.Collections
  * @author Fei
  * 
  */
+@Utility
 class UmlClassifierAndPackageUtil {
-    
-    /**
-     * Prevents instantiation
-     */
-    private new () {}
     
     def static Package createUmlPackageAndAddToSuperPackage(String name, Package superPackage) {
         val uPackage = UMLFactory.eINSTANCE.createPackage
@@ -327,7 +324,7 @@ class UmlClassifierAndPackageUtil {
         return buildNamespaceStringList(uNamespace, new ArrayList<String>)
     }
     
-     /**
+    /**
      * Converts the namespace of the given namespace into a String
      * and appends the name of the given namespace to the end of the String
      * 
@@ -336,7 +333,7 @@ class UmlClassifierAndPackageUtil {
      */
     def static String getUmlNamespaceAsString(Namespace uNamespace) {
         return uNamespace.getUmlNamespaceAsStringList.join(".")
-    } 
+    }
     
     def private static List<String> buildNamespaceStringList(Namespace uNamespace, List<String> namespace) {
         namespace += uNamespace?.name

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/java2pcm/PackageMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/java2pcm/PackageMappingTransformationTest.java
@@ -18,6 +18,7 @@ import tools.vitruv.applications.pcmjava.tests.util.Pcm2JavaTestUtils;
 import tools.vitruv.framework.correspondence.CorrespondenceModel;
 import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*;
+import static java.util.stream.Collectors.toSet;
 
 public class PackageMappingTransformationTest extends Java2PcmPackageMappingTransformationTest {
 
@@ -101,7 +102,8 @@ public class PackageMappingTransformationTest extends Java2PcmPackageMappingTran
         //waitForSynchronization();
 
         final Set<EObject> correspondingEObjects = CorrespondenceModelUtil
-                .getCorrespondingEObjects(this.getCorrespondenceModel(), renamedPackage);
+                .getCorrespondingEObjects(this.getCorrespondenceModel(), renamedPackage)
+                .stream().filter(it -> it != null).collect(toSet()); // filter out null from non-EObject correspondence
         final EObject correspondingEObject = claimOne(correspondingEObjects);
         assertTrue("The corresponding EObject for the package has to be a BasicComponent",
                 correspondingEObject instanceof BasicComponent);

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/java2pcm/TypeReferenceMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/java2pcm/TypeReferenceMappingTransformationTest.java
@@ -14,7 +14,7 @@ public class TypeReferenceMappingTransformationTest extends Java2PcmPackageMappi
 
     @Test
     public void testAddImplementsToClassWithCorrespondingComponent() throws Throwable {
-        // crete repo
+        // create repo
         this.addRepoContractsAndDatatypesPackage();
         // create class
         this.addSecondPackageCorrespondsWithoutCorrespondences();


### PR DESCRIPTION
Fixed an issue that prevented the deletion of the persisted Java packages (package info files). Java packages were created twice due to missing correspondences as a result of the Java packages being created by another reaction. As a result, references were overwritten, and the correlating persisted resources of the Java packages not correctly deleted. The unit tests were not able to catch this issue since it only affects the persisted files and not the loaded model (it occurred for the repository concept deletion & renaming test cases). 

This was fixed by attempting to locate the Java packages by name if the correspondence is missing (the find-or-create-pattern, see [PR54](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/54#discussion_r351258010)). When they are successfully located the missing correspondences are created.

To make it possible to search for Java packages by name, additional correspondences to the Java package `EClass` are now added whenever a Java package is created (UML to Java & PCM to Java reactions). To identify the correct existing package, the full package name is compared (e.g. `org.example.test.test2`).