### PR TITLE
Readd accidentally removed imports

### DIFF
--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm.tests/src/tools/vitruv/applications/pcmjava/tests/ejbtransformations/java2pcm/EjbPackageMappingTest.xtend
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm.tests/src/tools/vitruv/applications/pcmjava/tests/ejbtransformations/java2pcm/EjbPackageMappingTest.xtend
@@ -5,6 +5,9 @@ import org.palladiosimulator.pcm.repository.Repository
 
 import static org.junit.Assert.assertEquals
 
+import static extension tools.vitruv.framework.correspondence.CorrespondenceModelUtil.*
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
+
 class EjbPackageMappingTest extends EjbJava2PcmTransformationTest {
 	
 	@Test


### PR DESCRIPTION
Readds imports that were accidentally removed in #86 leading to compile errors.