### PR TITLE
Fixed incorrect creation and adaption of provided roles

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -40,6 +40,7 @@ import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
+import static extension tools.vitruv.framework.util.bridges.JavaHelper.claimOneOrNone
 
 import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
@@ -836,23 +837,50 @@ reaction CreatedProvidedRole {
 	call addProvidedRole(newValue)
 }
 
+routine findOrAddProvidedRole(pcm::OperationProvidedRole providedRole) {
+	match {
+		val operationProvidingInterface = retrieve java::Interface corresponding to providedRole.providedInterface__OperationProvidedRole
+		val javaClass = retrieve java::Class corresponding to providedRole.providingEntity_ProvidedRole
+		require absence of java::NamespaceClassifierReference corresponding to providedRole
+	}
+	action {
+		execute {
+			val matchingReference = javaClass.implements.filter[target == operationProvidingInterface].claimOneOrNone
+			if(matchingReference.isPresent) {
+				addProvidedRoleCorrespondence(providedRole, matchingReference.get)
+			} else {
+				addProvidedRole(providedRole)
+			}
+		}
+	}
+}
+
+routine addProvidedRoleCorrespondence(pcm::OperationProvidedRole providedRole, java::TypeReference reference) {
+	match {
+		require absence of java::TypeReference corresponding to providedRole
+	}
+	action {
+		add correspondence between reference and providedRole
+	}
+}
+
 routine addProvidedRole(pcm::OperationProvidedRole providedRole) {
 	match {
 		val operationProvidingInterface = retrieve java::Interface corresponding to providedRole.providedInterface__OperationProvidedRole
 		val javaClass = retrieve java::Class corresponding to providedRole.providingEntity_ProvidedRole
 	}
-	action {
+	action { 
 		// TODO HK This should be partly in the context of the compilation unit
 		val interfaceImport = create java::ClassifierImport and initialize {
-			addImportToCompilationUnitOfClassifier(interfaceImport, javaClass, operationProvidingInterface);
+			addImportToCompilationUnitOfClassifier(interfaceImport, javaClass, operationProvidingInterface)
 		}
 		add correspondence between interfaceImport and providedRole
 		val namespaceClassifierReference = create java::NamespaceClassifierReference and initialize {
-			createNamespaceClassifierReference(namespaceClassifierReference, operationProvidingInterface);
+			createNamespaceClassifierReference(namespaceClassifierReference, operationProvidingInterface)
 		}
 		add correspondence between namespaceClassifierReference and providedRole
 		update javaClass {
-			javaClass.implements += namespaceClassifierReference;
+			javaClass.implements += namespaceClassifierReference
 		}
 	}
 }
@@ -862,7 +890,7 @@ reaction ChangedProvidedInterfaceOfProvidedRole {
 	call {
 		val operationProvidedRole = affectedEObject;
 		removeProvidedRole(operationProvidedRole);
-		addProvidedRole(operationProvidedRole);
+		findOrAddProvidedRole(operationProvidedRole);
 	}
 }
 
@@ -871,7 +899,7 @@ reaction ChangedProvidingEntityOfProvidedRole {
 	call {
 		val operationProvidedRole = affectedEObject;
 		removeProvidedRole(operationProvidedRole);
-		addProvidedRole(operationProvidedRole);
+		findOrAddProvidedRole(operationProvidedRole);
 	}
 }
 
@@ -888,11 +916,12 @@ reaction DeletedProvidedRoleFromComponent {
 routine removeProvidedRole(pcm::ProvidedRole providedRole) {
 	match {
 		val requiredInterfaceImport = retrieve java::ClassifierImport corresponding to providedRole
-		val namespaceClassifierReference = retrieve java::NamespaceClassifierReference corresponding to providedRole
+		val typeReference = retrieve java::TypeReference corresponding to providedRole
 	}
 	action {
 		delete requiredInterfaceImport
-		delete namespaceClassifierReference
+		delete typeReference.getPureClassifierReference // seems to be necessary to properly delete reference if it is a NamespaceClassifierReference
+		delete typeReference
 	}
 }
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -20,9 +20,6 @@ import org.emftext.language.java.references.IdentifierReference
 import org.emftext.language.java.references.SelfReference
 import org.emftext.language.java.statements.ExpressionStatement
 import org.emftext.language.java.types.PrimitiveType
-import org.emftext.language.java.types.TypeReference
-import org.emftext.language.java.containers.ContainersPackage
-import org.emftext.language.java.classifiers.Interface
 import org.palladiosimulator.pcm.repository.BasicComponent
 import org.palladiosimulator.pcm.repository.CollectionDataType
 import org.palladiosimulator.pcm.repository.CompositeDataType

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmProvidedRole.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmProvidedRole.reactions
@@ -31,21 +31,19 @@ routine insertCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 routine detectOrCreateCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRealization = retrieve optional uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 		val umlInterface = retrieve optional uml::Interface corresponding to pcmProvided.providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE 
+	    require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	action {
 		call {
-			if (!umlRealization.isPresent) {
-				var InterfaceRealization umlRealizationCandidate = null
-				if(umlInterface.isPresent) 
-					umlRealizationCandidate = umlComponentImpl.interfaceRealizations
-						.findFirst[it.name == pcmProvided.entityName && it.contract === umlInterface.get]
-				if (umlRealizationCandidate !== null) {
-					addCorrespondenceForExistingRealization(pcmProvided, umlRealizationCandidate)
-				}
-				createCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
+			var InterfaceRealization umlRealizationCandidate = null
+			if(umlInterface.isPresent) 
+				umlRealizationCandidate = umlComponentImpl.interfaceRealizations
+					.findFirst[it.name == pcmProvided.entityName && it.contract === umlInterface.get]
+			if (umlRealizationCandidate !== null) {
+				addCorrespondenceForExistingRealization(pcmProvided, umlRealizationCandidate)
 			}
+			createCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
 		}
 	}
 }

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmProvidedRole.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmProvidedRole.reactions
@@ -1,4 +1,3 @@
-import org.eclipse.uml2.uml.InterfaceRealization
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
@@ -31,19 +30,17 @@ routine insertCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 routine detectOrCreateCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlInterface = retrieve optional uml::Interface corresponding to pcmProvided.providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE 
+		val umlInterface = retrieve uml::Interface corresponding to pcmProvided.providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 	    require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	action {
 		call {
-			var InterfaceRealization umlRealizationCandidate = null
-			if(umlInterface.isPresent) 
-				umlRealizationCandidate = umlComponentImpl.interfaceRealizations
-					.findFirst[it.name == pcmProvided.entityName && it.contract === umlInterface.get]
+			var umlRealizationCandidate = umlComponentImpl.interfaceRealizations.findFirst[it.name == pcmProvided.entityName && it.contract === umlInterface]
 			if (umlRealizationCandidate !== null) {
 				addCorrespondenceForExistingRealization(pcmProvided, umlRealizationCandidate)
+			} else {
+				createCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
 			}
-			createCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
 		}
 	}
 }

--- a/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlProvidedRoleRealization.reactions
+++ b/bundles/pcmumlclass/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml/UmlProvidedRoleRealization.reactions
@@ -50,18 +50,16 @@ routine detectOrCreateCorrespondingProvidedRole(uml::InterfaceRealization umlRea
 	match {
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val pcmProvided = retrieve optional pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	action {
 		call {
-			if (!pcmProvided.isPresent) {
-				val pcmProvidedCandidate = pcmComponent.providedRoles_InterfaceProvidingEntity
-					.filter(OperationProvidedRole).findFirst[it.providedInterface__OperationProvidedRole === pcmInterface]
-				if (pcmProvidedCandidate !== null) {
-					addCorrespondenceForExistingProvidedRole(umlRealization, pcmProvidedCandidate)
-				} else {
-					createCorrespondingProvidedRole(umlRealization, umlComponent)
-				}
+			val pcmProvidedCandidate = pcmComponent.providedRoles_InterfaceProvidingEntity
+				.filter(OperationProvidedRole).findFirst[it.providedInterface__OperationProvidedRole === pcmInterface]
+			if (pcmProvidedCandidate !== null) {
+				addCorrespondenceForExistingProvidedRole(umlRealization, pcmProvidedCandidate)
+			} else {
+				createCorrespondingProvidedRole(umlRealization, umlComponent)
 			}
 		}
 	}

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -12,6 +12,7 @@ import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPacka
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
 import static tools.vitruv.applications.util.temporary.uml.UmlTypeUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
+import static extension tools.vitruv.framework.util.bridges.JavaHelper.claimOneOrNone
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -272,7 +273,10 @@ routine addUmlClassImplement(java::Class jClass, java::TypeReference jReference,
     }
     action {
         execute {
-            if (uInterface !== null) {
+            val matchingInterfaceRealization = uClass.interfaceRealizations.filter[name == uInterface.name + uInterface.name].filter[contract == uInterface].claimOneOrNone
+            if(matchingInterfaceRealization.present) {
+                 addImplementsCorrespondence(jReference, matchingInterfaceRealization.get)
+            } else if (uInterface !== null) {
                 val uRealization = uClass.createInterfaceRealization(uInterface.name + uInterface.name, uInterface)
                 addImplementsCorrespondence(jReference, uRealization)
             } else {

--- a/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.java2uml/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -273,11 +273,11 @@ routine addUmlClassImplement(java::Class jClass, java::TypeReference jReference,
     }
     action {
         execute {
-            val matchingInterfaceRealization = uClass.interfaceRealizations.filter[name == uInterface.name + uInterface.name].filter[contract == uInterface].claimOneOrNone
-            if(matchingInterfaceRealization.present) {
+            val matchingInterfaceRealization = uClass.interfaceRealizations.filter[contract == uInterface].claimOneOrNone
+            if(matchingInterfaceRealization.isPresent) {
                  addImplementsCorrespondence(jReference, matchingInterfaceRealization.get)
             } else if (uInterface !== null) {
-                val uRealization = uClass.createInterfaceRealization(uInterface.name + uInterface.name, uInterface)
+                val uRealization = uClass.createInterfaceRealization(uInterface.name, uInterface)
                 addImplementsCorrespondence(jReference, uRealization)
             } else {
                 logger.warn("Could not add " + jInterface.name + " as implemented interface for " + uClass

--- a/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/umljava/tools.vitruv.applications.umljava.uml2java/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -16,6 +16,7 @@ import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
+import static extension tools.vitruv.framework.util.bridges.JavaHelper.claimOneOrNone
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -247,13 +248,19 @@ routine createJavaClassImplementsReference(uml::InterfaceRealization uRealizatio
 		require absence of java::TypeReference corresponding to uRealization
 	}
 	action {
-		execute { // Should actually be split into execute and call
-            var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null, userInteractor)
-            addJavaImport(jClass.containingCompilationUnit, typeReference)
-            jClass.implements += typeReference
-            addImplementsCorrespondence(uRealization, typeReference)
-        }
-    }
+		execute {
+			val matchingReference = jClass.implements.filter[target == jInterface].claimOneOrNone
+			if (matchingReference.isPresent) {
+				addImplementsCorrespondence(uRealization, matchingReference.get)
+			} else {
+				var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null, userInteractor)
+				addJavaImport(jClass.containingCompilationUnit, typeReference)
+				jClass.implements += typeReference
+				addImplementsCorrespondence(uRealization, typeReference)
+			}
+			
+		}
+	}
 }
 
 routine addImplementsCorrespondence(uml::InterfaceRealization uRealization, java::TypeReference jReference) {


### PR DESCRIPTION
I fixed a problem with endless provided role generation by implementing the find-or-create-pattern for provided roles and interface realizations. The pattern avoids duplicate creation which enabled the change propagation loop. I also solved two problems by ensuring proper deletion of the type references that represent realization relations. First, the problem of uncontained reference objects and, second, the problem of duplicate references due to the creation of a semantically identical type reference after the improper deletion of the original one. Depending on the execution order, either one of these problems appeared.