### PR TITLE
Fixed incorrect name propagation for repository components and classifiers

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -624,8 +624,8 @@ routine createOrFindJavaClass(pcm::NamedElement pcmElement, java::Package contai
 routine createJavaClass(pcm::NamedElement sourceElementMappedToClass, java::Package containingPackage, String className) {
 	action {
 		val javaClass = create java::Class and initialize {
-			javaClass.name = className;
-			javaClass.addModifier(ModifiersFactory.eINSTANCE.createPublic());
+			javaClass.name = className.toFirstUpper
+			javaClass.addModifier(ModifiersFactory.eINSTANCE.createPublic())
 		}
 		add correspondence between javaClass and sourceElementMappedToClass
 		call createCompilationUnit(sourceElementMappedToClass, javaClass, containingPackage)
@@ -653,7 +653,7 @@ routine createOrFindJavaInterface(pcm::Interface pcmInterface) {
 routine createJavaInterface(pcm::Interface pcmInterface, java::Package containingPackage) {
 	action {
 		val javaInterface = create java::Interface and initialize {
-			javaInterface.name = pcmInterface.entityName;
+			javaInterface.name = pcmInterface.entityName.toFirstUpper;
 			javaInterface.addModifier(ModifiersFactory.eINSTANCE.createPublic());
 		}
 		add correspondence between javaInterface and pcmInterface
@@ -690,10 +690,10 @@ routine renameJavaClassifier(pcm::NamedElement classSourceElement, java::Package
 	}
 	action {
 		update javaClassifier {
-			javaClassifier.name = className;
+			javaClassifier.name = className.toFirstUpper;
 		}
 		update compilationUnit {
-			compilationUnit.name = className + ".java";
+			compilationUnit.name = className.toFirstUpper + ".java";
 			compilationUnit.namespaces.clear;
 			compilationUnit.namespaces += containingPackage.namespaces;
 			compilationUnit.namespaces += containingPackage.name;

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmRepositoryComponent.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmRepositoryComponent.reactions
@@ -117,7 +117,7 @@ routine createCorrespondingComponentImplementation(pcm::RepositoryComponent pcmC
 	}
 	action {
 		val umlComponentImplementation = create uml::Class and initialize {
-			umlComponentImplementation.name = pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX
+			umlComponentImplementation.name = pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
 			umlComponentImplementation.isFinalSpecialization = true
 			umlComponentPackage.packagedElements += umlComponentImplementation
 		} 
@@ -134,7 +134,7 @@ routine detectOrCreateCorrespondingComponentConstructor(pcm::RepositoryComponent
 		call {
 			if (!umlComponentConstructor.isPresent) {
 				val umlComponentConstructorCandidate = umlComponentImplementation.ownedOperations
-						.findFirst[it.name == pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+						.findFirst[it.name == pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
 				if (umlComponentConstructorCandidate !== null) {
 					addCorrespondenceForExistingComponentConstructor(pcmComponent, umlComponentConstructorCandidate)
 				} else {
@@ -162,7 +162,7 @@ routine createCorrespondingComponentConstructor(pcm::RepositoryComponent pcmComp
 	}
 	action {
 		val umlComponentConstructor = create uml::Operation and initialize {
-			umlComponentConstructor.name = pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX
+			umlComponentConstructor.name = pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
 			umlComponentImplementation.ownedOperations += umlComponentConstructor
 		}
 		add correspondence between pcmComponent and umlComponentConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
@@ -233,8 +233,8 @@ routine changeNameOfComponentCorrespondences(pcm::RepositoryComponent pcmCompone
 	action {
 		execute {
 			if (umlComponentPackage.isPresent) umlComponentPackage.get.name = pcmComponent.entityName.toFirstLower
-			if (umlComponentImplementation.isPresent) umlComponentImplementation.get.name = newName + DefaultLiterals.IMPLEMENTATION_SUFFIX
-			if (umlComponentConstructor.isPresent) umlComponentConstructor.get.name = newName + DefaultLiterals.IMPLEMENTATION_SUFFIX
+			if (umlComponentImplementation.isPresent) umlComponentImplementation.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+			if (umlComponentConstructor.isPresent) umlComponentConstructor.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
 		}
 	}
 }

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmSystem.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmSystem.reactions
@@ -86,7 +86,7 @@ routine detectOrCreateCorrespondingSystemImplementation(pcm::System pcmSystem) {
 	action {
 		call {
 			val umlSystemImplementationCandidate = umlSystemPackage.packagedElements
-					.filter(Class).findFirst[it.name == pcmSystem.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+					.filter(Class).findFirst[it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
 			if (umlSystemImplementationCandidate !== null) {
 				addCorrespondenceForExistingSystemImplementation(pcmSystem, umlSystemImplementationCandidate)
 			} else {
@@ -113,7 +113,7 @@ routine createCorrespondingSystemImplementation(pcm::System pcmSystem) {
 	}
 	action {
 		val umlSystemImplementation = create uml::Class and initialize {
-			umlSystemImplementation.name = pcmSystem.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX
+			umlSystemImplementation.name = pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
 			umlSystemImplementation.isFinalSpecialization = true
 			umlSystemPackage.packagedElements += umlSystemImplementation
 		}
@@ -129,7 +129,7 @@ routine detectOrCreateCorrespondingSystemConstructor(pcm::System pcmSystem) {
 	action {
 		call {
 			val umlSystemConstructorCandidate = umlSystemImplementation.ownedOperations
-					.findFirst[it.name == pcmSystem.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+					.findFirst[it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
 			if (umlSystemConstructorCandidate !== null) {
 				addCorrespondenceForExistingSystemConstructor(pcmSystem, umlSystemConstructorCandidate)
 			} else {
@@ -156,7 +156,7 @@ routine createCorrespondingSystemConstructor(pcm::System pcmSystem) {
 	}
 	action {
 		val umlSystemConstructor = create uml::Operation and initialize {
-			umlSystemConstructor.name = pcmSystem.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX
+			umlSystemConstructor.name = pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
 			umlSystemImplementation.ownedOperations += umlSystemConstructor
 		}
 		add correspondence between pcmSystem and umlSystemConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlIPREClass.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlIPREClass.reactions
@@ -28,13 +28,10 @@ reaction IPREClassRemoved {
 
 routine warnUserAboutImplRemoveIfIPRECorrespondenceExists(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmRepositoryComponent = retrieve optional pcm::RepositoryComponent corresponding to umlClass tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val pcmRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to umlClass tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
 	action {
-		execute {
-			if (pcmRepositoryComponent.isPresent)
-				logger.warn(DefaultLiterals.WARNING_IPRE_IMPLEMENTATION_REMOVED + umlClass)
-		}
+		execute logger.warn(DefaultLiterals.WARNING_IPRE_IMPLEMENTATION_REMOVED + umlClass)
 	}
 }
 

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryComponentPackage.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlRepositoryComponentPackage.reactions
@@ -47,17 +47,15 @@ routine insertCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package
 routine detectOrCreateCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmComponent = retrieve optional pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
 	action {
 		call {
-			if(!pcmComponent.isPresent) {
-				val pcmComponentCandidate = pcmRepository.components__Repository.findFirst[it.entityName == umlPkg.name.toFirstUpper]
-				if (pcmComponentCandidate !== null) {
-					addCorrespondenceForExistingRepositoryComponent(umlPkg, pcmComponentCandidate)
-				} else {
-					userDisambiguateCorrespondingRepositoryComponentType(umlPkg, umlParentPkg)
-				}
+			val pcmComponentCandidate = pcmRepository.components__Repository.findFirst[entityName.toFirstLower == umlPkg.name]
+			if (pcmComponentCandidate === null) {
+				userDisambiguateCorrespondingRepositoryComponentType(umlPkg, umlParentPkg)
+			} else {
+				addCorrespondenceForExistingRepositoryComponent(umlPkg, pcmComponentCandidate)
 			}
 		}
 	}
@@ -151,12 +149,10 @@ routine removeCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package
 	}
 }
 
-
 reaction PackageDeleted {
 	after element uml::Package deleted
 	call deleteCorrespondingRepositoryComponent(affectedEObject)
 }
-
 
 routine deleteCorrespondingRepositoryComponent(uml::Package umlComponentPkg) {
 	match {
@@ -167,7 +163,6 @@ routine deleteCorrespondingRepositoryComponent(uml::Package umlComponentPkg) {
 		delete pcmComponent
 	}
 }
-
 
 reaction RepositoryComponentPackageRenamed {
 	after attribute replaced at uml::Package[name]

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -43,7 +43,7 @@ reaction UmlMethodCreatedInDataType {
 routine createJavaMethod(uml::Classifier uClassifier, uml::Operation uOperation) {
     action {
         call {
-            if (uClassifier.name.equals(uOperation.name)) {
+            if (uClassifier.name.toFirstUpper == uOperation.name.toFirstUpper) {
                 createJavaConstructor(uClassifier, uOperation)
             } else if (uClassifier instanceof Class
                 || uClassifier instanceof DataType) {

--- a/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaContainerAndClassifierUtil.xtend
+++ b/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaContainerAndClassifierUtil.xtend
@@ -200,14 +200,15 @@ class JavaContainerAndClassifierUtil {
 
     /**
      * Finds and retrieves a specific {@link ConcreteClassifier} that is contained in a {@link Package}.
-     * @param name is the name of the desired {@link ConcreteClassifier}.
+     * The {@link ConcreteClassifier} is found by name, ignoring the capitalization of the first letter.
+     * @param name is the name of the desired {@link ConcreteClassifier}, the first letter can be upper and lower case.
      * @param javaPackage is the specific {@link Package} to search in.
      * @param classifierType specifies the class of the desired {@link ConcreteClassifier}, e.g. {@link Interface}.
      * @return the found classifier, or null if there is no matching classifer.
      * @throws IllegalStateException if there are multiple classifers in the package with a matching name.
      */
     public static def <T extends ConcreteClassifier> T findClassifier(String name, Package javaPackage, java.lang.Class<T> classifierType) {
-        val matchingClassifiers = javaPackage.compilationUnits.map[it.classifiers].flatten.filter(classifierType).filter[it.name == name]
+        val matchingClassifiers = javaPackage.compilationUnits.map[it.classifiers].flatten.filter(classifierType).filter[it.name.toFirstUpper == name.toFirstUpper]
         if (matchingClassifiers.size > 1) throw new IllegalStateException("Multiple matching classifers were found: " + matchingClassifiers)
         return matchingClassifiers.head
     }

--- a/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/uml/UmlClassifierAndPackageUtil.xtend
+++ b/bundles/util/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/uml/UmlClassifierAndPackageUtil.xtend
@@ -55,7 +55,7 @@ class UmlClassifierAndPackageUtil {
     }
 
     /**
-     * Searches and retrieves the UML interface located in a specific package of a UML model that has an equal name as the given package name.
+     * Searches and retrieves the UML interface located in a specific package of a UML model that has an equal name as the given package name (ignoring the capitalization of the first letter).
      * If there is more than one package with the given name an {@link IllegalStateException} is thrown.
      * @param umlModel the UML model Model in which the UML packages should be searched
      * @param interfaceName the interface name for which a fitting UML interface should be retrieved
@@ -67,7 +67,7 @@ class UmlClassifierAndPackageUtil {
     }
 
     /**
-     * Searches and retrieves the UML class located in a specific package of a UML model that has an equal name as the given package name.
+     * Searches and retrieves the UML class located in a specific package of a UML model that has an equal name as the given package name (ignoring the capitalization of the first letter).
      * If there is more than one package with the given name an {@link IllegalStateException} is thrown.
      * 
      * @param umlModel the UML model Model in which the UML packages should be searched
@@ -84,7 +84,7 @@ class UmlClassifierAndPackageUtil {
         if (uPackage === null) {
             return null
         }
-        val types = uPackage.ownedTypes.filter(type).filter[name == typeName].toSet
+        val types = uPackage.ownedTypes.filter(type).filter[name.toFirstUpper == typeName.toFirstUpper].toSet
         if (types.size > 1) {
             throw new IllegalStateException("There is more than one type with name " + typeName + " in the package " + uPackage)
         }


### PR DESCRIPTION
This pull request restores the consistent capitalization for repository components and classifiers in the fully transitive case between PCM, UML, and Java.

Even when an incorrectly capitalized name was propagated and then later corrected, it could result in problems depending on the execution order of the transformations. This led, amongst other problems, to duplicate element creation due to mismatching names.

This was fixed by enforcing the required capitalization in routines that assumed the capitalization of the source element was correct and therefore did not enforce any naming scheme. In a non-transitive scenario, these problems do not occur as the source element always conforms to the assumed naming schemes.