### PR TITLE
Fixed duplicate operation interface creation

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -179,7 +179,7 @@ reaction InterfaceCreated {
 routine createOrFindPCMInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit) {
 	match {
 		val containingPackage = retrieve java::Package corresponding to ContainersPackage.Literals.PACKAGE
-			with containingPackage.compilationUnits.map[name].contains(compilationUnit.name)
+			with containingPackage.compilationUnits.map[namespacesAsString + '.' + name].contains(compilationUnit.namespacesAsString + '.' + compilationUnit.name)
 		val pcmRepository = retrieve optional pcm::Repository corresponding to containingPackage tagged with "contracts"
 		require absence of pcm::OperationInterface corresponding to javaInterface
 	}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -178,37 +178,30 @@ reaction InterfaceCreated {
 
 routine createOrFindPCMInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit) {
 	match {
-		val contractsPackage = retrieve java::Package corresponding to ContainersPackage.Literals.PACKAGE
-			with contractsPackage.compilationUnits.contains(compilationUnit)
-		val pcmRepository = retrieve pcm::Repository corresponding to contractsPackage tagged with "contracts"
+		val containingPackage = retrieve java::Package corresponding to ContainersPackage.Literals.PACKAGE
+			with containingPackage.compilationUnits.map[name].contains(compilationUnit.name)
+		val pcmRepository = retrieve optional pcm::Repository corresponding to containingPackage tagged with "contracts"
 		require absence of pcm::OperationInterface corresponding to javaInterface
 	}
 	action {
 		call {
-		val pcmInterface = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[entityName == javaInterface.name]
-			if (pcmInterface === null) {
-				createPCMInterface(javaInterface, compilationUnit, contractsPackage)
+			if(pcmRepository.isPresent) {
+				createOrFindContractsInterface(javaInterface, compilationUnit, containingPackage, pcmRepository.get)
 			} else {
-				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
+				createNonContractsInterface(javaInterface, compilationUnit, containingPackage)
 			}
 		}
 	}
 }
 
-routine createPCMInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package contractsPackage) {
+routine createOrFindContractsInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package contractsPackage, pcm::Repository pcmRepository) {
 	action {
-		val pcmInterface = create pcm::OperationInterface and initialize {
-			pcmInterface.entityName = javaInterface.name
-		}		
 		call {
-			val javaPackage = getContainingPackageFromCorrespondenceModel(javaInterface,
-				correspondenceModel)
-				
-			if (javaPackage.name.equals(contractsPackage.name)) {
-				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
-				updateRepositoryInterfaces(pcmInterface)
+			val pcmInterface = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[entityName == javaInterface.name]
+			if (pcmInterface === null) {
+				createInterface(javaInterface, compilationUnit, contractsPackage)
 			} else {
-				createdInterfaceNotInContracts(javaInterface, pcmInterface, compilationUnit)
+				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
 			}
 		}
 	}
@@ -217,7 +210,7 @@ routine createPCMInterface(java::Interface javaInterface, java::CompilationUnit 
 /**
  * User selects if interface should be created if interface was not created into contract package.
  */
-routine createdInterfaceNotInContracts(java::Interface javaInterface, pcm::OperationInterface pcmInterface, java::CompilationUnit compilationUnit) {
+routine createNonContractsInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package javaPackage) {
 	action {
 		call {
 			val String userMsg = "The created interface is not in the contracts packages. Should an architectural interface be created for the interface " +
@@ -226,11 +219,22 @@ routine createdInterfaceNotInContracts(java::Interface javaInterface, pcm::Opera
 				Java2PcmUserSelection.SELECT_DONT_CREATE_INTERFACE_NOT_IN_CONTRACTS.message
 			]
 			val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-			    .windowModality(WindowModality.MODAL).startInteraction()
+				.windowModality(WindowModality.MODAL).startInteraction()
 			if (selected == Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.selection) {
-				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
-				updateRepositoryInterfaces(pcmInterface)
+				createInterface(javaInterface, compilationUnit, javaPackage)
 			}
+		}
+	}
+}
+
+routine createInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package javaPackage) {
+	action {
+		val pcmInterface = create pcm::OperationInterface and initialize {
+			pcmInterface.entityName = javaInterface.name
+		}
+		call {
+			addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
+			updateRepositoryInterfaces(pcmInterface)
 		}
 	}
 }
@@ -455,5 +459,6 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 		}
 		add correspondence between javaPackage and sourceElementMappedToPackage
 			tagged with newTag
+		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE
 	}
 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -7,6 +7,7 @@ import tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.Java2PcmUs
 import org.emftext.language.java.containers.ContainersPackage
 import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil
 import org.palladiosimulator.pcm.repository.RepositoryPackage
+import org.palladiosimulator.pcm.repository.OperationInterface
 
 import static extension tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaTypeUtil.getNormalizedClassifierFromTypeReference
@@ -172,26 +173,42 @@ routine addcorrespondenceAndUpdateRepository(pcm::ImplementationComponentType pc
 //Interface
 reaction InterfaceCreated {
 	after element java::Interface inserted in java::CompilationUnit[classifiers]
-	call createPCMInterface(newValue, affectedEObject)		
+	call createOrFindPCMInterface(newValue, affectedEObject)
 }
 
-routine createPCMInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit) {
+routine createOrFindPCMInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-		val contractsPackage = retrieve java::Package corresponding to pcmRepository tagged with "contracts" 
+		val contractsPackage = retrieve java::Package corresponding to ContainersPackage.Literals.PACKAGE
+			with contractsPackage.compilationUnits.contains(compilationUnit)
+		val pcmRepository = retrieve pcm::Repository corresponding to contractsPackage tagged with "contracts"
+		require absence of pcm::OperationInterface corresponding to javaInterface
 	}
 	action {
-		val pcmIface = create pcm::OperationInterface and initialize {
-			pcmIface.entityName = javaInterface.name
+		call {
+		val pcmInterface = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[entityName == javaInterface.name]
+			if (pcmInterface === null) {
+				createPCMInterface(javaInterface, compilationUnit, contractsPackage)
+			} else {
+				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
+			}
+		}
+	}
+}
+
+routine createPCMInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package contractsPackage) {
+	action {
+		val pcmInterface = create pcm::OperationInterface and initialize {
+			pcmInterface.entityName = javaInterface.name
 		}		
 		call {
 			val javaPackage = getContainingPackageFromCorrespondenceModel(javaInterface,
 				correspondenceModel)
 				
 			if (javaPackage.name.equals(contractsPackage.name)) {
-				addcorrespondenceToInterfaceAndUpdateRepository(pcmIface, javaInterface, compilationUnit)
+				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
+				updateRepositoryInterfaces(pcmInterface)
 			} else {
-				createdInterfaceNotInContracts(javaInterface, pcmIface, compilationUnit)
+				createdInterfaceNotInContracts(javaInterface, pcmInterface, compilationUnit)
 			}
 		}
 	}
@@ -211,23 +228,28 @@ routine createdInterfaceNotInContracts(java::Interface javaInterface, pcm::Opera
 			val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
 			    .windowModality(WindowModality.MODAL).startInteraction()
 			if (selected == Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.selection) {
-				addcorrespondenceToInterfaceAndUpdateRepository(pcmInterface, javaInterface, compilationUnit)
+				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
+				updateRepositoryInterfaces(pcmInterface)
 			}
 		}
 	}
 }
 
-/**
- * Add correspondence between OperationInterface and JavaInterface and CompilationUnit. Also adds OperationInterface into Repository.
- */
-routine addcorrespondenceToInterfaceAndUpdateRepository(pcm::OperationInterface pcmInterface, java::Interface javaInterface, java::CompilationUnit compilationUnit) {
+routine addInterfaceCorrespondence(pcm::OperationInterface pcmInterface, java::Interface javaInterface, java::CompilationUnit compilationUnit) {
+	match {
+		require absence of pcm::Interface corresponding to javaInterface
+	}
+	action {
+		add correspondence between pcmInterface and javaInterface
+		add correspondence between pcmInterface and compilationUnit 
+	}
+}
+
+routine updateRepositoryInterfaces(pcm::OperationInterface pcmInterface) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 	}
 	action {
-		add correspondence between pcmInterface and javaInterface
-		add correspondence between pcmInterface and compilationUnit	
-			
 		update pcmRepository {
 			pcmRepository.interfaces__Repository += pcmInterface
 		}

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlInterface.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlInterface.reactions
@@ -41,18 +41,16 @@ routine insertCorrespondingInterface(uml::Interface umlInterface, uml::Package u
 routine detectOrCreateCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	action {
 		call {
-			if (!pcmInterface.isPresent) {
-				val pcmInterfaceCandidate = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[it.entityName == umlInterface.name]
-				if (pcmInterfaceCandidate !== null) {
-					addCorrespondenceForExistingInterface(umlInterface, pcmInterfaceCandidate)
-				} else {
-					createCorrespondingInterface(umlInterface, umlPackage)
-				}
-			}	
+			val pcmInterfaceCandidate = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[it.entityName == umlInterface.name]
+			if (pcmInterfaceCandidate !== null) {
+				addCorrespondenceForExistingInterface(umlInterface, pcmInterfaceCandidate)
+			} else {
+				createCorrespondingInterface(umlInterface, umlPackage)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixed a problem with duplicate operation interface creation in the PCM model. A second operation interface was created due to the existing operation interface missing the required correspondences. This could be fixed by implementing the find-or-create-pattern in the Java-to-PCM reactions. Interestingly, the UML-to-PCM reactions already had the pattern implemented.

It is important to note that it seems like the Java-to-PCM reactions assume there is only one Repository existing at a time, which is different from UML-to-PCM which does not explicitly make that assumption. I am not sure if these reactions are required to handle multiple repositories, but one can and the other explicitly cannot.

Furthermore, the Java-to-PCM interface routines cover a case where the user can decide to create a PCM operation interface outside of a contracts package for a correlating Java package. This is an edge case where I do not fully understand why it makes sense to include it. Nevertheless, I made my changes without altering this edge case.