### PR TITLE
Fixed duplicate CompositeDataType creation

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -314,7 +314,19 @@ routine createCompositeDataTypeImplementation(pcm::CompositeDataType compositeDa
 			with datatypesPackage.name == "datatypes"
 	}
 	action {
-		call createOrFindJavaClass(compositeDataType, datatypesPackage, compositeDataType.entityName)
+		call createOrFindDataTypeClass(compositeDataType, datatypesPackage)
+	}
+}
+
+routine createOrFindDataTypeClass(pcm::NamedElement dataType, java::Package datatypesPackage) {
+	action {
+		call {
+			if (dataType.entityName == "aName") {
+				createOrFindJavaClass(dataType, datatypesPackage, null)
+			} else {
+				createOrFindJavaClass(dataType, datatypesPackage, dataType.entityName)
+			}
+		}
 	}
 }
 
@@ -368,7 +380,7 @@ routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType)
 				.choices(collectionDataTypeNames).windowModality(WindowModality.MODAL).startInteraction();
 			val Class<?> selectedClass = collectionDataTypes.get(selectedType);
 
-			createOrFindJavaClass(dataType, datatypesPackage, dataType.entityName);
+			createOrFindDataTypeClass(dataType, datatypesPackage)
 			addSuperTypeToDataType(dataType, innerTypeClassOrWrapper, selectedClass.name);
 		}
 	}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -135,9 +135,9 @@ reaction CreatedSystem {
 }
 
 routine addSystemCorrespondence(pcm::System pcmSystem) {
-    action { // required to enable find-or-create-pattern:
-        add correspondence between pcmSystem and SystemPackage.Literals.SYSTEM
-    }
+	action { // required to enable find-or-create-pattern:
+		add correspondence between pcmSystem and SystemPackage.Literals.SYSTEM
+	}
 }
 
 routine createImplementationForSystem(pcm::System system) {
@@ -250,7 +250,7 @@ reaction RenameComponent {
 routine renameComponentPackageAndClass(pcm::RepositoryComponent component) {
 	match {
 		val repositoryPackage = retrieve java::Package corresponding to component.repository__RepositoryComponent
-			with repositoryPackage.name.equals(component.repository__RepositoryComponent.entityName)
+			with repositoryPackage.name == component.repository__RepositoryComponent.entityName
 	}
 	action {
 		call {
@@ -880,7 +880,7 @@ routine removeParameterToFieldAssignmentFromConstructor(java::Constructor ctor, 
 							if (fieldReference instanceof IdentifierReference) {
 								val field = fieldReference.target;
 								if (field instanceof Field) {
-									if (field.name.equals(fieldName)) {
+									if (field.name == fieldName) {
 										ctor.statements -= statement;
 										return;
 									}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -15,6 +15,7 @@ import org.palladiosimulator.pcm.core.entity.Entity
 import static tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimNotMany
 
 import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
@@ -519,14 +520,12 @@ routine createOrFindCompositeDataType(java::Class javaClass, java::CompilationUn
 	}
 	action {
 		call {
-			val foundCompositeDataTypes = pcmRepository.dataTypes__Repository.filter(CompositeDataType)
-				.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"]
-			if (foundCompositeDataTypes.empty) {
+			val foundCompositeDataType = pcmRepository.dataTypes__Repository.filter(CompositeDataType)
+				.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"].claimNotMany
+			if (foundCompositeDataType === null) {
 				createCompositeDataType(javaClass, compilationUnit)
-			} else if (foundCompositeDataTypes.size == 1) {
-				addDataTypeCorrespondence(javaClass, compilationUnit, foundCompositeDataTypes.head)
 			} else {
-				throw new IllegalStateException("Multiple composite data types found: " + foundCompositeDataTypes)
+				addDataTypeCorrespondence(javaClass, compilationUnit, foundCompositeDataType)
 			}
 		}
 	}
@@ -551,14 +550,12 @@ routine createOrFindCollectionDataType(java::Class javaClass, java::CompilationU
 	}
 	action {
 		call {
-			val foundCollectionDataTypes = pcmRepository.dataTypes__Repository.filter(CollectionDataType)
-				.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"]
-			if (foundCollectionDataTypes.empty) {
+			val foundCollectionDataType = pcmRepository.dataTypes__Repository.filter(CollectionDataType)
+				.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"].claimNotMany
+			if (foundCollectionDataType === null) {
 				createCollectionDataType(javaClass, compilationUnit)
-			} else if (foundCollectionDataTypes.size == 1) {
-				addDataTypeCorrespondence(javaClass, compilationUnit, foundCollectionDataTypes.head)
 			} else {
-				throw new IllegalStateException("Multiple collection data types found: " + foundCollectionDataTypes)
+				addDataTypeCorrespondence(javaClass, compilationUnit, foundCollectionDataType)
 			}
 		}
 	}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -8,6 +8,9 @@ import org.palladiosimulator.pcm.repository.RepositoryPackage
 import org.palladiosimulator.pcm.system.SystemPackage
 import tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.Java2PcmUserSelection
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
+import org.palladiosimulator.pcm.repository.CompositeDataType
+import org.palladiosimulator.pcm.repository.CollectionDataType
+import org.palladiosimulator.pcm.core.entity.Entity
 
 import static tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
@@ -98,7 +101,7 @@ routine createArchitecturalElement(java::Package javaPackage, String name, Strin
 				Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
 			]
 			val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-			   .windowModality(WindowModality.MODAL).startInteraction()
+				.windowModality(WindowModality.MODAL).startInteraction()
 			switch(selected) {
 				case Java2PcmUserSelection.SELECT_BASIC_COMPONENT.selection: 
 					createBasicComponent(javaPackage, name, rootPackageName) 
@@ -132,7 +135,7 @@ routine createOrFindRepository(java::Package javaPackage, String packageName, St
 
 routine ensureFirstCaseUpperCaseRepositoryNaming(pcm::Repository pcmRepository, java::Package javaPackage) {
 	match {
-	   check pcmRepository.entityName == javaPackage.name
+		check pcmRepository.entityName == javaPackage.name
 	}
 	action {
 		update pcmRepository {
@@ -181,9 +184,9 @@ routine createOrFindSystem(java::Package javaPackage, String name) {
 	action {
 		call {
 			if (foundSystem.isPresent) {
-			   addSystemCorrespondence(foundSystem.get, javaPackage)
+				addSystemCorrespondence(foundSystem.get, javaPackage)
 			} else {
-			   createSystem(javaPackage, name)
+				createSystem(javaPackage, name)
 			}
 		}
 	}
@@ -392,7 +395,10 @@ routine updateRepositoryInterfaces(pcm::OperationInterface pcmInterface) {
 //Class
 reaction JavaClassRenamed {
 	after attribute replaced at java::Class[name]
-	call renameComponentFromClass(affectedEObject)
+	call {
+		renameComponentFromClass(affectedEObject)
+		renameDataTypeFromClass(affectedEObject)
+	}
 }
 
 routine renameComponentFromClass(java::Class javaClass) {
@@ -404,6 +410,19 @@ routine renameComponentFromClass(java::Class javaClass) {
 			var newName = javaClass.name.toFirstUpper
 			if (newName.endsWith("Impl")) newName = newName.substring(0, newName.length - "Impl".length)
 			pcmComponent.entityName = newName
+		}
+	}
+}
+
+routine renameDataTypeFromClass(java::Class javaClass) {
+	match {
+		val dataType = retrieve pcm::DataType corresponding to javaClass
+	}
+	action {
+		update dataType {
+			if(dataType instanceof Entity) { // primitive data types don't have names
+				dataType.entityName = javaClass.name.toFirstUpper
+			}
 		}
 	}
 }
@@ -446,7 +465,7 @@ routine createDataType(java::Class javaClass, java::CompilationUnit compilationU
 	action {
 		call {
 			val String userMsg = "Class " + javaClass.name +
-						"has been created in the datatypes pacakage. Please decide which kind of data type should be created."
+						" has been created in the datatypes package. Please decide which kind of data type should be created."
 			val String[] selections = #[Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.message,
 				Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.message,
 				Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
@@ -455,9 +474,9 @@ routine createDataType(java::Class javaClass, java::CompilationUnit compilationU
 				.windowModality(WindowModality.MODAL).startInteraction()
 			switch(selected) {
 				case Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.selection: 
-					createCompositeDataType(javaClass, compilationUnit)
+					createOrFindCompositeDataType(javaClass, compilationUnit)
 				case Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.selection: 
-					createCollectionDataType(javaClass, compilationUnit)
+					createOrFindCollectionDataType(javaClass, compilationUnit)
 			}
 		}
 	}
@@ -494,32 +513,73 @@ routine checkSystemAndComponent(java::Package javaPackage, java::Class javaClass
 	}
 }
 
+routine createOrFindCompositeDataType(java::Class javaClass, java::CompilationUnit compilationUnit) {
+	match {
+		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
+	}
+	action {
+		call {
+			val foundCompositeDataTypes = pcmRepository.dataTypes__Repository.filter(CompositeDataType)
+				.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"]
+			if (foundCompositeDataTypes.empty) {
+				createCompositeDataType(javaClass, compilationUnit)
+			} else if (foundCompositeDataTypes.size == 1) {
+				addDataTypeCorrespondence(javaClass, compilationUnit, foundCompositeDataTypes.head)
+			} else {
+				throw new IllegalStateException("Multiple composite data types found: " + foundCompositeDataTypes)
+			}
+		}
+	}
+}
+
 routine createCompositeDataType(java::Class javaClass, java::CompilationUnit compilationUnit) {
 	action {
 		val pcmCompositeDataType = create pcm::CompositeDataType and initialize {
 			pcmCompositeDataType.entityName = javaClass.name
 		}
-		
 		add correspondence between pcmCompositeDataType and javaClass
-		add correspondence between compilationUnit and javaClass
-		
 		call {
+			addDataTypeCorrespondence(javaClass, compilationUnit, pcmCompositeDataType)
 			addDataTypeInRepository(pcmCompositeDataType)
 		}
 	}
 }
+
+routine createOrFindCollectionDataType(java::Class javaClass, java::CompilationUnit compilationUnit) {
+	match {
+		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
+	}
+	action {
+		call {
+			val foundCollectionDataTypes = pcmRepository.dataTypes__Repository.filter(CollectionDataType)
+				.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"]
+			if (foundCollectionDataTypes.empty) {
+				createCollectionDataType(javaClass, compilationUnit)
+			} else if (foundCollectionDataTypes.size == 1) {
+				addDataTypeCorrespondence(javaClass, compilationUnit, foundCollectionDataTypes.head)
+			} else {
+				throw new IllegalStateException("Multiple collection data types found: " + foundCollectionDataTypes)
+			}
+		}
+	}
+}
+
 routine createCollectionDataType(java::Class javaClass, java::CompilationUnit compilationUnit) {
 	action {
 		val pcmCollectionDataType = create pcm::CollectionDataType and initialize {
 			pcmCollectionDataType.entityName = javaClass.name
 		}
-		
-		add correspondence between pcmCollectionDataType and javaClass
-		add correspondence between compilationUnit and javaClass
-		
 		call {
+			addDataTypeCorrespondence(javaClass, compilationUnit, pcmCollectionDataType)
 			addDataTypeInRepository(pcmCollectionDataType)
 		}
+	}
+}
+
+routine addDataTypeCorrespondence(java::Class javaClass, java::CompilationUnit compilationUnit, pcm::DataType dataType) {
+	action {
+		add correspondence between dataType and javaClass
+		add correspondence between compilationUnit and javaClass
 	}
 }
 

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlCompositeDataTypeClass.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlCompositeDataTypeClass.reactions
@@ -45,20 +45,18 @@ routine insertCorrespondingCompositeDataType(uml::Class umlClass, uml::Package u
 routine detectOrCreateCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
 	match{
 		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
-		val pcmCompositeType = retrieve optional pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	action {
 		call {
-			if (!pcmCompositeType.isPresent) {
-				val candidates = pcmRepository.dataTypes__Repository.filter(CompositeDataType).filter[type | type.entityName == umlClass.name]
-				switch (candidates.size) {
-					case 0: createCorrespondingCompositeDataType(umlClass, umlPackage)
-					case 1: addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
-					default: {
-						logger.warn(DefaultLiterals.WARNING_MULTIPLE_COMPOSITE_DATA_TYPE_CANDIDATES + umlClass)
-						addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
-					}
-				}				
+			val candidates = pcmRepository.dataTypes__Repository.filter(CompositeDataType).filter[type | type.entityName == umlClass.name]
+			switch (candidates.size) {
+				case 0: createCorrespondingCompositeDataType(umlClass, umlPackage)
+				case 1: addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
+				default: {
+					logger.warn(DefaultLiterals.WARNING_MULTIPLE_COMPOSITE_DATA_TYPE_CANDIDATES + umlClass)
+					addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
+				}
 			}
 		}
 	}

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -562,7 +562,7 @@ routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
             persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
         }
         call {
-            if (!uPackage.name.equals(jPackage.name)) {
+            if (uPackage.name != jPackage.name) {
                 for (compUnit : jPackage.compilationUnits) {
                     changePackageOfJavaCompilationUnit(jPackage, compUnit, uNamespace)
                 }


### PR DESCRIPTION
I fixed duplicate CompositeDataType creation by implementing the find-or-create-pattern in the Java-to-PCM reactions. This was done for both composite and collection data types. I also implemented a rename routine that renames PCM composite and collection data types when Java classes are renamed. This renaming is not a functionality that is required by the Java-to-PCM test cases, but it missing could lead to problems later on. This pull request also includes some smaller syntactical fixes.