### PR TITLE
Fixed character eating UML element rename routine

### DIFF
--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -322,10 +322,13 @@ routine renameUmlNamedElementCorrespondingToCompilationUnit(java::CompilationUni
     action {
         update uElement {
         	var propagatedName = jElement.name
-        	val namespacePrefix = jElement.namespaces.join(".") + "."
-        	// trim off the namespace and file-extension in case the name is loaded fully classified
-        	propagatedName = propagatedName.replaceFirst(namespacePrefix, "")
-        	propagatedName = propagatedName.replaceFirst(".java", "")
+        	if(!jElement.namespaces.empty) { // trim off the namespace in case the name is loaded fully classified
+                var namespacePrefix = jElement.namespaces.join("\\.") + "\\." // escaping avoids eating any char with "." regex
+                propagatedName = propagatedName.replaceFirst(namespacePrefix, "")
+        	}
+            if(propagatedName.endsWith(".java")) { // trim off file extension if it exists 
+                propagatedName = propagatedName.replaceFirst("\\.java", "") // escaping avoids eating any char with "." regex
+            }
             uElement.name = propagatedName;
         }
     }


### PR DESCRIPTION
Fixed a bug in the Java to UML reactions where UML element names were either shortened by one character or completely mutilated during a valid rename change. This was caused by the somewhat careless use of the `replaceFirst()` method that expects regular expressions. Dots were not escaped and therefore led to matching any character. This occurred in two different ways.
 
1. When the namespace was empty (the `namespacePrefix` was `"."`):
```diff
+   TestSystemImpl
-    estSystemImpl
```

2. When the non-empty namespace matched the name (the `namespacePrefix` was `"TestSystem."`):
```diff
+   TestSystemImpl
-              mpl
```