### PR TITLE
Fixed duplicate system creation

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -28,6 +28,7 @@ import org.palladiosimulator.pcm.repository.OperationProvidedRole
 import org.palladiosimulator.pcm.repository.OperationSignature
 import org.palladiosimulator.pcm.repository.RepositoryComponent
 import org.palladiosimulator.pcm.repository.RepositoryPackage
+import org.palladiosimulator.pcm.system.SystemPackage
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
 import static tools.vitruv.domains.java.util.JavaModificationUtil.*
@@ -127,10 +128,16 @@ routine renamePackageForRepository(pcm::Repository repository) {
 reaction CreatedSystem {
 	after element pcm::System created and inserted as root
 	call {
-		val system = newValue;
-		createOrFindJavaPackage(system, null, system.entityName, "root_system");
-		createImplementationForSystem(system);
+		addSystemCorrespondence(newValue)
+		createOrFindJavaPackage(newValue, null, newValue.entityName, "root_system");
+		createImplementationForSystem(newValue);
 	}
+}
+
+routine addSystemCorrespondence(pcm::System pcmSystem) {
+    action { // required to enable find-or-create-pattern:
+        add correspondence between pcmSystem and SystemPackage.Literals.SYSTEM
+    }
 }
 
 routine createImplementationForSystem(pcm::System system) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -8,6 +8,7 @@ import org.emftext.language.java.containers.ContainersPackage
 import edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil
 import org.palladiosimulator.pcm.repository.RepositoryPackage
 import org.palladiosimulator.pcm.repository.OperationInterface
+import org.palladiosimulator.pcm.system.SystemPackage
 
 import static extension tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaTypeUtil.getNormalizedClassifierFromTypeReference
@@ -28,9 +29,9 @@ reaction PackageCreated {
 	with newValue.name === null || (!newValue.name.contains("contracts") && !newValue.name.contains("datatypes"))
 		
 	call {
+	    createPackageEClassCorrespondence(newValue)
 		createArchitecturalElement(newValue, getLastPackageName(newValue.name), getRootPackageName(newValue.name))
 		createOrFindRepository(newValue, newValue.name, "package_root")
-		createPackageEClassCorrespondence(newValue)
 	}
 }
 
@@ -70,7 +71,7 @@ routine createArchitecturalElement(java::Package javaPackage, String name, Strin
 				case Java2PcmUserSelection.SELECT_COMPOSITE_COMPONENT.selection: 
 					createCompositeComponent(javaPackage, name, rootPackageName)
 				case Java2PcmUserSelection.SELECT_SYSTEM.selection: 
-					createSystem(javaPackage, name)
+					createOrFindSystem(javaPackage, name)
 			}
 		}
 	}
@@ -86,10 +87,10 @@ routine createOrFindRepository(java::Package javaPackage, String packageName, St
     action {
         call {
             if (foundRepository.isPresent) {
-               ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, javaPackage)
-               addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
+                ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, javaPackage)
+                addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
             } else {
-               createRepository(javaPackage, packageName, newTag)
+                createRepository(javaPackage, packageName, newTag)
             }
         }
     }
@@ -137,6 +138,29 @@ routine createRepository(java::Package javaPackage, String packageName, String n
 	}
 }
 
+routine createOrFindSystem(java::Package javaPackage, String name) {
+     match {
+        require absence of pcm::System corresponding to javaPackage
+        val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM
+            with foundSystem.entityName.toFirstLower == javaPackage.name // PCM systems can be both upper and lower case
+    }
+    action {
+        call {
+            if (foundSystem.isPresent) {
+               addSystemCorrespondence(foundSystem.get, javaPackage)
+            } else {
+               createSystem(javaPackage, javaPackage.name)
+            }
+        }
+    }
+}
+
+routine addSystemCorrespondence(pcm::System pcmSystem, java::Package javaPackage) {
+    action {
+        add correspondence between pcmSystem and javaPackage tagged with "root_system"
+    }
+}
+
 routine createSystem(java::Package javaPackage, String name) {
 	action {
 		val pcmSystem = create pcm::System and initialize {
@@ -144,6 +168,7 @@ routine createSystem(java::Package javaPackage, String name) {
 			persistProjectRelative(javaPackage, pcmSystem, "model/" + pcmSystem.entityName + ".system")
 		}
 		add correspondence between pcmSystem and javaPackage
+		add correspondence between pcmSystem and SystemPackage.Literals.SYSTEM tagged with "root_system"
 	}
 }
 
@@ -293,7 +318,7 @@ routine classMapping(java::Class javaClass, java::CompilationUnit compilationUni
 	}
 	action {
 		call {
-			if (javaPackage !== null && javaPackage.name.equals(datatypesPackage.name)) {
+			if (javaPackage?.name?.equals(datatypesPackage.name)) {
 				createDataType(javaClass, compilationUnit)
 				
 			} else {
@@ -469,6 +494,7 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 			javaPackage.name = packageName;
 			persistProjectRelative(parentPackage, javaPackage, buildJavaFilePath(javaPackage));
 		}
+		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE
 		add correspondence between javaPackage and sourceElementMappedToPackage
 			tagged with newTag
 		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -149,7 +149,7 @@ routine createOrFindSystem(java::Package javaPackage, String name) {
             if (foundSystem.isPresent) {
                addSystemCorrespondence(foundSystem.get, javaPackage)
             } else {
-               createSystem(javaPackage, javaPackage.name)
+               createSystem(javaPackage, name)
             }
         }
     }
@@ -318,9 +318,8 @@ routine classMapping(java::Class javaClass, java::CompilationUnit compilationUni
 	}
 	action {
 		call {
-			if (javaPackage?.name?.equals(datatypesPackage.name)) {
+			if (javaPackage !== null && javaPackage.name == datatypesPackage.name) {
 				createDataType(javaClass, compilationUnit)
-				
 			} else {
 				checkSystemAndComponent(javaPackage, javaClass)
 				createElement(javaClass, javaPackage, compilationUnit)

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -29,9 +29,9 @@ reaction PackageCreated {
 	with newValue.name === null || (!newValue.name.contains("contracts") && !newValue.name.contains("datatypes"))
 		
 	call {
-	    createPackageEClassCorrespondence(newValue)
 		createArchitecturalElement(newValue, getLastPackageName(newValue.name), getRootPackageName(newValue.name))
 		createOrFindRepository(newValue, newValue.name, "package_root")
+		createPackageEClassCorrespondence(newValue) // IMPORTANT: Always call this last here!
 	}
 }
 
@@ -496,6 +496,5 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE
 		add correspondence between javaPackage and sourceElementMappedToPackage
 			tagged with newTag
-		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE
 	}
 }

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmSystem.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmSystem.reactions
@@ -2,6 +2,7 @@ import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.UMLPackage
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
+import org.palladiosimulator.pcm.system.SystemPackage
 
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlPackage
 
@@ -26,11 +27,18 @@ import routines sharedRoutines // for UML model handling
 reaction SystemCreated {
 	after element pcm::System inserted as root
 	call{
+	    addSystemCorrespondence(newValue)
 		ensureUmlModelExists(newValue)
 		createOrFindCorrespondingSystemPackage(newValue)
 		detectOrCreateCorrespondingSystemImplementation(newValue)
 		detectOrCreateCorrespondingSystemConstructor(newValue)
 	}
+}
+
+routine addSystemCorrespondence(pcm::System pcmSystem) {
+    action { // required to enable find-or-create-pattern:
+        add correspondence between pcmSystem and SystemPackage.Literals.SYSTEM
+    }
 }
 
 routine createOrFindCorrespondingSystemPackage(pcm::System pcmSystem) {

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryAndSystemPackage.reactions
@@ -6,6 +6,7 @@ import tools.vitruv.extensions.dslsruntime.reactions.helper.PersistenceHelper
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 import org.eclipse.uml2.uml.UMLPackage
 import org.palladiosimulator.pcm.repository.RepositoryPackage
+import org.palladiosimulator.pcm.system.SystemPackage
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
@@ -77,7 +78,7 @@ routine userDisambiguateRepositoryOrSystemCreation(uml::Package umlPkg, uml::Pac
 				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REPOSITORY:
 						createOrFindCorrespondingRepository(umlPkg, umlParentPkg)
 				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__SYSTEM:
-						createCorrespondingSystem(umlPkg, umlParentPkg)
+						createOrFindCorrespondingSystem(umlPkg, umlParentPkg)
 				default: return //do nothing
 			}
 		}
@@ -153,12 +154,36 @@ routine createCorrespondingRepository(uml::Package umlPkg, uml::Package umlParen
 	}
 }
 
+routine createOrFindCorrespondingSystem(uml::Package umlPkg, uml::Package umlParentPkg) {
+    match {
+        require absence of pcm::System corresponding to umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+        val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM
+            with foundSystem.entityName.toFirstLower == umlPkg.name // PCM system can be both upper and lower case
+    }
+    action {
+        call {
+            if (foundSystem.isPresent) {
+                addSystemCorrespondence(foundSystem.get, umlPkg)
+            } else {
+                createCorrespondingSystem(umlPkg, umlParentPkg)
+            }
+        }
+    }
+}
+
+routine addSystemCorrespondence(pcm::System pcmSystem, uml::Package umlPkg) {
+    action {
+        add correspondence between pcmSystem and umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+    }
+}
+
 routine createCorrespondingSystem(uml::Package umlPkg, uml::Package umlParentPkg) {
 	action {
 		val pcmSystem = create pcm::System and initialize {
 			pcmSystem.entityName = umlPkg.name?.toFirstUpper
 		}
 		add correspondence between pcmSystem and umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		add correspondence between pcmSystem and  SystemPackage.Literals.SYSTEM
 		execute {
 			val fileExtension = DefaultLiterals.PCM_SYSTEM_EXTENSION
 			var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/system/SystemMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/system/SystemMappingTransformationTest.java
@@ -1,5 +1,6 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.system;
 
+import org.eclipse.emf.ecore.EClass;
 import org.emftext.language.java.containers.CompilationUnit;
 import org.emftext.language.java.containers.Package;
 import org.junit.Test;
@@ -49,8 +50,8 @@ public class SystemMappingTransformationTest extends Pcm2JavaTransformationTest 
     private void assertSystem(final System system) throws Throwable {
         final String expectedName = system.getEntityName();
         final String expectedLowerCaseName = Character.toLowerCase(expectedName.charAt(0)) + expectedName.substring(1);
-        this.assertCorrespondnecesAndCompareNames(system, 3,
-                new Class[] { Package.class, CompilationUnit.class, org.emftext.language.java.classifiers.Class.class },
-                new String[] { expectedLowerCaseName, expectedName + "Impl", expectedName + "Impl" });
+        this.assertCorrespondnecesAndCompareNames(system, 4,
+                new Class[] { Package.class, CompilationUnit.class, org.emftext.language.java.classifiers.Class.class, EClass.class},
+                new String[] { expectedLowerCaseName, expectedName + "Impl", expectedName + "Impl", null});
     }
 }


### PR DESCRIPTION
Prevented duplicate PCM system creation by implementing the find-or-create-pattern and adding system `EClass` correspondences to enable locating existing systems.

Similar to the find-or-create-pattern of repositories (see [PR69](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/pull/69#issuecomment-578171304)), we are matching first case upper AND lower case names when trying to locate an existing system, since both could be possible.