### PR TITLE
PCM->UML: React to Repository Deletion Instead of Root Removal

### DIFF
--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm/PcmRepository.reactions
@@ -133,8 +133,8 @@ routine changeNameOfCorrespondingRepositoryPackage(pcm::Repository pcmRepo) {
 }
 
 reaction RepositoryDeleted {
-	after element pcm::Repository removed as root
-	call deleteCorrespondingRepositoryPackages(oldValue)
+	after element pcm::Repository deleted
+	call deleteCorrespondingRepositoryPackages(affectedEObject)
 }
 
 routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {


### PR DESCRIPTION
The reaction was also triggered when moving a repository file.