### PR TITLE
Uml-Java Improvements

### DIFF
--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -103,6 +103,7 @@ routine createOrFindUmlClass(java::Class jClass, java::CompilationUnit jCompUnit
 	match {
 		val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 		require absence of uml::Class corresponding to jClass
+		require absence of uml::DataType corresponding to jClass
 	}
     action {
 		call {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -146,6 +146,7 @@ routine renameJavaClassifier(uml::Classifier umlClassifier) {
         val jPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
         val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
         val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifier
+        check umlClassifier.name != javaClassifier.name
     }
     action {
         update javaClassifier {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -591,6 +591,7 @@ reaction UmlPackageRenamed {
 routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
     match {
         val jPackage = retrieve java::Package corresponding to uPackage
+        check uPackage.name != jPackage.name
     }
     action {
         update jPackage {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -10,10 +10,10 @@ import tools.vitruv.framework.userinteraction.UserInteractionOptions.Notificatio
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
 import static tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.*
-import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 
+import static extension tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import static extension tools.vitruv.framework.util.bridges.JavaHelper.claimOneOrNone
@@ -591,12 +591,12 @@ reaction UmlPackageRenamed {
 routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
     match {
         val jPackage = retrieve java::Package corresponding to uPackage
-        check uPackage.name != jPackage.name
+        check uPackage.name != jPackage.name || uPackage.umlParentNamespaceAsStringList != jPackage.namespaces
     }
     action {
         update jPackage {
             jPackage.namespaces.clear
-            jPackage.namespaces += getUmlParentNamespaceAsStringList(uPackage)
+            jPackage.namespaces += uPackage.umlParentNamespaceAsStringList
             jPackage.name = uPackage.name
             persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
         }


### PR DESCRIPTION
This PR fixes some minor problems leading to errors when using UML-Java Reactions as a bidirectional transformation.
* Ensure that already performed name changes are not processed again in the opposite direction
* Ensure that a Java class created for a UML data type is not mapped to a UML class again