### PR TITLE
Fixed more problems with duplicate Java/UML type creation

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/META-INF/MANIFEST.MF
@@ -34,4 +34,5 @@ Require-Bundle: org.eclipse.emf.ecore,
  tools.vitruv.domains.java.util.jamoppparser,
  tools.vitruv.domains.java.util,
  tools.vitruv.domains.java,
- tools.vitruv.domains.pcm
+ tools.vitruv.domains.pcm,
+ tools.vitruv.applications.umljava.util

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -18,6 +18,8 @@ import org.emftext.language.java.references.SelfReference
 import org.emftext.language.java.statements.ExpressionStatement
 import org.emftext.language.java.types.PrimitiveType
 import org.emftext.language.java.types.TypeReference
+import org.emftext.language.java.containers.ContainersPackage
+import org.emftext.language.java.classifiers.Interface
 import org.palladiosimulator.pcm.repository.BasicComponent
 import org.palladiosimulator.pcm.repository.CollectionDataType
 import org.palladiosimulator.pcm.repository.CompositeDataType
@@ -25,12 +27,13 @@ import org.palladiosimulator.pcm.repository.OperationInterface
 import org.palladiosimulator.pcm.repository.OperationProvidedRole
 import org.palladiosimulator.pcm.repository.OperationSignature
 import org.palladiosimulator.pcm.repository.RepositoryComponent
+import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
 import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 
 import static extension tools.vitruv.applications.pcmjava.util.pcm2java.Pcm2JavaHelper.*
-import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
+import static extension tools.vitruv.applications.umljava.util.java.JavaContainerAndClassifierUtil.*
 
 import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
@@ -56,7 +59,7 @@ routine createRepositoryPackages(pcm::Repository repository) {
 	}
 	action {
 		call {
-			createJavaPackage(repository, null, repository.entityName, "repository_root");
+			createOrFindJavaPackage(repository, null, repository.entityName, "repository_root");
 			createRepositorySubPackages(repository);
 		} 
 	}
@@ -68,8 +71,8 @@ routine createRepositorySubPackages(pcm::Repository repository) {
 	}
 	action {
 		call {
-			createJavaPackage(repository, repositoryPackage, "datatypes", "datatypes");
-			createJavaPackage(repository, repositoryPackage, "contracts", "contracts");
+			createOrFindJavaPackage(repository, repositoryPackage, "datatypes", "datatypes");
+			createOrFindJavaPackage(repository, repositoryPackage, "contracts", "contracts");
 		}
 	}
 }
@@ -110,7 +113,7 @@ reaction CreatedSystem {
 	after element pcm::System created and inserted as root
 	call {
 		val system = newValue;
-		createJavaPackage(system, null, system.entityName, "root_system");
+		createOrFindJavaPackage(system, null, system.entityName, "root_system");
 		createImplementationForSystem(system);
 	}
 }
@@ -120,7 +123,7 @@ routine createImplementationForSystem(pcm::System system) {
 		val systemPackage = retrieve java::Package corresponding to system
 	}
 	action {
-		call createJavaClass(system, systemPackage, system.entityName + "Impl")
+		call createOrFindJavaClass(system, systemPackage, system.entityName + "Impl")
 	}
 }
 
@@ -210,7 +213,7 @@ routine createImplementationForComponent(pcm::RepositoryComponent component) {
 		val componentPackage = retrieve java::Package corresponding to component
 	}
 	action {
-		call createJavaClass(component, componentPackage, component.entityName + "Impl")
+		call createOrFindJavaClass(component, componentPackage, component.entityName + "Impl")
 	}
 }
 
@@ -290,7 +293,7 @@ routine createCompositeDataTypeImplementation(pcm::CompositeDataType compositeDa
 	}
 	action {
 		call {
-			createJavaClass(compositeDataType, datatypesPackage, compositeDataType.entityName);
+			createOrFindJavaClass(compositeDataType, datatypesPackage, compositeDataType.entityName);
 		}
 	}
 }
@@ -345,7 +348,7 @@ routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType)
 			    .choices(collectionDataTypeNames).windowModality(WindowModality.MODAL).startInteraction();
 			val Class<?> selectedClass = collectionDataTypes.get(selectedType);
 
-			createJavaClass(dataType, datatypesPackage, dataType.entityName);
+			createOrFindJavaClass(dataType, datatypesPackage, dataType.entityName);
 			addSuperTypeToDataType(dataType, innerTypeClassOrWrapper, selectedClass.name);
 		}
 	}
@@ -507,6 +510,33 @@ routine changeInnerDeclarationType(pcm::InnerDeclaration innerDeclaration, java:
 // ######################################################
 // ################ JAVA PACKAGE ROUTINES ################
 
+routine createOrFindJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
+	match {
+		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
+		val allPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+	}
+	action {
+		call {
+			var matchingPackages = allPackages.filter[name == packageName.toFirstLower]
+			if(parentPackage !== null) { // checks full package namespace for non-root packages:
+				matchingPackages = matchingPackages.filter[namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + "."]
+			}
+			if(matchingPackages.empty) {
+				createJavaPackage(sourceElementMappedToPackage, parentPackage, packageName, newTag)
+			} else {
+				addPackageCorrespondence(sourceElementMappedToPackage, matchingPackages.head, newTag)
+			}
+		}
+	}
+}
+
+routine addPackageCorrespondence(EObject sourceElementMappedToPackage, java::Package javaPackage, String newTag) {
+	action {
+		add correspondence between javaPackage and sourceElementMappedToPackage
+			tagged with newTag
+	}
+}
+
 routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
@@ -520,8 +550,9 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 			javaPackage.name = packageName.toFirstLower;
 			persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage));
 		}
-		add correspondence between javaPackage and sourceElementMappedToPackage
-			tagged with newTag
+		add correspondence between javaPackage and sourceElementMappedToPackage tagged with newTag
+		// Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
+		add correspondence between javaPackage and javaPackage.eClass
 	}
 }
 
@@ -555,6 +586,23 @@ routine deleteJavaPackage(pcm::NamedElement sourceElementMappedToPackage, String
 // ######################################################
 // ################ JAVA CLASS ROUTINES ##################
 
+
+routine createOrFindJavaClass(pcm::NamedElement pcmElement, java::Package containingPackage, String className) {
+	match {
+        require absence of java::Class corresponding to pcmElement
+    }
+	action {
+		call {
+			val foundClass = findClassifier(className, containingPackage, org.emftext.language.java.classifiers.Class)
+			if(foundClass === null) {
+				createJavaClass(pcmElement, containingPackage, className)
+			} else {
+				addMissingClassifierCorrespondence(pcmElement, foundClass)
+			}
+		}
+	}
+}
+
 routine createJavaClass(pcm::NamedElement sourceElementMappedToClass, java::Package containingPackage, String className) {
 	action {
 		val javaClass = create java::Class and initialize {
@@ -574,20 +622,13 @@ routine createOrFindJavaInterface(pcm::Interface pcmInterface) {
 	}
 	action {
 		call {
-			val foundInterface = findInterface(pcmInterface.entityName, contractsPackage)
+			val foundInterface = findClassifier(pcmInterface.entityName, contractsPackage, Interface)
 			if(foundInterface === null) {
 				createJavaInterface(pcmInterface, contractsPackage)
 			} else {
-				addMissingInterfaceCorrespondence(pcmInterface, foundInterface)
+				addMissingClassifierCorrespondence(pcmInterface, foundInterface)
 			}
 		}
-	}
-}
-
-routine addMissingInterfaceCorrespondence(pcm::Interface pcmInterface, java::Interface javaInterface ) {
-	action {
-		add correspondence between javaInterface and pcmInterface
-		add correspondence between javaInterface.containingCompilationUnit and pcmInterface
 	}
 }
 
@@ -602,6 +643,13 @@ routine createJavaInterface(pcm::Interface pcmInterface, java::Package containin
 	}
 }
 
+routine addMissingClassifierCorrespondence(pcm::NamedElement pcmElement, java::ConcreteClassifier javaClassifier) {
+	action {
+		add correspondence between javaClassifier and pcmElement
+		add correspondence between javaClassifier.containingCompilationUnit and pcmElement
+	}
+}
+
 routine createCompilationUnit(pcm::NamedElement sourceElementMappedToClass, java::ConcreteClassifier classifier, java::Package containingPackage) {
 	action {
 		val compilationUnit = create java::CompilationUnit and initialize {
@@ -611,6 +659,9 @@ routine createCompilationUnit(pcm::NamedElement sourceElementMappedToClass, java
 			compilationUnit.classifiers += classifier;
 			persistProjectRelative(sourceElementMappedToClass, compilationUnit, buildJavaFilePath(compilationUnit));
 		}
+		call {
+        	containingPackage.compilationUnits += compilationUnit
+        }
 		add correspondence between compilationUnit and sourceElementMappedToClass
 	}
 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -345,7 +345,7 @@ routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType)
 			}
 			val String selectTypeMsg = "Please select type (or interface) that should be used for the type";
 			val int selectedType = userInteractor.singleSelectionDialogBuilder.message(selectTypeMsg)
-			    .choices(collectionDataTypeNames).windowModality(WindowModality.MODAL).startInteraction();
+				.choices(collectionDataTypeNames).windowModality(WindowModality.MODAL).startInteraction();
 			val Class<?> selectedClass = collectionDataTypes.get(selectedType);
 
 			createOrFindJavaClass(dataType, datatypesPackage, dataType.entityName);
@@ -513,14 +513,12 @@ routine changeInnerDeclarationType(pcm::InnerDeclaration innerDeclaration, java:
 routine createOrFindJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
-		val allPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+		with matchingPackages.name == packageName.toFirstLower && (parentPackage === null || 
+			matchingPackages.namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + ".")
 	}
 	action {
 		call {
-			var matchingPackages = allPackages.filter[name == packageName.toFirstLower]
-			if(parentPackage !== null) { // checks full package namespace for non-root packages:
-				matchingPackages = matchingPackages.filter[namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + "."]
-			}
 			if(matchingPackages.empty) {
 				createJavaPackage(sourceElementMappedToPackage, parentPackage, packageName, newTag)
 			} else {
@@ -552,7 +550,7 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 		}
 		add correspondence between javaPackage and sourceElementMappedToPackage tagged with newTag
 		// Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
-		add correspondence between javaPackage and javaPackage.eClass
+		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE
 	}
 }
 
@@ -589,8 +587,8 @@ routine deleteJavaPackage(pcm::NamedElement sourceElementMappedToPackage, String
 
 routine createOrFindJavaClass(pcm::NamedElement pcmElement, java::Package containingPackage, String className) {
 	match {
-        require absence of java::Class corresponding to pcmElement
-    }
+		require absence of java::Class corresponding to pcmElement
+	}
 	action {
 		call {
 			val foundClass = findClassifier(className, containingPackage, org.emftext.language.java.classifiers.Class)
@@ -617,8 +615,8 @@ routine createJavaClass(pcm::NamedElement sourceElementMappedToClass, java::Pack
 routine createOrFindJavaInterface(pcm::Interface pcmInterface) {
 	match {
 		val contractsPackage = retrieve java::Package corresponding to pcmInterface.repository__Interface tagged with "contracts"
-        require absence of java::Interface corresponding to pcmInterface
-        require absence of java::CompilationUnit corresponding to pcmInterface
+		require absence of java::Interface corresponding to pcmInterface
+		require absence of java::CompilationUnit corresponding to pcmInterface
 	}
 	action {
 		call {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -660,8 +660,8 @@ routine createCompilationUnit(pcm::NamedElement sourceElementMappedToClass, java
 			persistProjectRelative(sourceElementMappedToClass, compilationUnit, buildJavaFilePath(compilationUnit));
 		}
 		call {
-        	containingPackage.compilationUnits += compilationUnit
-        }
+			containingPackage.compilationUnits += compilationUnit
+		}
 		add correspondence between compilationUnit and sourceElementMappedToClass
 	}
 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/src/tools/vitruv/applications/pcmjava/util/pcm2java/Pcm2JavaHelper.xtend
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/src/tools/vitruv/applications/pcmjava/util/pcm2java/Pcm2JavaHelper.xtend
@@ -8,8 +8,6 @@ import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.util.EcoreUtil
 import org.emftext.language.java.classifiers.Class
 import org.emftext.language.java.classifiers.ConcreteClassifier
-import org.emftext.language.java.classifiers.Interface
-import org.emftext.language.java.containers.Package
 import org.emftext.language.java.expressions.ExpressionsFactory
 import org.emftext.language.java.literals.LiteralsFactory
 import org.emftext.language.java.members.ClassMethod
@@ -171,12 +169,6 @@ class Pcm2JavaHelper {
 		if (null !== parameters) {
 			classMethod.parameters.addAll(EcoreUtil.copyAll(parameters))
 		}
-	}
-	
-	public static def Interface findInterface(String interfaceName, Package javaPackage) {
-		val matchingInterfaces = javaPackage.compilationUnits.map[it.classifiers].flatten.filter(Interface).filter[it.name == interfaceName]
-		if(matchingInterfaces.size > 1) throw new IllegalStateException("Multiple matching interfaces were found: " + matchingInterfaces)
-		return matchingInterfaces.head
 	}
 
 	public static def ClassMethod findMethodInClass(ConcreteClassifier concreteClassifier, ClassMethod method) {

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -17,6 +17,17 @@ in reaction to changes in Java
 execute actions in UML
 
 //===========================================
+//=========================================== All Types
+//===========================================
+
+routine addTypeCorrespondence(java::ConcreteClassifier jClassifier, uml::Type uType, java::CompilationUnit jCompUnit) {
+	action {
+		add correspondence between uType and jClassifier
+        add correspondence between uType and jCompUnit
+	}
+}
+
+//===========================================
 //=========================================== Class
 //===========================================
 
@@ -80,21 +91,34 @@ reaction JavaClassCreated {
     call {
     	detectOrCreateUmlModel(affectedEObject)
 		registerPredefinedUmlPrimitiveTypes(correspondenceModel, affectedEObject.eResource.resourceSet)
-	    createUmlClass(newValue, affectedEObject)
+	    createOrFindUmlClass(newValue, affectedEObject)
     }
 }
 
-routine createUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
+routine createOrFindUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
 	match {
+		val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 		require absence of uml::Class corresponding to jClass
 	}
+    action {
+		call {
+			val uClass = findUmlClass(uModel, jClass.name, jCompUnit.namespaces.last)
+			if(uClass === null) {
+				createUmlClass(jClass, jCompUnit)
+			} else {
+				addTypeCorrespondence(jClass, uClass, jCompUnit)
+			}
+		}
+	}
+}
+
+routine createUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
     action {
         val uClass = create uml::Class and initialize {
             uClass.name = jClass.name;
         }
-        add correspondence between uClass and jClass
-        add correspondence between uClass and jCompUnit
         call {
+        	addTypeCorrespondence(jClass, uClass, jCompUnit)
             addUmlElementToModelOrPackage(jCompUnit, uClass)
         }
     }
@@ -309,7 +333,7 @@ routine createOrFindUmlInterface(java::Interface jInterface, java::CompilationUn
 			if(uInterface === null) {
 				createUmlInterface(jInterface, jCompUnit)
 			} else {
-				addInterfaceCorrespondence(jInterface, uInterface, jCompUnit)
+				addTypeCorrespondence(jInterface, uInterface, jCompUnit)
 			}
 		}
 	}
@@ -321,16 +345,9 @@ routine createUmlInterface(java::Interface jInterface, java::CompilationUnit jCo
             uInterface.name = jInterface.name;
         }
 		call {
-			addInterfaceCorrespondence(jInterface, uInterface, jCompUnit)
+			addTypeCorrespondence(jInterface, uInterface, jCompUnit)
 			addUmlElementToModelOrPackage(jCompUnit, uInterface)
 		}
-	}
-}
-
-routine addInterfaceCorrespondence(java::Interface jInterface, uml::Interface uInterface, java::CompilationUnit jCompUnit) {
-	action {
-		add correspondence between uInterface and jInterface
-        add correspondence between uInterface and jCompUnit
 	}
 }
 

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlHelper.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlHelper.xtend
@@ -7,6 +7,8 @@ import org.eclipse.uml2.uml.Model
 import org.eclipse.uml2.uml.Package
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 import tools.vitruv.framework.userinteraction.UserInteractor
+import org.eclipse.uml2.uml.Type
+import org.eclipse.uml2.uml.Class
 
 /**
  * Helper class for the Java2Uml reactions. Contains functions who depends on
@@ -34,7 +36,7 @@ class JavaToUmlHelper {
             return null
         }
         if (packages.size > 1) {
-        	throw new IllegalStateException("There is more than one package with name " + packageName + " in the UML model.")
+            throw new IllegalStateException("There is more than one package with name " + packageName + " in the UML model.")
         }
         return packages.head
     }
@@ -49,16 +51,33 @@ class JavaToUmlHelper {
      * @return the UML interface or null if none could be found
      */
     def static Interface findUmlInterface(Model umlModel, String interfaceName, String packageName) {
-		val uPackage = findUmlPackage(umlModel, packageName)
-		val interfaces = uPackage?.ownedTypes?.filter[it instanceof Interface]?.filter[name == interfaceName]?.toSet
-		if (interfaces.nullOrEmpty) {
-			return null
-		}
-		if (interfaces.size > 1) {
-			throw new IllegalStateException("There is more than one interface with name " + interfaceName + " in the package " + uPackage)
-		}
-		return interfaces.head as Interface
-	}
+        return umlModel.findUmlType(interfaceName, packageName, Interface)
+    }
+
+    /**
+     * Searches and retrieves the UML class located in a specific package of a UML model that has an equal name as the given package name.
+     * If there is more than one package with the given name an {@link IllegalStateException} is thrown.
+     * 
+     * @param umlModel the UML model Model in which the UML packages should be searched
+     * @param className the class name for which a fitting UML class should be retrieved
+     * @param packageName the package name in which the UML class should be located.
+     * @return the UML class or null if none could be found
+     */
+    def static Class findUmlClass(Model umlModel, String className, String packageName) {
+        return umlModel.findUmlType(className, packageName, Class)
+    }
+
+    def private static <T extends Type> findUmlType(Model umlModel, String typeName, String packageName, java.lang.Class<T> type) {
+        val uPackage = umlModel.findUmlPackage(packageName)
+        if (uPackage === null) {
+            return null
+        }
+        val types = uPackage.ownedTypes.filter(type).filter[name == typeName].toSet
+        if (types.size > 1) {
+            throw new IllegalStateException("There is more than one type with name " + typeName + " in the package " + uPackage)
+        }
+        return types.head
+    }
 
     /**
      * Displays a text message for the user.
@@ -68,6 +87,6 @@ class JavaToUmlHelper {
      * 
      */
     def static void showMessage(UserInteractor userinteractor, String message) {
-		userinteractor.notificationDialogBuilder.message(message).windowModality(WindowModality.MODAL).startInteraction
+        userinteractor.notificationDialogBuilder.message(message).windowModality(WindowModality.MODAL).startInteraction
     }
 }

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -32,18 +32,6 @@ reaction UmlClassCreated {
     after element uml::Class created and inserted in uml::Package[packagedElement]
     call {
         createOrFindJavaClass(newValue)
-        createRootJavaClass(newValue)
-    }
-}
-
-routine createRootJavaClass(uml::Classifier umlClassifier) {
-    match{
-        require absence of java::Class corresponding to umlClassifier
-        require absence of java::CompilationUnit corresponding to umlClassifier
-        require absence of java::Package corresponding to umlClassifier.eContainer
-    }
-    action {
-        call createJavaClass(umlClassifier) // if the direct container is the model
     }
 }
 
@@ -51,8 +39,20 @@ routine createOrFindJavaClass(uml::Classifier umlClassifier) {
     match{
         require absence of java::Class corresponding to umlClassifier
         require absence of java::CompilationUnit corresponding to umlClassifier
-        val javaPackage = retrieve java::Package corresponding to umlClassifier.eContainer
+        val javaPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
     }
+    action {
+        call {
+           if (javaPackage.isPresent) {
+               createOrFindJavaClassInPackage(umlClassifier, javaPackage.get)
+           } else {
+                createJavaClass(umlClassifier) // root class, direct container is the model
+           }
+        }
+    }
+}
+
+routine createOrFindJavaClassInPackage(uml::Classifier umlClassifier, java::Package javaPackage) {
     action {
         call {
             val foundClass = findClassifier(umlClassifier.name, javaPackage, org.emftext.language.java.classifiers.Class)
@@ -200,11 +200,11 @@ routine addJavaSuperClass(uml::Class uClass, uml::Generalization uGeneralization
     }
     action {
         execute {
-        	if (uClass.generals.size == 1) {
-	            var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null, userInteractor)
-	            addJavaImport(jClass.containingCompilationUnit, typeReference)
-	            jClass.extends = typeReference
-	            addGeneralizationCorrespondence(uGeneralization, typeReference)
+            if (uClass.generals.size == 1) {
+                var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null, userInteractor)
+                addJavaImport(jClass.containingCompilationUnit, typeReference)
+                jClass.extends = typeReference
+                addGeneralizationCorrespondence(uGeneralization, typeReference)
             } else {
                 userInteractor.notificationDialogBuilder.message("Can not synchronize multiple inheritance for " + uClass)
                     .title("Warning").notificationType(NotificationType.WARNING).windowModality(WindowModality.MODAL)
@@ -312,7 +312,6 @@ reaction UmlDataTypeCreated {
     	&& !(newValue instanceof Enumeration) 
     call {
         createOrFindJavaClass(newValue)
-        createRootJavaClass(newValue)
     } 
 }
 
@@ -325,25 +324,26 @@ reaction UmlInterfaceCreated {
     after element uml::Interface created and inserted in uml::Package[packagedElement]
     call { 
         createOrFindJavaInterface(newValue)
-        createRootJavaInterface(newValue)
    }
-}
-
-routine createRootJavaInterface(uml::Interface umlInterface) {
-    match {
-        require absence of java::Interface corresponding to umlInterface
-        require absence of java::Package corresponding to umlInterface.eContainer
-    }
-    action {
-        call createJavaInterface(umlInterface) // if the direct container is the model
-    }
 }
 
 routine createOrFindJavaInterface(uml::Interface umlInterface) {
     match {
         require absence of java::Interface corresponding to umlInterface
-        val javaPackage = retrieve java::Package corresponding to umlInterface.eContainer
+        val javaPackage = retrieve optional java::Package corresponding to umlInterface.eContainer
     }
+    action {
+        call {
+            if (javaPackage.isPresent) {
+                createOrFindJavaInterfaceInPackage(umlInterface, javaPackage.get)
+            } else {
+                createJavaInterface(umlInterface) // root interface, the direct container is the model
+            }
+        }
+    }
+}
+
+routine createOrFindJavaInterfaceInPackage(uml::Interface umlInterface, java::Package javaPackage) {
     action {
         call {
             val foundInterface = findClassifier(umlInterface.name, javaPackage, org.emftext.language.java.classifiers.Interface)

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -309,7 +309,10 @@ reaction UmlDataTypeCreated {
     after element uml::DataType created and inserted in uml::Package[packagedElement] 
     with !(newValue instanceof PrimitiveType)
     	&& !(newValue instanceof Enumeration) 
-    call createOrFindJavaClass(newValue)
+    call {
+        createOrFindJavaClass(newValue)
+        createRootJavaClass(newValue)
+    } 
 }
 
 //===========================================

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -29,37 +29,58 @@ execute actions in Java
 
 reaction UmlClassCreated {
     after element uml::Class created and inserted in uml::Package[packagedElement]
-    call createJavaClass(newValue)
+    call createOrFindJavaClass(newValue)
 
 }
 
-routine createJavaClass(uml::Classifier umlClassifier) {
-	match{
+routine createOrFindJavaClass(uml::Classifier umlClassifier) {
+    match{
         require absence of java::Class corresponding to umlClassifier
         require absence of java::CompilationUnit corresponding to umlClassifier
-	}
+        val javaPackage = retrieve java::Package corresponding to umlClassifier.eContainer
+    }
+    action {
+        call {
+            val foundClass = findClassifier(umlClassifier.name, javaPackage, org.emftext.language.java.classifiers.Class)
+            if(foundClass === null) {
+                createJavaClass(umlClassifier)
+            } else {
+                addMissingClassifierCorrespondence(umlClassifier, foundClass)
+            }
+        }
+    }
+}
+
+routine createJavaClass(uml::Classifier umlClassifier) {
     action {
         val javaClassifier = create java::Class and initialize {
-        	javaClassifier.name = umlClassifier.name;
-        	javaClassifier.makePublic
+            javaClassifier.name = umlClassifier.name;
+            javaClassifier.makePublic
         }
         call { 
-        	createJavaCompilationUnit (umlClassifier, javaClassifier, umlClassifier.namespace)
+            createJavaCompilationUnit (umlClassifier, javaClassifier, umlClassifier.namespace)
         }
         add correspondence between umlClassifier and javaClassifier
     }
 }
 
+routine addMissingClassifierCorrespondence(uml::Classifier umlClassifier, java::ConcreteClassifier javaClassifier) {
+    action {
+        add correspondence between javaClassifier and umlClassifier
+        add correspondence between javaClassifier.containingCompilationUnit and umlClassifier
+    }
+}
+
 routine createJavaCompilationUnit(uml::Classifier umlClassifier, java::ConcreteClassifier jClassifier, uml::Namespace uNamespace) {
-	match {
+    match {
         val jPackage = retrieve optional java::Package corresponding to uNamespace
         require absence of java::CompilationUnit corresponding to umlClassifier
-	}
-	action {
-		val javaCompilationUnit = create java::CompilationUnit and initialize {
-			if (jPackage.present) {
-				javaCompilationUnit.namespaces += jPackage.get.javaPackageAsStringList
-			}
+    }
+    action {
+        val javaCompilationUnit = create java::CompilationUnit and initialize {
+            if (jPackage.present) {
+                javaCompilationUnit.namespaces += jPackage.get.javaPackageAsStringList
+            }
             javaCompilationUnit.name = jClassifier.name + ".java";
             javaCompilationUnit.classifiers += jClassifier;
             persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit));
@@ -70,7 +91,7 @@ routine createJavaCompilationUnit(uml::Classifier umlClassifier, java::ConcreteC
             }
         }
         add correspondence between umlClassifier and javaCompilationUnit
-	}
+    }
 }
 
 reaction UmlClassifierRenamed {
@@ -275,7 +296,7 @@ reaction UmlDataTypeCreated {
     after element uml::DataType created and inserted in uml::Package[packagedElement] 
     with !(newValue instanceof PrimitiveType)
     	&& !(newValue instanceof Enumeration) 
-    call createJavaClass(newValue)
+    call createOrFindJavaClass(newValue)
 }
 
 //===========================================
@@ -285,22 +306,39 @@ reaction UmlDataTypeCreated {
 
 reaction UmlInterfaceCreated {
     after element uml::Interface created and inserted in uml::Package[packagedElement]
-    call createJavaInterface(newValue)
+    call createOrFindJavaInterface(newValue)
+}
+
+routine createOrFindJavaInterface(uml::Interface umlInterface) {
+    match {
+        require absence of java::Interface corresponding to umlInterface
+        val javaPackage = retrieve java::Package corresponding to umlInterface.eContainer
+    }
+    action {
+        call {
+            val foundInterface = findClassifier(umlInterface.name, javaPackage, org.emftext.language.java.classifiers.Interface)
+            if(foundInterface === null) {
+                createJavaInterface(umlInterface)
+            } else {
+                addMissingClassifierCorrespondence(umlInterface, foundInterface)
+            }
+        }
+    }
 }
 
 routine createJavaInterface(uml::Interface umlInterface) {
-	match {
+    match {
         require absence of java::Interface corresponding to umlInterface
-	}
+    }
     action {
         val javaInterface = create java::Interface and initialize {
             javaInterface.name = umlInterface.name;
             javaInterface.makePublic
         }
         call {
-			createJavaCompilationUnit(umlInterface, javaInterface, umlInterface.namespace)
-		}
-		add correspondence between umlInterface and javaInterface
+            createJavaCompilationUnit(umlInterface, javaInterface, umlInterface.namespace)
+        }
+        add correspondence between umlInterface and javaInterface
     }
 }
 

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -29,8 +29,21 @@ execute actions in Java
 
 reaction UmlClassCreated {
     after element uml::Class created and inserted in uml::Package[packagedElement]
-    call createOrFindJavaClass(newValue)
+    call {
+        createOrFindJavaClass(newValue)
+        createRootJavaClass(newValue)
+    }
+}
 
+routine createRootJavaClass(uml::Classifier umlClassifier) {
+    match{
+        require absence of java::Class corresponding to umlClassifier
+        require absence of java::CompilationUnit corresponding to umlClassifier
+        require absence of java::Package corresponding to umlClassifier.eContainer
+    }
+    action {
+        call createJavaClass(umlClassifier) // if the direct container is the model
+    }
 }
 
 routine createOrFindJavaClass(uml::Classifier umlClassifier) {
@@ -306,7 +319,20 @@ reaction UmlDataTypeCreated {
 
 reaction UmlInterfaceCreated {
     after element uml::Interface created and inserted in uml::Package[packagedElement]
-    call createOrFindJavaInterface(newValue)
+    call { 
+        createOrFindJavaInterface(newValue)
+        createRootJavaInterface(newValue)
+   }
+}
+
+routine createRootJavaInterface(uml::Interface umlInterface) {
+    match {
+        require absence of java::Interface corresponding to umlInterface
+        require absence of java::Package corresponding to umlInterface.eContainer
+    }
+    action {
+        call createJavaInterface(umlInterface) // if the direct container is the model
+    }
 }
 
 routine createOrFindJavaInterface(uml::Interface umlInterface) {

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaHelper.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaHelper.xtend
@@ -38,7 +38,6 @@ class UmlToJavaHelper {
         jAttribute.containingConcreteClassifier.members += jSetter
     }
     
-    
     /**
      * Displays the given message with the userInteractor.
      * 
@@ -49,5 +48,4 @@ class UmlToJavaHelper {
         userInteractor.notificationDialogBuilder.message(message).windowModality(WindowModality.MODAL)
             .startInteraction()
     }
-	
 }

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/META-INF/MANIFEST.MF
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/META-INF/MANIFEST.MF
@@ -25,7 +25,8 @@ Require-Bundle: com.google.guava,
  org.emftext.language.java,
  org.junit;bundle-version="4.12.0",
  tools.vitruv.domains.java.util.jamoppparser;bundle-version="0.2.0",
- tools.vitruv.testutils;bundle-version="0.2.0"
+ tools.vitruv.testutils;bundle-version="0.2.0",
+ edu.kit.ipd.sdq.activextendannotations
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: tools.vitruv.applications.umljava.testutil,
  tools.vitruv.applications.umljava.util,

--- a/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/util/java/JavaContainerAndClassifierUtil.xtend
+++ b/bundles/umljava/tools.vitruv.applications.umljava.util/src/tools/vitruv/applications/umljava/util/java/JavaContainerAndClassifierUtil.xtend
@@ -24,16 +24,15 @@ import org.emftext.language.java.commons.NamedElement
 import org.emftext.language.java.members.Member
 import org.emftext.language.java.parameters.Parameter
 import java.util.ArrayList
+import edu.kit.ipd.sdq.activextendannotations.Utility
 
 /**
  * Class for java classifier, package and compilation unit util functions
  * 
  * @author Fei
  */
+@Utility
 class JavaContainerAndClassifierUtil {
-    private new() {
-        
-    }
     
     /**
      * Creates and return a  new java class with the given name, visibility and modifiers
@@ -199,6 +198,20 @@ class JavaContainerAndClassifierUtil {
         writer.println("package " + packageName + ";")
         writer.close
         return file
+    }
+    
+    /**
+     * Finds and retrieves a specific {@link ConcreteClassifier} that is contained in a {@link Package}.
+     * @param name is the name of the desired {@link ConcreteClassifier}.
+     * @param javaPackage is the specific {@link Package} to search in.
+     * @param classifierType specifies the class of the desired {@link ConcreteClassifier}, e.g. {@link Interface}.
+     * @return the found classifier, or null if there is no matching classifer.
+     * @throws IllegalStateException if there are multiple classifers in the package with a matching name.
+     */
+    public static def <T extends ConcreteClassifier> T findClassifier(String name, Package javaPackage, java.lang.Class<T> classifierType) {
+        val matchingClassifiers = javaPackage.compilationUnits.map[it.classifiers].flatten.filter(classifierType).filter[it.name == name]
+        if (matchingClassifiers.size > 1) throw new IllegalStateException("Multiple matching classifers were found: " + matchingClassifiers)
+        return matchingClassifiers.head
     }
     
     /**


### PR DESCRIPTION
This pull request resolves more problems with the duplicated creation of Java/UML types by applying the find-or-create-pattern ([see PR54](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/54#discussion_r351258010)) to both class and interface creation across the reactions. 
This solves the issue of signature, attribute, and parameter concept tests crashing during the test setup since they originally did find two instances when resolving via the correspondences.

This pull request also addresses another issue where newly created Java compilation units were not added to the reference of their packages in the PCM to Java reaction file. This is required to enable the find or create pattern.