### PR TITLE
Fixed a problem with duplicate repository creation

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -27,6 +27,7 @@ import org.palladiosimulator.pcm.repository.OperationInterface
 import org.palladiosimulator.pcm.repository.OperationProvidedRole
 import org.palladiosimulator.pcm.repository.OperationSignature
 import org.palladiosimulator.pcm.repository.RepositoryComponent
+import org.palladiosimulator.pcm.repository.RepositoryPackage
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
 import static tools.vitruv.domains.java.util.JavaModificationUtil.*
@@ -45,6 +46,19 @@ execute actions in Java
 
 // ###################################################
 // ################ PACKAGE REACTIONS ################
+
+reaction RepositoryCreated {
+	after element pcm::Repository inserted as root
+	call {
+		addRepositoryCorrespondence(newValue)
+	}
+}
+
+routine addRepositoryCorrespondence(pcm::Repository pcmRepository) {
+	action {
+		add correspondence between pcmRepository and RepositoryPackage.Literals.REPOSITORY
+	}
+}
 
 reaction RenamedRepository {
 	after attribute replaced at pcm::Repository[entityName]

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -8,7 +8,6 @@ import org.emftext.language.java.containers.ContainersPackage
 import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil
 import org.palladiosimulator.pcm.repository.RepositoryPackage
 
-import static extension tools.vitruv.applications.util.temporary.pcm.PcmRepositoryUtil.findRepository
 import static extension tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaTypeUtil.getNormalizedClassifierFromTypeReference
 import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
@@ -80,15 +79,15 @@ routine createOrFindRepository(java::Package javaPackage, String packageName, St
     match {
         require absence of pcm::Repository corresponding to javaPackage tagged with newTag
         require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-        val allRepositories = retrieve many pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
+        val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
+            with foundRepository.entityName == packageName.toFirstUpper
     }
     action {
         call {
-            val matchingRepository = allRepositories.findRepository(packageName.toFirstUpper)
-            if (matchingRepository === null) {
-               createRepository(javaPackage, packageName, newTag)
+            if (foundRepository.present) {
+               addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
             } else {
-               addRepositoryCorrespondence(matchingRepository, javaPackage, newTag)
+               createRepository(javaPackage, packageName, newTag)
             }
         }
     }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -1,14 +1,17 @@
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
-import static extension tools.vitruv.domains.java.util.JavaPersistenceHelper.*
-import static extension tools.vitruv.applications.util.temporary.java.JavaTypeUtil.getNormalizedClassifierFromTypeReference
-import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import org.emftext.language.java.classifiers.Class
 import org.emftext.language.java.types.NamespaceClassifierReference
 import org.emftext.language.java.types.ClassifierReference
 import tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.Java2PcmUserSelection
 import org.emftext.language.java.containers.ContainersPackage
 import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil
+import org.palladiosimulator.pcm.repository.RepositoryPackage
+
+import static extension tools.vitruv.applications.util.temporary.pcm.PcmRepositoryUtil.findRepository
+import static extension tools.vitruv.domains.java.util.JavaPersistenceHelper.*
+import static extension tools.vitruv.applications.util.temporary.java.JavaTypeUtil.getNormalizedClassifierFromTypeReference
+import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 
 import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
@@ -26,7 +29,7 @@ reaction PackageCreated {
 		
 	call {
 		createArchitecturalElement(newValue, getLastPackageName(newValue.name), getRootPackageName(newValue.name))
-		createRepository(newValue, newValue.name, "package_root")
+		createOrFindRepository(newValue, newValue.name, "package_root")
 		createPackageEClassCorrespondence(newValue)
 	}
 }
@@ -73,14 +76,32 @@ routine createArchitecturalElement(java::Package javaPackage, String name, Strin
 	}
 }
 
-/**
- * Creates Repository.
- */
+routine createOrFindRepository(java::Package javaPackage, String packageName, String newTag) {
+    match {
+        require absence of pcm::Repository corresponding to javaPackage tagged with newTag
+        require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
+        val allRepositories = retrieve many pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
+    }
+    action {
+        call {
+            val matchingRepository = allRepositories.findRepository(packageName.toFirstUpper)
+            if (matchingRepository === null) {
+               createRepository(javaPackage, packageName, newTag)
+            } else {
+               addRepositoryCorrespondence(matchingRepository, javaPackage, newTag)
+            }
+        }
+    }
+}
+
+routine addRepositoryCorrespondence(pcm::Repository pcmRepository, java::Package javaPackage, String newTag) {
+    action {
+        add correspondence between pcmRepository and ContainersPackage.Literals.PACKAGE
+        add correspondence between pcmRepository and javaPackage tagged with newTag
+    }
+}
+
 routine createRepository(java::Package javaPackage, String packageName, String newTag) {
-	match {
-		require absence of pcm::Repository corresponding to javaPackage tagged with newTag
-		require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-	}
 	action {
 		update javaPackage {
 			// If the package-info.java is not persisted, do it
@@ -100,6 +121,7 @@ routine createRepository(java::Package javaPackage, String packageName, String n
 			
 		call createJavaSubPackages(javaPackage)
 		add correspondence between pcmRepository and ContainersPackage.Literals.PACKAGE
+		add correspondence between pcmRepository and RepositoryPackage.Literals.REPOSITORY
 	}
 }
 
@@ -401,7 +423,7 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
 	} 
-	action { 
+	action { // TODO FIXME find or create pattern
 		val javaPackage = create java::Package and initialize {
 			if (parentPackage !== null) {
 				javaPackage.namespaces += parentPackage.namespaces;

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmRepository.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmRepository.reactions
@@ -4,9 +4,10 @@ import tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.util.temporary.uml.UmlTypeUtil
 import tools.vitruv.extensions.dslsruntime.reactions.helper.ReactionsCorrespondenceHelper
+import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil
+import org.palladiosimulator.pcm.repository.RepositoryPackage
 
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlPackage
-import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
@@ -29,11 +30,18 @@ import routines sharedRoutines // for UML model handling
 reaction RepositoryCreated {
 	after element pcm::Repository inserted as root
 	call {
+		addRepositoryCorrespondence(newValue)
 		ensureUmlModelExists(newValue)
 		createOrFindUmlRepositoryPackage(newValue)
 		createUmlContractsPackage(newValue)
 		createUmlDatatypesPackage(newValue)
 		bootstrapPrimitiveDatatypes(newValue)
+	}
+}
+
+routine addRepositoryCorrespondence(pcm::Repository pcmRepository) {
+	action {
+		add correspondence between pcmRepository and RepositoryPackage.Literals.REPOSITORY
 	}
 }
 

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
@@ -5,6 +5,9 @@ import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.extensions.dslsruntime.reactions.helper.PersistenceHelper
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 import org.eclipse.uml2.uml.UMLPackage
+import org.palladiosimulator.pcm.repository.RepositoryPackage
+
+import static extension tools.vitruv.applications.util.temporary.pcm.PcmRepositoryUtil.findRepository
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
@@ -74,7 +77,7 @@ routine userDisambiguateRepositoryOrSystemCreation(uml::Package umlPkg, uml::Pac
 					.startInteraction
 			switch (pcmElementType) {
 				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REPOSITORY:
-						createCorrespondingRepository(umlPkg, umlParentPkg)
+						createOrFindCorrespondingRepository(umlPkg, umlParentPkg)
 				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__SYSTEM:
 						createCorrespondingSystem(umlPkg, umlParentPkg)
 				default: return //do nothing
@@ -83,12 +86,36 @@ routine userDisambiguateRepositoryOrSystemCreation(uml::Package umlPkg, uml::Pac
 	}
 }
 
+routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package umlParentPkg) {
+    match {
+        require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+        val allRepositories = retrieve many pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
+    }
+    action {
+        call {
+            val matchingRepository = allRepositories.findRepository(umlPkg.name?.toFirstUpper)
+            if (matchingRepository === null) {
+                createCorrespondingRepository(umlPkg, umlParentPkg)
+            } else {
+                addRepositoryCorrespondence(matchingRepository, umlPkg)
+            }
+        }
+    }
+}
+
+routine addRepositoryCorrespondence(pcm::Repository pcmRepository, uml::Package umlPkg) {
+    action {
+        add correspondence between pcmRepository and umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+    }
+}
+
 routine createCorrespondingRepository(uml::Package umlPkg, uml::Package umlParentPkg) {
 	action {
 		val pcmRepository = create pcm::Repository and initialize {
 			pcmRepository.entityName = umlPkg.name?.toFirstUpper
 		}
 		add correspondence between pcmRepository and umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		add correspondence between pcmRepository and RepositoryPackage.Literals.REPOSITORY
 		execute {
 			val fileExtension = DefaultLiterals.PCM_REPOSITORY_EXTENSION
 

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
@@ -7,8 +7,6 @@ import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModal
 import org.eclipse.uml2.uml.UMLPackage
 import org.palladiosimulator.pcm.repository.RepositoryPackage
 
-import static extension tools.vitruv.applications.util.temporary.pcm.PcmRepositoryUtil.findRepository
-
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
@@ -89,15 +87,15 @@ routine userDisambiguateRepositoryOrSystemCreation(uml::Package umlPkg, uml::Pac
 routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package umlParentPkg) {
     match {
         require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-        val allRepositories = retrieve many pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
+        val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
+            with foundRepository.entityName == umlPkg.name.toFirstUpper
     }
     action {
         call {
-            val matchingRepository = allRepositories.findRepository(umlPkg.name?.toFirstUpper)
-            if (matchingRepository === null) {
-                createCorrespondingRepository(umlPkg, umlParentPkg)
+            if (foundRepository.present) {
+                addRepositoryCorrespondence(foundRepository.get, umlPkg)
             } else {
-                addRepositoryCorrespondence(matchingRepository, umlPkg)
+                createCorrespondingRepository(umlPkg, umlParentPkg)
             }
         }
     }

--- a/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/pcm/PcmRepositoryUtil.xtend
+++ b/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/pcm/PcmRepositoryUtil.xtend
@@ -10,6 +10,16 @@ import tools.vitruv.framework.correspondence.CorrespondenceModel
 class PcmRepositoryUtil {
     private static final Logger logger = Logger.getLogger(PcmRepositoryUtil.simpleName)
 
+    /**
+     * Tries to locate a repository with a specific name out of a collection of repositories.
+     * @throws IllegalStateException if there is more than one matching repository.
+     */
+    def static Repository findRepository(Iterable<Repository> allRepositories, String name) {
+        val matchingRepositories = allRepositories.filter[entityName == name]
+        if (matchingRepositories.size > 1) throw new IllegalStateException("There are " + matchingRepositories.size + " repositories with name " + name)
+        return matchingRepositories.head
+    }
+
     def static Repository getFirstRepository(CorrespondenceModel correspondenceModel) {
         val Set<Repository> repos = correspondenceModel.getAllEObjectsOfTypeInCorrespondences(Repository)
         if (repos.nullOrEmpty) {

--- a/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/pcm/PcmRepositoryUtil.xtend
+++ b/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/pcm/PcmRepositoryUtil.xtend
@@ -10,16 +10,6 @@ import tools.vitruv.framework.correspondence.CorrespondenceModel
 class PcmRepositoryUtil {
     private static final Logger logger = Logger.getLogger(PcmRepositoryUtil.simpleName)
 
-    /**
-     * Tries to locate a repository with a specific name out of a collection of repositories.
-     * @throws IllegalStateException if there is more than one matching repository.
-     */
-    def static Repository findRepository(Iterable<Repository> allRepositories, String name) {
-        val matchingRepositories = allRepositories.filter[entityName == name]
-        if (matchingRepositories.size > 1) throw new IllegalStateException("There are " + matchingRepositories.size + " repositories with name " + name)
-        return matchingRepositories.head
-    }
-
     def static Repository getFirstRepository(CorrespondenceModel correspondenceModel) {
         val Set<Repository> repos = correspondenceModel.getAllEObjectsOfTypeInCorrespondences(Repository)
         if (repos.nullOrEmpty) {


### PR DESCRIPTION
Prevented duplicate repository creation with the find-or-create pattern. Existing repositories are matched by name and retrieved with a newly added repository `EClass` correspondence that is now always inserted when creating a repository.