### PR TITLE
Fixed inability to deal with null-names when reacting to the creation of Java packages

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -24,7 +24,7 @@ reaction PackageCreated {
 	after element java::Package inserted as root
 	//This condition prevents another execution after automatically creating contracts and datatypes package.
 	//The reaction is called because every package insert is a root insert. 
-	with !newValue.name.contains("contracts") && !newValue.name.contains("datatypes")
+	with newValue.name === null || (!newValue.name.contains("contracts") && !newValue.name.contains("datatypes"))
 		
 	call {
 		createArchitecturalElement(newValue, getLastPackageName(newValue.name), getRootPackageName(newValue.name))

--- a/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaContainerAndClassifierUtil.xtend
+++ b/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaContainerAndClassifierUtil.xtend
@@ -271,10 +271,10 @@ class JavaContainerAndClassifierUtil {
     }
 
     def static String getRootPackageName(String packageName) { // TODO TS technically not depending on Java domain
-        return packageName.split("\\.").get(0)
+        return packageName?.split("\\.")?.get(0)
     }
 
     def static String getLastPackageName(String packageName) { // TODO TS technically not depending on Java domain
-        return packageName.substring(packageName.indexOf('.') + 1)
+        return packageName?.substring(packageName.indexOf('.') + 1)
     }
 }


### PR DESCRIPTION
Fixed an issue where the change propagation crashed because the Java to PCM reactions did not expect the edge case `null` as a value for Java package names, which means the package is unnamed. This can only appear during transitive scenarios, not with the Java to PCM reactions alone.