### PR TITLE
Fixed a problem with repository name propagation

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -80,11 +80,11 @@ routine createOrFindRepository(java::Package javaPackage, String packageName, St
         require absence of pcm::Repository corresponding to javaPackage tagged with newTag
         require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
         val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
-            with foundRepository.entityName == packageName.toFirstUpper
+            with foundRepository.entityName.toFirstLower == packageName // PCM repositories can be both upper and lower case
     }
     action {
         call {
-            if (foundRepository.present) {
+            if (foundRepository.isPresent) {
                addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
             } else {
                createRepository(javaPackage, packageName, newTag)
@@ -111,7 +111,7 @@ routine createRepository(java::Package javaPackage, String packageName, String n
 			}
 		}
 		val pcmRepository = create pcm::Repository and initialize {
-			pcmRepository.entityName = packageName
+			pcmRepository.entityName = packageName.toFirstUpper
 			persistProjectRelative(javaPackage, pcmRepository, "model/" + pcmRepository.entityName + ".repository")
 		}
 		

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -85,10 +85,22 @@ routine createOrFindRepository(java::Package javaPackage, String packageName, St
     action {
         call {
             if (foundRepository.isPresent) {
+               ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, javaPackage)
                addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
             } else {
                createRepository(javaPackage, packageName, newTag)
             }
+        }
+    }
+}
+
+routine ensureFirstCaseUpperCaseRepositoryNaming(pcm::Repository pcmRepository, java::Package javaPackage) {
+    match {
+       check pcmRepository.entityName == javaPackage.name
+    }
+    action {
+        update pcmRepository {
+            pcmRepository.entityName = javaPackage.name.toFirstUpper
         }
     }
 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
@@ -37,7 +37,7 @@ routine renameNamedElement(java::NamedElement javaElement) {
 
 routine renameRepository(java::NamedElement javaElement) {
     match {
-        val pcmRepository = retrieve pcm::Repository corresponding to javaElement
+        val pcmRepository = retrieve pcm::Repository corresponding to javaElement tagged with "package_root"
     }
     action {
         update pcmRepository {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
@@ -1,5 +1,6 @@
 import tools.vitruv.applications.pcmjava.util.java2pcm.TypeReferenceCorrespondenceHelper
 import org.palladiosimulator.pcm.repository.OperationProvidedRole
+import org.palladiosimulator.pcm.repository.Repository
 
 import static extension edu.kit.ipd.sdq.commons.util.org.palladiosimulator.pcm.repository.ParameterUtil.*
 import static extension tools.vitruv.applications.pcmjava.util.java2pcm.TypeReferenceCorrespondenceHelper.getCorrespondingPCMDataTypeForTypeReference
@@ -17,17 +18,30 @@ execute actions in PCM
 reaction JavaNamedElementRenamed {
     after attribute replaced at java::NamedElement[name]
     call {
-    	renameNamedElement(affectedEObject)
+        renameNamedElement(affectedEObject)
+        renameRepository(affectedEObject)
     }
 }
 
 routine renameNamedElement(java::NamedElement javaElement) {
     match {
         val pcmElement = retrieve pcm::NamedElement corresponding to javaElement
+        with !(pcmElement instanceof Repository)
     }
     action {
         update pcmElement {
             pcmElement.entityName = javaElement.name;
+        }
+    }
+}
+
+routine renameRepository(java::NamedElement javaElement) {
+    match {
+        val pcmRepository = retrieve pcm::Repository corresponding to javaElement
+    }
+    action {
+        update pcmRepository {
+            pcmRepository.entityName = javaElement.name.toFirstUpper;
         }
     }
 }

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
@@ -93,10 +93,22 @@ routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package um
     action {
         call {
             if (foundRepository.isPresent) {
+                ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, umlPkg)
                 addRepositoryCorrespondence(foundRepository.get, umlPkg)
             } else {
                 createCorrespondingRepository(umlPkg, umlParentPkg)
             }
+        }
+    }
+}
+
+routine ensureFirstCaseUpperCaseRepositoryNaming(pcm::Repository pcmRepository, uml::Package umlPackage) {
+    match {
+       check pcmRepository.entityName == umlPackage.name
+    }
+    action {
+        update pcmRepository {
+            pcmRepository.entityName = umlPackage.name.toFirstUpper
         }
     }
 }

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
@@ -88,11 +88,11 @@ routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package um
     match {
         require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
         val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
-            with foundRepository.entityName == umlPkg.name.toFirstUpper
+            with foundRepository.entityName.toFirstLower == umlPkg.name // PCM repositories can be both upper and lower case
     }
     action {
         call {
-            if (foundRepository.present) {
+            if (foundRepository.isPresent) {
                 addRepositoryCorrespondence(foundRepository.get, umlPkg)
             } else {
                 createCorrespondingRepository(umlPkg, umlParentPkg)

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/java2pcm/PackageMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/java2pcm/PackageMappingTransformationTest.java
@@ -31,7 +31,7 @@ public class PackageMappingTransformationTest extends Java2PcmPackageMappingTran
     public void testAddFirstPackage() throws Throwable {
         final Repository repo = super.addRepoContractsAndDatatypesPackage();
         assertEquals("Name of the repository is not the same as the name of the package",
-                Pcm2JavaTestUtils.REPOSITORY_NAME, repo.getEntityName());
+                Pcm2JavaTestUtils.REPOSITORY_NAME_EXPECTED, repo.getEntityName());
         this.assertResourceAndFileForEObjects(repo);
         this.assertFilesOnlyForEObjects(repo);
     }

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/Pcm2JavaTestUtils.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/Pcm2JavaTestUtils.java
@@ -12,6 +12,7 @@ import org.palladiosimulator.pcm.system.SystemFactory;
 public class Pcm2JavaTestUtils {
 
     public static final String REPOSITORY_NAME = "testRepository";
+    public static final String REPOSITORY_NAME_EXPECTED = "TestRepository";
     public static final String BASIC_COMPONENT_NAME = "TestBasicComponent";
     public static final String IMPLEMENTING_CLASS_NAME = BASIC_COMPONENT_NAME + "Impl";
     public static final String INTERFACE_NAME = "TestInterface";


### PR DESCRIPTION
Prevented invalid repository name propagation by enforcing the required naming rule:
```java
pcmRepository.entityName = javaPackage.name.toFirstUpper
```
This rule is part of the following connections:
![test](https://www.lucidchart.com/publicSegments/view/d3d2c2bf-70d7-462c-8c9b-64d7c43b9767/image.png)