### PR TITLE
Fixed incorrect Java to PCM name change propagation

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -43,9 +43,9 @@ routine createPackageEClassCorrespondence(java::Package jPackage) {
 		val allPackages = retrieve many java::Package corresponding to jPackage.eClass
 		check !allPackages.contains(jPackage)
 	}
-    action {
-        add correspondence between jPackage and jPackage.eClass
-    }
+	action {
+		add correspondence between jPackage and jPackage.eClass
+	}
 }
 
 /**
@@ -78,40 +78,40 @@ routine createArchitecturalElement(java::Package javaPackage, String name, Strin
 }
 
 routine createOrFindRepository(java::Package javaPackage, String packageName, String newTag) {
-    match {
-        require absence of pcm::Repository corresponding to javaPackage tagged with newTag
-        require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-        val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
-            with foundRepository.entityName.toFirstLower == packageName // PCM repositories can be both upper and lower case
-    }
-    action {
-        call {
-            if (foundRepository.isPresent) {
-                ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, javaPackage)
-                addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
-            } else {
-                createRepository(javaPackage, packageName, newTag)
-            }
-        }
-    }
+	match {
+		require absence of pcm::Repository corresponding to javaPackage tagged with newTag
+		require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
+		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
+			with foundRepository.entityName.toFirstLower == packageName // PCM repositories can be both upper and lower case
+	}
+	action {
+		call {
+			if (foundRepository.isPresent) {
+				ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, javaPackage)
+				addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
+			} else {
+				createRepository(javaPackage, packageName, newTag)
+			}
+		}
+	}
 }
 
 routine ensureFirstCaseUpperCaseRepositoryNaming(pcm::Repository pcmRepository, java::Package javaPackage) {
-    match {
-       check pcmRepository.entityName == javaPackage.name
-    }
-    action {
-        update pcmRepository {
-            pcmRepository.entityName = javaPackage.name.toFirstUpper
-        }
-    }
+	match {
+	   check pcmRepository.entityName == javaPackage.name
+	}
+	action {
+		update pcmRepository {
+			pcmRepository.entityName = javaPackage.name.toFirstUpper
+		}
+	}
 }
 
 routine addRepositoryCorrespondence(pcm::Repository pcmRepository, java::Package javaPackage, String newTag) {
-    action {
-        add correspondence between pcmRepository and ContainersPackage.Literals.PACKAGE
-        add correspondence between pcmRepository and javaPackage tagged with newTag
-    }
+	action {
+		add correspondence between pcmRepository and ContainersPackage.Literals.PACKAGE
+		add correspondence between pcmRepository and javaPackage tagged with newTag
+	}
 }
 
 routine createRepository(java::Package javaPackage, String packageName, String newTag) {
@@ -139,26 +139,26 @@ routine createRepository(java::Package javaPackage, String packageName, String n
 }
 
 routine createOrFindSystem(java::Package javaPackage, String name) {
-     match {
-        require absence of pcm::System corresponding to javaPackage
-        val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM
-            with foundSystem.entityName.toFirstLower == javaPackage.name // PCM systems can be both upper and lower case
-    }
-    action {
-        call {
-            if (foundSystem.isPresent) {
-               addSystemCorrespondence(foundSystem.get, javaPackage)
-            } else {
-               createSystem(javaPackage, name)
-            }
-        }
-    }
+	 match {
+		require absence of pcm::System corresponding to javaPackage
+		val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM
+			with foundSystem.entityName.toFirstLower == javaPackage.name // PCM systems can be both upper and lower case
+	}
+	action {
+		call {
+			if (foundSystem.isPresent) {
+			   addSystemCorrespondence(foundSystem.get, javaPackage)
+			} else {
+			   createSystem(javaPackage, name)
+			}
+		}
+	}
 }
 
 routine addSystemCorrespondence(pcm::System pcmSystem, java::Package javaPackage) {
-    action {
-        add correspondence between pcmSystem and javaPackage tagged with "root_system"
-    }
+	action {
+		add correspondence between pcmSystem and javaPackage tagged with "root_system"
+	}
 }
 
 routine createSystem(java::Package javaPackage, String name) {
@@ -177,7 +177,7 @@ routine createBasicComponent(java::Package javaPackage, String name, String root
 		val pcmBasicComponent = create pcm::BasicComponent and initialize {
 			pcmBasicComponent.entityName = name
 		}
-		call addcorrespondenceAndUpdateRepository(pcmBasicComponent, javaPackage)
+		call addCorrespondenceAndUpdateRepository(pcmBasicComponent, javaPackage)
 	}
 }
 
@@ -186,14 +186,14 @@ routine createCompositeComponent(java::Package javaPackage, String name, String 
 		val pcmCompositeComponent = create pcm::CompositeComponent and initialize {
 			pcmCompositeComponent.entityName = name
 		}		
-		call addcorrespondenceAndUpdateRepository(pcmCompositeComponent, javaPackage)
+		call addCorrespondenceAndUpdateRepository(pcmCompositeComponent, javaPackage)
 	}
 }
 
 /**
  * Adds correspondence between component and package and add component into repository.
  */
-routine addcorrespondenceAndUpdateRepository(pcm::ImplementationComponentType pcmComponent, java::Package javaPackage) {
+routine addCorrespondenceAndUpdateRepository(pcm::ImplementationComponentType pcmComponent, java::Package javaPackage) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 		
@@ -203,6 +203,48 @@ routine addcorrespondenceAndUpdateRepository(pcm::ImplementationComponentType pc
 		
 		update pcmRepository {
 			pcmRepository.components__Repository += pcmComponent
+		}
+	}
+}
+
+reaction JavaPackageRenamed {
+	after attribute replaced at java::Package[name]
+	call {
+		renameRepository(affectedEObject)
+		renameSystem(affectedEObject)
+		renameComponent(affectedEObject)
+	}
+}
+
+routine renameRepository(java::Package javaPackage) {
+	match {
+		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged with "package_root"
+	}
+	action {
+		update pcmRepository {
+			pcmRepository.entityName = javaPackage.name.toFirstUpper
+		}
+	}
+}
+
+routine renameSystem(java::Package javaPackage) {
+	match {
+		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged with "root_system"
+	}
+	action {
+		update pcmSystem {
+			pcmSystem.entityName = javaPackage.name.toFirstUpper
+		}
+	}
+}
+
+routine renameComponent(java::NamedElement javaElement) {
+	match {
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaElement
+	}
+	action {
+		update pcmComponent {
+			pcmComponent.entityName = javaElement.name.toFirstUpper;
 		}
 	}
 }
@@ -240,6 +282,21 @@ routine createOrFindContractsInterface(java::Interface javaInterface, java::Comp
 			} else {
 				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
 			}
+		}
+	}
+}
+
+reaction JavaInterfaceRenamed {
+	after attribute replaced at java::Interface[name]
+	call renameInterface(affectedEObject)
+}
+
+routine renameInterface(java::Interface javaInterface) {
+	match {
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to javaInterface}
+	action {
+		update pcmInterface {
+			pcmInterface.entityName = javaInterface.name
 		}
 	}
 }
@@ -298,6 +355,11 @@ routine updateRepositoryInterfaces(pcm::OperationInterface pcmInterface) {
 }
 
 //Class
+reaction JavaClassRenamed {
+	after attribute replaced at java::Class[name]
+	call renameComponent(affectedEObject)
+}
+
 reaction ClassCreated {
 	after element java::Class inserted in java::CompilationUnit[classifiers]
 	call {
@@ -342,7 +404,7 @@ routine createDataType(java::Class javaClass, java::CompilationUnit compilationU
 				Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
 			]
 			val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-			    .windowModality(WindowModality.MODAL).startInteraction()
+				.windowModality(WindowModality.MODAL).startInteraction()
 			switch(selected) {
 				case Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.selection: 
 					createCompositeDataType(javaClass, compilationUnit)

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -238,13 +238,13 @@ routine renameSystem(java::Package javaPackage) {
 	}
 }
 
-routine renameComponent(java::NamedElement javaElement) {
+routine renameComponent(java::Package javaPackage) {
 	match {
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaElement
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaPackage
 	}
 	action {
 		update pcmComponent {
-			pcmComponent.entityName = javaElement.name.toFirstUpper;
+			pcmComponent.entityName = javaPackage.name.toFirstUpper;
 		}
 	}
 }
@@ -357,7 +357,20 @@ routine updateRepositoryInterfaces(pcm::OperationInterface pcmInterface) {
 //Class
 reaction JavaClassRenamed {
 	after attribute replaced at java::Class[name]
-	call renameComponent(affectedEObject)
+	call renameComponentFromClass(affectedEObject)
+}
+
+routine renameComponentFromClass(java::Class javaClass) {
+	match {
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaClass
+	}
+	action {
+		update pcmComponent {
+			var newName = javaClass.name.toFirstUpper
+			if (newName.endsWith("Impl")) newName = newName.substring(0, newName.length - "Impl".length)
+			pcmComponent.entityName = newName
+		}
+	}
 }
 
 reaction ClassCreated {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
@@ -1,11 +1,12 @@
-import tools.vitruv.applications.pcmjava.util.java2pcm.TypeReferenceCorrespondenceHelper
 import org.palladiosimulator.pcm.repository.OperationProvidedRole
-import org.palladiosimulator.pcm.repository.Repository
+import org.emftext.language.java.classifiers.ConcreteClassifier
+import tools.vitruv.applications.pcmjava.util.java2pcm.TypeReferenceCorrespondenceHelper
+
+import static tools.vitruv.applications.pcmjava.util.java2pcm.TypeReferenceCorrespondenceHelper.*
+import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 
 import static extension edu.kit.ipd.sdq.commons.util.org.palladiosimulator.pcm.repository.ParameterUtil.*
-import static extension tools.vitruv.applications.pcmjava.util.java2pcm.TypeReferenceCorrespondenceHelper.getCorrespondingPCMDataTypeForTypeReference
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.hasSameSignature
-import static extension tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 
 import "http://www.emftext.org/java" as java 
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
@@ -14,39 +15,25 @@ reactions: java2PcmMethod
 in reaction to changes in Java
 execute actions in PCM
 
-//Rename
-reaction JavaNamedElementRenamed {
-    after attribute replaced at java::NamedElement[name]
-    call {
-        renameNamedElement(affectedEObject)
-        renameRepository(affectedEObject)
-    }
+
+// General:
+reaction MemberRenamed {
+	after attribute replaced at java::Member[name]
+	with !(affectedEObject instanceof ConcreteClassifier) // avoid classes etc.
+	call renameMember(affectedEObject)
 }
 
-routine renameNamedElement(java::NamedElement javaElement) {
-    match {
-        val pcmElement = retrieve pcm::NamedElement corresponding to javaElement
-        with !(pcmElement instanceof Repository)
-    }
-    action {
-        update pcmElement {
-            pcmElement.entityName = javaElement.name;
-        }
-    }
+routine renameMember(java::Member javaMember) {
+	match {
+		val pcmElement = retrieve pcm::NamedElement corresponding to javaMember}
+	action {
+		update pcmElement {
+			pcmElement.entityName = javaMember.name
+		}
+	}
 }
 
-routine renameRepository(java::NamedElement javaElement) {
-    match {
-        val pcmRepository = retrieve pcm::Repository corresponding to javaElement tagged with "package_root"
-    }
-    action {
-        update pcmRepository {
-            pcmRepository.entityName = javaElement.name.toFirstUpper;
-        }
-    }
-}
-
-//Parameter
+// Parameter:
 reaction ParameterCreated {
 	after element java::OrdinaryParameter inserted in java::Parametrizable[parameters]
 	call {
@@ -77,21 +64,21 @@ routine createParameter(java::OrdinaryParameter javaParameter, java::Parametriza
 
 //TODO changed Parameter doesn't work yet
 reaction ParameterDeleted {
-    after element java::OrdinaryParameter removed from java::Parametrizable[parameters]
-    call {
-    	//oldValue has no correspondence element, but it should
-    	//this seems to be a bug. If fixed it should have a correspondence and work.
-    	deleteParameter(oldValue)
-    }
+	after element java::OrdinaryParameter removed from java::Parametrizable[parameters]
+	call {
+		//oldValue has no correspondence element, but it should
+		//this seems to be a bug. If fixed it should have a correspondence and work.
+		deleteParameter(oldValue)
+	}
 }
 
 routine deleteParameter(java::OrdinaryParameter javaParameter) {
-    match {
-    	val pcmParameter = retrieve pcm::Parameter corresponding to javaParameter
-    }
-    action{
-    	delete pcmParameter         
-    }
+	match {
+		val pcmParameter = retrieve pcm::Parameter corresponding to javaParameter
+	}
+	action{
+		delete pcmParameter
+	}
 }
 
 /**
@@ -113,7 +100,7 @@ routine changeParameterName(String newName, java::Parameter javaParameter) {
 	}
 }
 
-//Field
+// Field:
 /**
  * Check if Field has correspondence to CompositeDataType, ComposedProvidingRequiringEntity, 
  * OperationInterface or RepositoryComponent and react accordingly.
@@ -142,7 +129,6 @@ routine createInnerDeclaration(java::ConcreteClassifier classifier, java::Field 
 			innerDeclaration.compositeDataType_InnerDeclaration = compositeDataType
 		}
 		add correspondence between innerDeclaration and javaField
-			
 	}
 }
 
@@ -158,7 +144,6 @@ routine createAssemblyContext(java::ConcreteClassifier classifier, java::Field j
 			assemblyContext.parentStructure__AssemblyContext = composedProvidingRequiringEntity	
 		}
 		add correspondence between assemblyContext and javaField
-			
 	}
 }
 
@@ -185,7 +170,6 @@ routine fieldCreatedCorrespondingToRepositoryComponent(java::Classifier classifi
 				createOperationRequiredRoleCorrespondingToField(javaField, providedRole.providedInterface__OperationProvidedRole, concreteRepositoryComponent)
 			}
 		}
-			
 	}
 }
 
@@ -213,12 +197,12 @@ routine changeInnerDeclarationType(java::TypeReference typeReference, java::Fiel
 	action {
 		update innerDeclaration {
 			innerDeclaration.datatype_InnerDeclaration = TypeReferenceCorrespondenceHelper.
-						getDataTypeFromTypeReference(typeReference, correspondenceModel,
-							userInteractor, null)
+				getDataTypeFromTypeReference(typeReference, correspondenceModel, userInteractor, null)
 		}
 	}
 }
-//Class Method
+
+// Class Method:
 reaction ClassMethodCreated {
 	after element java::ClassMethod inserted in java::Class[members]
 	call createSeffFromImplementingInterfaces(newValue, affectedEObject)
@@ -267,7 +251,7 @@ routine createSEFF(java::Method javaMethod, java::Class javaClass, java::ClassMe
 	}
 }
 
-//Interface Method
+// Interface Method:
 reaction InterfaceMethodCreated {
 	after element java::InterfaceMethod inserted in java::Interface[members] 
 	call createPCMSignature(newValue)
@@ -292,18 +276,18 @@ routine createPCMSignature(java::InterfaceMethod interfaceMethod) {
 }
 
 reaction JavaReturnTypeChanged {
-    after element java::TypeReference replaced at java::Method[typeReference]
-    call changeReturnType(affectedEObject, newValue)
+	after element java::TypeReference replaced at java::Method[typeReference]
+	call changeReturnType(affectedEObject, newValue)
 }
 
 routine changeReturnType(java::Method javaMethod, java::TypeReference typeReference) {
-    match {
-        val operationSignature = retrieve pcm::OperationSignature corresponding to javaMethod
-    }
-     action {
-         update operationSignature {
-         	val repository = operationSignature.interface__OperationSignature.repository__Interface
-            operationSignature.returnType__OperationSignature = getCorrespondingPCMDataTypeForTypeReference(typeReference, correspondenceModel, userInteractor, repository, javaMethod.arrayDimension)
-         }
-     }
+	match {
+		val operationSignature = retrieve pcm::OperationSignature corresponding to javaMethod
+	}
+	 action {
+		 update operationSignature {
+			val repository = operationSignature.interface__OperationSignature.repository__Interface
+			operationSignature.returnType__OperationSignature = getCorrespondingPCMDataTypeForTypeReference(typeReference, correspondenceModel, userInteractor, repository, javaMethod.arrayDimension)
+		 }
+	 }
 }


### PR DESCRIPTION
Multiple issues were caused by the naive rename routine that just renamed every `pcm::NamedElement` corresponding to a `java::NamedElement`:
```java
pcmElement.entityName = javaElement.name
```
While this worked for the Java to PCM reactions on their own, it did not work in combination with other reactions as they introduce correspondences between elements that should not be renamed together.

These are some of the issues observed in the transitive scenario:
-  Loops that endlessly appended `.java` to the names of compilation units and corresponding PCM and UML elements
-  Loops that endlessly appended `Impl` to the names of classes and corresponding PCM and UML elements
- PCM repositories renamed to `"datatypes"` as their subpackages correspond to the PCM element
- Invalid first letter upper/lower case naming due to directly transferring the name as it is

This was fixed by creating multiple rename routines for the different model elements to actually allow the correct propagation of name changes:
![new rename relations](https://www.lucidchart.com/publicSegments/view/332fd544-c8d4-4955-8fc6-3db0e4e4d8cb/image.png)