### PR TITLE
Fixed the duplicate creation of the assembly context concept elements

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -7,9 +7,12 @@ import java.util.Set
 import java.util.Stack
 import java.util.Vector
 import org.eclipse.emf.ecore.util.EcoreUtil
+import org.emftext.language.java.classifiers.Interface
+import org.emftext.language.java.containers.ContainersPackage
 import org.emftext.language.java.expressions.AssignmentExpression
 import org.emftext.language.java.generics.GenericsFactory
 import org.emftext.language.java.imports.ClassifierImport
+import org.emftext.language.java.instantiations.NewConstructorCall
 import org.emftext.language.java.members.Constructor
 import org.emftext.language.java.members.Field
 import org.emftext.language.java.modifiers.ModifiersFactory
@@ -31,11 +34,11 @@ import org.palladiosimulator.pcm.repository.RepositoryPackage
 import org.palladiosimulator.pcm.system.SystemPackage
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
+import static tools.vitruv.applications.pcmjava.util.pcm2java.Pcm2JavaHelper.*
+import static tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 
-import static extension tools.vitruv.applications.pcmjava.util.pcm2java.Pcm2JavaHelper.*
-import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
 
 import "http://www.emftext.org/java" as java
@@ -177,35 +180,135 @@ routine changeSystemImplementationName(pcm::System system) {
 
 reaction AddedAssemblyContextToComposedStructure {
 	after element pcm::AssemblyContext created and inserted in pcm::ComposedStructure[assemblyContexts__ComposedStructure]
-	call addAssemblyContextToComposedStructure(affectedEObject, newValue)
+	call {
+		createOrFindAssemblyContextField(newValue, affectedEObject)
+		createOrFindAssemblyContextConstructor(newValue, affectedEObject)
+		createOrFindAssemblyContextImport(newValue, affectedEObject)
+	}
 }
 
-// TODO HK This is ugly...
-routine addAssemblyContextToComposedStructure(pcm::ComposedStructure composedStructure, pcm::AssemblyContext assemblyContext) {
+routine createOrFindAssemblyContextField(pcm::AssemblyContext assemblyContext, pcm::ComposedStructure composedStructure) {
+	 match {
+		 val compositeComponentJavaClass = retrieve java::Class corresponding to composedStructure
+		 val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
+		 require absence of java::Field corresponding to assemblyContext
+	 }
+	 action {
+		call {
+			val foundField = compositeComponentJavaClass.members.filter(Field).findFirst[name == assemblyContext.entityName]
+			if (foundField === null) {
+				createAssemblyContextField(assemblyContext, compositeComponentJavaClass, encapsulatedComponentJavaClass)
+			} else {
+				addAssemblyContextFieldCorrespondence(assemblyContext, foundField)
+			}
+		}
+	 }
+}
+
+routine createAssemblyContextField(pcm::AssemblyContext assemblyContext, java::Class compositeComponentJavaClass, java::Class encapsulatedComponentJavaClass) {
+	action {
+		val assemblyContextField = create java::Field and initialize {
+			createPrivateField(assemblyContextField, createNamespaceClassifierReference(encapsulatedComponentJavaClass), assemblyContext.entityName)
+			compositeComponentJavaClass.members += assemblyContextField
+		}
+		add correspondence between assemblyContextField and assemblyContext
+	}
+}
+
+routine addAssemblyContextFieldCorrespondence(pcm::AssemblyContext assemblyContext, java::Field javaField) {
+	action {
+		add correspondence between javaField and assemblyContext
+	}
+}
+
+routine createOrFindAssemblyContextConstructor(pcm::AssemblyContext assemblyContext, pcm::ComposedStructure composedStructure) {
 	match {
 		val compositeComponentJavaClass = retrieve java::Class corresponding to composedStructure
 		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
+		require absence of java::Constructor corresponding to assemblyContext
 	}
 	action {
-		val assemblyContextField = create java::Field and initialize {
-			val TypeReference typeRef = createNamespaceClassifierReference(encapsulatedComponentJavaClass);
-			createPrivateField(assemblyContextField, typeRef, assemblyContext.entityName);
+		call {
+			val foundConstructor = compositeComponentJavaClass.members.filter(Constructor).findFirst[name == compositeComponentJavaClass.name]
+			if (foundConstructor === null) {
+				createAssemblyContextConstructor(assemblyContext, compositeComponentJavaClass)
+			} else {
+				val foundCall = foundConstructor.statements.filter(ExpressionStatement).map[expression].filter(AssignmentExpression).map[value].filter(NewConstructorCall).head
+				if (foundCall === null) {
+					createAssemblyContextStatement(assemblyContext, foundConstructor, compositeComponentJavaClass)
+				} else{
+					addAssemblyContextConstructorCorrespondence(assemblyContext, foundConstructor, foundCall)
+				}
+			}
 		}
-		val newConstructorCall = create java::NewConstructorCall
-		val contextClassImport = create java::ClassifierImport
+	}
+}
+
+routine createAssemblyContextConstructor(pcm::AssemblyContext assemblyContext, java::Class compositeComponentJavaClass) {
+	match {
+		val assemblyContextField = retrieve java::Field corresponding to assemblyContext
+	}
+	action {
 		val constructor = create java::Constructor
-		update compositeComponentJavaClass {
-			compositeComponentJavaClass.members += assemblyContextField;
-			addConstructorToClass(constructor, compositeComponentJavaClass);
-			addImportToCompilationUnitOfClassifier(contextClassImport, compositeComponentJavaClass, encapsulatedComponentJavaClass);
+		call {
+			createAssemblyContextStatement(assemblyContext, constructor, compositeComponentJavaClass)
+			addConstructorToClass(constructor, compositeComponentJavaClass)
 		}
+	}
+}
+
+routine createAssemblyContextStatement(pcm::AssemblyContext assemblyContext, java::Constructor constructor, java::Class compositeComponentJavaClass) {
+	match {
+		val assemblyContextField = retrieve java::Field corresponding to assemblyContext
+	}
+	action {
+		val newConstructorCall = create java::NewConstructorCall
 		update constructor {
-			createNewForFieldInConstructor(newConstructorCall, constructor, assemblyContextField);
+			createNewForFieldInConstructor(newConstructorCall, constructor, assemblyContextField)
 		}
-		add correspondence between assemblyContextField and assemblyContext
 		add correspondence between newConstructorCall and assemblyContext
-		add correspondence between contextClassImport and assemblyContext
 		add correspondence between constructor and assemblyContext
+	}
+}
+
+routine addAssemblyContextConstructorCorrespondence(pcm::AssemblyContext assemblyContext, java::Constructor constructor, java::NewConstructorCall constructorCall) {
+	action {
+		add correspondence between constructorCall and assemblyContext
+		add correspondence between constructor and assemblyContext
+	}
+}
+
+routine createOrFindAssemblyContextImport(pcm::AssemblyContext assemblyContext, pcm::ComposedStructure composedStructure) {
+	match {
+		val compositeComponentJavaClass = retrieve java::Class corresponding to composedStructure
+		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
+		require absence of java::ClassifierImport corresponding to assemblyContext
+	}
+	action {
+		call {
+			val foundImport = compositeComponentJavaClass.containingCompilationUnit.imports.filter(ClassifierImport).findFirst[it.classifier == encapsulatedComponentJavaClass]
+			if(foundImport === null) {
+				createAssemblyContextImport(assemblyContext, compositeComponentJavaClass, encapsulatedComponentJavaClass)
+			} else {
+				addAssemblyContextImportCorrespondence(assemblyContext, foundImport)
+			}
+		}
+	}
+}
+
+routine createAssemblyContextImport(pcm::AssemblyContext assemblyContext, java::Class compositeComponentJavaClass, java::Class encapsulatedComponentJavaClass) {
+	action {
+		val contextClassImport = create java::ClassifierImport and initialize {
+			addImportToCompilationUnitOfClassifier(contextClassImport, compositeComponentJavaClass, encapsulatedComponentJavaClass)
+		}
+		add correspondence between contextClassImport and assemblyContext
+	}
+}
+
+
+routine addAssemblyContextImportCorrespondence(pcm::AssemblyContext assemblyContext, java::ClassifierImport contextClassImport) {
+	action {
+		add correspondence between contextClassImport and assemblyContext
 	}
 }
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations.pcm2java/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
@@ -57,7 +57,7 @@ reaction pcm2javaCommon::AddedAssemblyContextToComposedStructure {
 	call addAssemblyContextToComposedStructure(affectedEObject, newValue)
 }
 
-routine pcm2javaCommon::addAssemblyContextToComposedStructure(pcm::ComposedStructure composedStructure, pcm::AssemblyContext assemblyContext) {
+routine addAssemblyContextToComposedStructure(pcm::ComposedStructure composedStructure, pcm::AssemblyContext assemblyContext) {
 	match {
 		val compositeComponentJavaClass = retrieve java::Class corresponding to composedStructure
 		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.java2pcm/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
@@ -112,7 +112,7 @@ reaction FieldCreated {
 		val type = getNormalizedClassifierFromTypeReference(newValue.typeReference)
 		fieldCreatedCorrespondingToOperationInterface(type, newValue)
 		fieldCreatedCorrespondingToRepositoryComponent(type, newValue)
-		createAssemblyContext(newValue.containingConcreteClassifier, newValue)
+		createOrFindAssemblyContext(newValue.containingConcreteClassifier, newValue)
 	}
 }
 
@@ -132,6 +132,24 @@ routine createInnerDeclaration(java::ConcreteClassifier classifier, java::Field 
 	}
 }
 
+routine createOrFindAssemblyContext(java::ConcreteClassifier classifier, java::Field javaField) {
+    match {
+        val composedProvidingRequiringEntity = retrieve pcm::ComposedProvidingRequiringEntity corresponding to classifier
+        val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to getClassifierFromTypeReference(javaField.typeReference)
+        require absence of pcm::AssemblyContext corresponding to javaField
+    }
+    action {
+        call {
+            val pcmAssemblyContextCandidate = composedProvidingRequiringEntity.assemblyContexts__ComposedStructure.findFirst[entityName === javaField.name]
+            if (pcmAssemblyContextCandidate === null) {
+                createAssemblyContext(classifier, javaField)
+            } else {
+                addAssemblyContextCorrespondence(pcmAssemblyContextCandidate, javaField)
+            }
+        }
+    }
+}
+
 routine createAssemblyContext(java::ConcreteClassifier classifier, java::Field javaField) {
 	match {
 		val composedProvidingRequiringEntity = retrieve pcm::ComposedProvidingRequiringEntity corresponding to classifier
@@ -145,6 +163,12 @@ routine createAssemblyContext(java::ConcreteClassifier classifier, java::Field j
 		}
 		add correspondence between assemblyContext and javaField
 	}
+}
+
+routine addAssemblyContextCorrespondence(pcm::AssemblyContext assemblyContext, java::Field javaField) {
+    action {
+        add correspondence between assemblyContext and javaField
+    }
 }
 
 routine fieldCreatedCorrespondingToOperationInterface(java::Classifier classifier, java::Field javaField) {

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmAssemblyContext.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmAssemblyContext.reactions
@@ -34,19 +34,17 @@ routine insertCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 routine detectOrCreateCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
 		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlProperty = retrieve optional uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		require absence of uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 		val umlComponentImplementation = retrieve optional uml::Class 
 			corresponding to pcmAssembly.encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
 	action{
 		call {
-			if (!umlProperty.isPresent) {
-				val Property umlPropertyCandidate = umlCompositeImplementation.ownedAttributes.findFirst[it.type == umlComponentImplementation]
-				if (umlPropertyCandidate !== null) {
-					addCorrespondenceForExistingAssemblyContextProperty(pcmAssembly, umlPropertyCandidate)
-				} else {
-					createCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
-				}
+			val Property umlPropertyCandidate = umlCompositeImplementation.ownedAttributes.findFirst[name == pcmAssembly.entityName]
+			if (umlPropertyCandidate === null) {
+				createCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
+			} else {
+				addCorrespondenceForExistingAssemblyContextProperty(pcmAssembly, umlPropertyCandidate)
 			}
 		}
 	}

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlAssemblyContextProperty.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlAssemblyContextProperty.reactions
@@ -34,8 +34,7 @@ routine insertCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 	}
 	action {
 		call {
-			if (pcmCompositeComponent.isPresent 
-				&& (pcmInnerComponent.isPresent || umlProperty.type === null) // allow 'null' for uninitialized references
+			if (pcmCompositeComponent.isPresent && (pcmInnerComponent.isPresent || umlProperty.type === null) // allow 'null' for uninitialized references
 			) {
 				detectOrCreateCorrespondingAssemblyContext(umlProperty, umlComponent)
 				moveCorrespondingAssemblyContext(umlProperty, umlComponent)
@@ -51,18 +50,15 @@ routine detectOrCreateCorrespondingAssemblyContext(uml::Property umlProperty, um
 	match {
 		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.type tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmAssemblyContext = retrieve optional pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
 	action {
 		call {
-			if (!pcmAssemblyContext.isPresent) {
-				val pcmAssemblyContextCandidate = pcmCompositeComponent.assemblyContexts__ComposedStructure
-						.findFirst[it.encapsulatedComponent__AssemblyContext === pcmInnerComponent]
-				if (pcmAssemblyContextCandidate !== null) {
-					addCorrespondenceForExistingAssemblyContext(umlProperty, pcmAssemblyContextCandidate)
-				} else {
-					createCorrespondingAssemblyContext(umlProperty, umlComponent)
-				}
+			val pcmAssemblyContextCandidate = pcmCompositeComponent.assemblyContexts__ComposedStructure.findFirst[entityName == umlProperty.name]
+			if (pcmAssemblyContextCandidate === null) {
+				createCorrespondingAssemblyContext(umlProperty, umlComponent)
+			} else {
+				addCorrespondenceForExistingAssemblyContext(umlProperty, pcmAssemblyContextCandidate)
 			}
 		}
 	}

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
@@ -1,4 +1,5 @@
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimNotMany
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -11,12 +12,54 @@ import routines javaToUmlTypePropagation using qualified names
 
 reaction JavaAttributeCreatedInClass {
     after element java::Field created and inserted in java::Class[members]
-    call createUmlAttributeInClass(affectedEObject, newValue)
+    call createOrFindUmlAttributeInClass(affectedEObject, newValue)
 }
 
 reaction JavaAttributeCreatedInEnum {
     after element java::Field created and inserted in java::Enumeration[members]
-    call createUmlAttributeInEnum(affectedEObject, newValue)
+    call createOrFindUmlAttributeInEnum(affectedEObject, newValue)
+}
+
+routine addAttributeCorrespondence(uml::Property umlAttribute, java::Field javaField) {
+     action {
+         add correspondence between umlAttribute and javaField
+     }
+}
+
+//UML-Enumeration and UML-Class don't have a common superclass for "having ownedAttributes".
+//Therefore we implemented two separate routines
+routine createOrFindUmlAttributeInEnum(java::Enumeration javaEnum, java::Field javaField) {
+    match {
+        val umlEnum = retrieve uml::Enumeration corresponding to javaEnum
+        require absence of uml::Property corresponding to javaField
+    }
+    action {
+        call {
+            val foundAttribute = umlEnum.ownedAttributes.filter[name == javaField.name].claimNotMany
+            if (foundAttribute === null) {
+                createUmlAttributeInEnum(javaEnum, javaField)
+            } else {
+                addAttributeCorrespondence(foundAttribute, javaField)
+            }
+        }
+    }
+}
+
+routine createOrFindUmlAttributeInClass(java::Class javaClass, java::Field javaField) {
+    match {
+        val umlClass = retrieve uml::Class corresponding to javaClass
+        require absence of uml::Property corresponding to javaField
+    }
+    action {
+        call {
+            val foundAttribute = umlClass.ownedAttributes.filter[name == javaField.name].claimNotMany
+            if (foundAttribute === null) {
+                createUmlAttributeInClass(javaClass, javaField)
+            } else {
+                addAttributeCorrespondence(foundAttribute, javaField)
+            }
+        }
+    }
 }
 
 //UML-Enumeration and UML-Class don't have a common superclass for "having ownedAttributes".

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -5,6 +5,7 @@ import org.emftext.language.java.containers.CompilationUnit
 import org.emftext.language.java.modifiers.Private
 import org.emftext.language.java.modifiers.Protected
 import org.emftext.language.java.modifiers.Public
+import org.eclipse.uml2.uml.OperationOwner
 
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
 import static tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
@@ -25,58 +26,63 @@ import routines javaToUmlTypePropagation using qualified names
 reaction JavaClassMethodCreated {
     after element java::ClassMethod created and inserted in java::ConcreteClassifier[members]
     with (affectedEObject instanceof Class)
-    	|| (affectedEObject instanceof Enumeration)
-    call createUmlClassMethod(newValue, affectedEObject)
+        || (affectedEObject instanceof Enumeration)
+    call createOrFindUmlClassMethod(newValue, affectedEObject)
 }
 
-routine createUmlClassMethod(java::ClassMethod jMeth, java::ConcreteClassifier jClassifier) {
-    match {
+routine createOrFindUmlClassMethod(java::ClassMethod jMethod, java::ConcreteClassifier jClassifier) {
+     match {
         val uClassifier = retrieve uml::Classifier corresponding to jClassifier
-		require absence of uml::Operation corresponding to jMeth
+            with uClassifier instanceof OperationOwner
+        require absence of uml::Operation corresponding to jMethod
     }
     action {
-        val uOperation = create uml::Operation and initialize {
-            uOperation.name = jMeth.name;
-        }
-        add correspondence between uOperation and jMeth
         call {
-            if (uClassifier instanceof org.eclipse.uml2.uml.Class) {
-                addUmlOperationToClass(uClassifier, uOperation)
-            } else if (uClassifier instanceof org.eclipse.uml2.uml.Enumeration) {
-                addUmlOperationToEnum(uClassifier, uOperation)
+            val foundMethod = (uClassifier as OperationOwner).ownedOperations.findFirst[name == jMethod.name]
+            if (foundMethod === null) {
+                createUmlClassMethod(jMethod, uClassifier)
             } else {
-                logger.warn("Can not add ClassMethod to " + uClassifier)
+                addUmlMethodCorrespondence(foundMethod, jMethod)
             }
         }
     }
 }
 
-routine addUmlOperationToClass(uml::Class uClass, uml::Operation uOperation) {
+routine createUmlClassMethod(java::ClassMethod jMethod, uml::Classifier uClassifier) {
     action {
-        update uClass {
-            uClass.ownedOperations += uOperation
+        val uOperation = create uml::Operation and initialize {
+            uOperation.name = jMethod.name;
         }
-    }
-}
-//separate routines because Enum and Class don't have a common super class for "having ownedOperations"
-routine addUmlOperationToEnum(uml::Enumeration uEnum, uml::Operation uOperation) {
-    action {
-        update uEnum {
-            uEnum.ownedOperations += uOperation
+        add correspondence between uOperation and jMethod
+        update uClassifier {
+            (uClassifier as OperationOwner).ownedOperations += uOperation
         }
     }
 }
 
 reaction JavaInterfaceMethodCreated {
     after element java::InterfaceMethod created and inserted in java::Interface[members]
-    call createUmlInterfaceMethod(newValue, affectedEObject)
+    call createOrFindUmlInterfaceMethod(newValue, affectedEObject)
 }
 
-routine createUmlInterfaceMethod(java::InterfaceMethod jMeth, java::Interface jInterface) {
-    match {
+routine createOrFindUmlInterfaceMethod(java::InterfaceMethod jMethod, java::Interface jInterface) {
+     match {
         val uInterface = retrieve uml::Interface corresponding to jInterface
-		require absence of uml::Operation corresponding to jMeth
+        require absence of uml::Operation corresponding to jMethod
     }
+    action {
+        call {
+            val foundMethod = uInterface.ownedOperations.findFirst[name == jMethod.name]
+            if (foundMethod === null) {
+                createUmlInterfaceMethod(jMethod, uInterface)
+            } else {
+                addUmlMethodCorrespondence(foundMethod, jMethod)
+            }
+        }
+    }
+}
+
+routine createUmlInterfaceMethod(java::InterfaceMethod jMeth, uml::Interface uInterface) {
     action {
         val uOperation = create uml::Operation and initialize {
             uOperation.name = jMeth.name;
@@ -89,16 +95,36 @@ routine createUmlInterfaceMethod(java::InterfaceMethod jMeth, java::Interface jI
     }
 }
 
-reaction JavaConstructorCreated {
-    after element java::Constructor created and inserted in java::ConcreteClassifier[members]
-    call createUmlConstructor(newValue, affectedEObject)
+// Shared between interface methods, class methods and constructors:
+routine addUmlMethodCorrespondence(uml::Operation uOperation, java::Member jMethodOrConstructor) {
+    action {
+        add correspondence between uOperation and jMethodOrConstructor
+    }
 }
 
-routine createUmlConstructor(java::Constructor jConstructor, java::ConcreteClassifier jClassifier) {
-    match {
+reaction JavaConstructorCreated {
+    after element java::Constructor created and inserted in java::ConcreteClassifier[members]
+    call createOrFindUmlConstructor(newValue, affectedEObject)
+}
+
+routine createOrFindUmlConstructor(java::Constructor jConstructor, java::ConcreteClassifier jClassifier) {
+     match {
         val uClassifier = retrieve uml::Class corresponding to jClassifier
-		require absence of uml::Operation corresponding to jConstructor
+        require absence of uml::Operation corresponding to jConstructor
     }
+    action {
+        call {
+            val foundConstructor = uClassifier.ownedOperations.findFirst[name == jConstructor.name]
+            if (foundConstructor === null) {
+                createUmlConstructor(jConstructor, uClassifier)
+            } else {
+                addUmlMethodCorrespondence(foundConstructor, jConstructor)
+            }
+        }
+    }
+}
+
+routine createUmlConstructor(java::Constructor jConstructor, uml::Class uClassifier) {
     action {
         val uConstructor = create uml::Operation and initialize {
             uConstructor.name = jConstructor.name
@@ -201,7 +227,7 @@ reaction JavaParameterCreated {
 routine createUmlParameter(java::Parametrizable jMeth, java::OrdinaryParameter jParam) {
     match {
         val uOperation = retrieve uml::Operation corresponding to jMeth
-		require absence of uml::Parameter corresponding to jParam
+        require absence of uml::Parameter corresponding to jParam
     }
     action {
         val uParam = create uml::Parameter and initialize {
@@ -252,15 +278,15 @@ routine changeUmlReturnType(java::Method jMeth, java::TypeReference jType) {
         val uOperation = retrieve uml::Operation corresponding to jMeth
     }
     action {
-		execute {
-			var uParam = uOperation.getReturnResult
-			if (uParam === null){
-				// create a new return parameter
-				uParam = uOperation.createOwnedParameter("returnParameter", null)
-				uParam.direction = ParameterDirectionKind.RETURN_LITERAL
-			}
-        	javaToUmlTypePropagation.propagateMethodReturnTypeChange(jMeth, uParam)
-		}
+        execute {
+            var uParam = uOperation.getReturnResult
+            if (uParam === null){
+                // create a new return parameter
+                uParam = uOperation.createOwnedParameter("returnParameter", null)
+                uParam.direction = ParameterDirectionKind.RETURN_LITERAL
+            }
+            javaToUmlTypePropagation.propagateMethodReturnTypeChange(jMeth, uParam)
+        }
     }
 }
 
@@ -288,7 +314,7 @@ routine changeUmlNamedElementVisibility(java::AnnotableAndModifiable jElem, java
     }
     action {
         update uElem {
-        	uElem.visibility = getUMLVisibilityKindFromJavaModifier(mod);
+            uElem.visibility = getUMLVisibilityKindFromJavaModifier(mod);
         }
     }
 }
@@ -321,11 +347,11 @@ routine renameUmlNamedElementCorrespondingToCompilationUnit(java::CompilationUni
     }
     action {
         update uElement {
-        	var propagatedName = jElement.name
-        	if(!jElement.namespaces.empty) { // trim off the namespace in case the name is loaded fully classified
+            var propagatedName = jElement.name
+            if(!jElement.namespaces.empty) { // trim off the namespace in case the name is loaded fully classified
                 var namespacePrefix = jElement.namespaces.join("\\.") + "\\." // escaping avoids eating any char with "." regex
                 propagatedName = propagatedName.replaceFirst(namespacePrefix, "")
-        	}
+            }
             if(propagatedName.endsWith(".java")) { // trim off file extension if it exists 
                 propagatedName = propagatedName.replaceFirst("\\.java", "") // escaping avoids eating any char with "." regex
             }

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
@@ -1,10 +1,12 @@
 import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.Property
+import org.emftext.language.java.members.Field
 
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimNotMany
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -18,7 +20,7 @@ import routines umlToJavaTypePropagation using qualified names
 reaction UmlAttributeCreatedInClass {
     after element uml::Property created and inserted in uml::Class[ownedAttribute]
     call {
-        createJavaAttribute(affectedEObject, newValue)
+        createOrFindJavaAttribute(affectedEObject, newValue)
     }
 }
 
@@ -27,8 +29,33 @@ reaction UmlAttributeCreatedInClass {
 reaction UmlAttributeCreatedInDataType {//Enum is a DataType
     after element uml::Property created and inserted in uml::DataType[ownedAttribute]
     call {
-        createJavaAttribute(affectedEObject, newValue)
+        createOrFindJavaAttribute(affectedEObject, newValue)
     }
+}
+
+routine createOrFindJavaAttribute(uml::Classifier uClassifier, uml::Property umlAttribute) {
+    match {
+        val jClassifier = retrieve java::ConcreteClassifier corresponding to uClassifier
+        require absence of java::Field corresponding to umlAttribute
+    }
+    action {
+        call {
+            val foundField = jClassifier.members.filter(Field).filter[name == umlAttribute.name].claimNotMany
+            if (foundField === null) {
+                createJavaAttribute(uClassifier, umlAttribute) 
+            } else {
+                addAttributeCorrespondence(umlAttribute, foundField)
+                createJavaGetter(foundField)
+                createJavaSetter(foundField)
+            }
+        }
+    }
+}
+
+routine addAttributeCorrespondence(uml::Property umlAttribute, java::Field javaField) {
+     action {
+         add correspondence between umlAttribute and javaField
+     }
 }
 
 routine createJavaAttribute(uml::Classifier uClassifier, uml::Property umlAttribute) {
@@ -38,7 +65,7 @@ routine createJavaAttribute(uml::Classifier uClassifier, uml::Property umlAttrib
     }
     action {
         val javaAttribute = create java::Field and initialize {
-            javaAttribute.name = umlAttribute.name;
+            javaAttribute.name = umlAttribute.name
             javaAttribute.makePublic
         }
         update jClassifier {

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -8,6 +8,9 @@ import org.eclipse.uml2.uml.ParameterDirectionKind
 import org.eclipse.uml2.uml.Property
 import org.eclipse.uml2.uml.VisibilityKind
 import org.emftext.language.java.types.TypesFactory
+import org.emftext.language.java.members.ClassMethod
+import org.emftext.language.java.members.Constructor
+import org.emftext.language.java.members.InterfaceMethod
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
@@ -32,6 +35,7 @@ reaction UmlMethodCreated {
         createJavaMethod(affectedEObject, newValue)       
     }
 }
+
 //We need separate Reactions for Class and Enums, because they don't have a common
 //superClass for "having ownedOperation"
 reaction UmlMethodCreatedInDataType {
@@ -44,23 +48,44 @@ routine createJavaMethod(uml::Classifier uClassifier, uml::Operation uOperation)
     action {
         call {
             if (uClassifier.name.toFirstUpper == uOperation.name.toFirstUpper) {
-                createJavaConstructor(uClassifier, uOperation)
+                createOrFindJavaConstructor(uClassifier, uOperation)
             } else if (uClassifier instanceof Class
                 || uClassifier instanceof DataType) {
-                createJavaClassMethod(uClassifier, uOperation)
+                createOrFindJavaClassMethod(uClassifier, uOperation)
             } else if (uClassifier instanceof Interface) {
-                createJavaInterfaceMethod(uClassifier, uOperation)
+                createOrFindJavaInterfaceMethod(uClassifier, uOperation)
             } else {
                 logger.warn("Invalid creation of " + uOperation + ", containing UML-Classifier is neither a Class, nor an Interface nor a DataType")
             }
         }
     }
 }
-routine createJavaClassMethod(uml::Classifier uClassifier, uml::Operation uOperation) {
+
+// Shared between interface methods, class methods and constructors:
+routine addMethodCorrespondence(java::Member javaMethodOrConstructor, uml::Operation uOperation) {
+     action {
+         add correspondence between uOperation and javaMethodOrConstructor
+     }
+}
+
+routine createOrFindJavaClassMethod(uml::Classifier uClassifier, uml::Operation uOperation) {
     match {
         val jClassifier = retrieve java::ConcreteClassifier corresponding to uClassifier
         require absence of java::ClassMethod corresponding to uOperation
     }
+    action {
+        call {
+            val foundMethod = jClassifier.members.filter(ClassMethod).findFirst[name == uOperation.name]
+            if (foundMethod === null) {
+                createJavaClassMethod(jClassifier, uOperation)
+            } else {
+                addMethodCorrespondence(foundMethod, uOperation)
+            }
+        }
+    }
+}
+
+routine createJavaClassMethod(java::ConcreteClassifier jClassifier, uml::Operation uOperation) {
     action {
         val javaMethod = create java::ClassMethod and initialize {
             javaMethod.name = uOperation.name;
@@ -74,11 +99,24 @@ routine createJavaClassMethod(uml::Classifier uClassifier, uml::Operation uOpera
     }
 }
 
-routine createJavaConstructor(uml::Classifier uClassifier, uml::Operation uOperation) {
+routine createOrFindJavaConstructor(uml::Classifier uClassifier, uml::Operation uOperation) {
     match {
         val jClassifier = retrieve java::ConcreteClassifier corresponding to uClassifier
         require absence of java::Constructor corresponding to uOperation
     }
+    action {
+        call {
+            val foundConstructor = jClassifier.members.filter(Constructor).findFirst[name == uOperation.name]
+            if (foundConstructor === null) {
+                createJavaConstructor(jClassifier, uOperation)
+            } else {
+                addMethodCorrespondence(foundConstructor, uOperation)
+            }
+        }
+    }
+}
+
+routine createJavaConstructor(java::ConcreteClassifier jClassifier, uml::Operation uOperation) {
     action {
         val jConstructor = create java::Constructor and initialize {
             jConstructor.name = uOperation.name;
@@ -90,7 +128,6 @@ routine createJavaConstructor(uml::Classifier uClassifier, uml::Operation uOpera
         add correspondence between uOperation and jConstructor
     }
 }
-
 
 reaction UmlClassMethodDeleted {
     after element uml::Operation deleted and removed from uml::Class[ownedOperation]
@@ -181,12 +218,24 @@ reaction UmlInterfaceMethodCreated {
     call createJavaMethod(affectedEObject, newValue)
 }
 
-routine createJavaInterfaceMethod(uml::Interface uInterface, uml::Operation uOperation) {
+routine createOrFindJavaInterfaceMethod(uml::Interface uInterface, uml::Operation uOperation) {
     match {
         val jInterface = retrieve java::Interface corresponding to uInterface
-        val customTypeClass = retrieve optional java::Class corresponding to uOperation.type
         require absence of java::InterfaceMethod corresponding to uOperation
     }
+    action {
+        call {
+            val foundMethod = uInterface.members.filter(InterfaceMethod).findFirst[name == uOperation.name]
+            if (foundMethod === null) {
+                createJavaInterfaceMethod(jInterface, uOperation)
+            } else {
+                addMethodCorrespondence(foundMethod, uOperation)
+            }
+        }
+    }
+}
+
+routine createJavaInterfaceMethod(java::Interface jInterface, uml::Operation uOperation) {
     action {
         val javaMethod = create java::InterfaceMethod and initialize {
             javaMethod.name = uOperation.name;


### PR DESCRIPTION
I fixed the duplicate creation of assembly contexts and correlating fields, constructors, import declarations, and access methods. This prevents several problems that appear during the assembly context concept propagation, mainly duplicate creation, overwriting and incorrect name propagation.

This was fixed by implementing the find-or-create-pattern for:
- Fields, constructors, and import declarations in the PCM-to-Java reactions
- Assembly contexts in the Java-to-PCM reactions
- Attributes of Classes and Enums in the Java-to-UML reactions
- Fields of Classes and Enums in the UML-to-Java reactions
- Methods (including constructors) of Classes, Interfaces, and Enums in the Java-to-UML reactions
- Methods (including constructors) of Classes, Interfaces, and Enums in the UML-to-Java reactions

Additionally, I changed the detection of fields correlating to assembly contexts. Instead of locating the fields by their type they are now located by their name, as multiple assembly contexts referencing the same component are possible but multiple fields with the same name are not possible.
