### PR TITLE
Release 0.2.0

### DIFF
--- a/bundles/pcmjava/pom.xml
+++ b/bundles/pcmjava/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>bundles</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>pcmjava</artifactId>

--- a/bundles/pcmjava/pom.xml
+++ b/bundles/pcmjava/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>bundles</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>pcmjava</artifactId>

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Application PCM-Java Common Reactions
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.common
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.common
 Bundle-Vendor: vitruv.tools
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: tools.vitruv.applications.pcmjava.common.pcm2java,
  mir.reactions.pcm2javaCommon,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Application PCM-Java Common Reactions
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.common
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.common
 Bundle-Vendor: vitruv.tools
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: tools.vitruv.applications.pcmjava.common.pcm2java,
  mir.reactions.pcm2javaCommon,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java Dependency Injection Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.depinjecttransformations
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.depinjecttransformations
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: mir.reactions.pcm2depInjectJava;x-internal:=true,
  mir.reactions.pcm2depInjectJava.pcm2javaCommon;x-internal:=true,
  mir.routines.pcm2depInjectJava;x-internal:=true,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java Dependency Injection Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.depinjecttransformations
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.depinjecttransformations
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: mir.reactions.pcm2depInjectJava;x-internal:=true,
  mir.reactions.pcm2depInjectJava.pcm2javaCommon;x-internal:=true,
  mir.routines.pcm2depInjectJava;x-internal:=true,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java EJB Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ejbtransformations;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.ejbtransformations
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.vitruv.framework.applications,
  tools.vitruv.extensions.dslsruntime.reactions,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java EJB Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ejbtransformations;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.ejbtransformations
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.vitruv.framework.applications,
  tools.vitruv.extensions.dslsruntime.reactions,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java POJO Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.applications.pcmjava.pojotransformations,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java POJO Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.applications.pcmjava.pojotransformations,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Application PCM-Java Utilities
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.util
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.util
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  org.apache.log4j,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/META-INF/MANIFEST.MF
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius Application PCM-Java Utilities
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.util
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.util
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib,
  org.apache.log4j,

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>bundles</artifactId>

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>bundles</artifactId>

--- a/bundles/tools.vitruv.applications.cbs.commonalities/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv CBS Commonalities Application
 Bundle-SymbolicName: tools.vitruv.applications.cbs.commonalities;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.applications.cbs.commonalities,
  tools.vitruv.applications.cbs.commonalities.cbs,

--- a/bundles/tools.vitruv.applications.cbs.commonalities/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv CBS Commonalities Application
 Bundle-SymbolicName: tools.vitruv.applications.cbs.commonalities;singleton:=true
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.applications.cbs.commonalities,
  tools.vitruv.applications.cbs.commonalities.cbs,

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Mappings Application Sources
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass.mapping.sources
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Require-Bundle: tools.vitruv.extensions.dslsruntime.mappings,
  tools.vitruv.extensions.dslsruntime.reactions,
  tools.vitruv.domains.uml;visibility:=reexport,

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Mappings Application Sources
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass.mapping.sources
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Require-Bundle: tools.vitruv.extensions.dslsruntime.mappings,
  tools.vitruv.extensions.dslsruntime.reactions,
  tools.vitruv.domains.uml;visibility:=reexport,

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Mappings Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass.mapping
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Export-Package: mir.reactions.combinedPcmToUml,
  mir.reactions.combinedUmlToPcm,
  mir.reactions.pcmCollectionDataTypeReactions;x-internal:=true,

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Mappings Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass.mapping
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Export-Package: mir.reactions.combinedPcmToUml,
  mir.reactions.combinedUmlToPcm,
  mir.reactions.pcmCollectionDataTypeReactions;x-internal:=true,

--- a/bundles/tools.vitruv.applications.pcmumlclass/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.pcmumlclass/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass;singleton:=true
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Automatic-Module-Name: tools.vitruv.applications.pcmumlclass
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Eclipse-ExtensibleAPI: true

--- a/bundles/tools.vitruv.applications.pcmumlclass/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.pcmumlclass/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass;singleton:=true
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Automatic-Module-Name: tools.vitruv.applications.pcmumlclass
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Eclipse-ExtensibleAPI: true

--- a/bundles/tools.vitruv.applications.pcmumlcomponents/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.pcmumlcomponents/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Components Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.vitruv.domains.uml;visibility:=reexport,
  tools.vitruv.domains.pcm;visibility:=reexport,

--- a/bundles/tools.vitruv.applications.pcmumlcomponents/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.pcmumlcomponents/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Components Application
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.vitruv.domains.uml;visibility:=reexport,
  tools.vitruv.domains.pcm;visibility:=reexport,

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML Class-UML Components Application
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Require-Bundle: tools.vitruv.extensions.dslsruntime.reactions,
  tools.vitruv.domains.uml;visibility:=reexport,
  edu.kit.ipd.sdq.activextendannotations

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML Class-UML Components Application
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Require-Bundle: tools.vitruv.extensions.dslsruntime.reactions,
  tools.vitruv.domains.uml;visibility:=reexport,
  edu.kit.ipd.sdq.activextendannotations

--- a/bundles/tools.vitruv.applications.umljava/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.umljava/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML-Java Application
 Bundle-SymbolicName: tools.vitruv.applications.umljava;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.umljava
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: edu.kit.ipd.sdq.activextendannotations,
  tools.vitruv.domains.uml;visibility:=reexport,

--- a/bundles/tools.vitruv.applications.umljava/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.umljava/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML-Java Application
 Bundle-SymbolicName: tools.vitruv.applications.umljava;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.umljava
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: edu.kit.ipd.sdq.activextendannotations,
  tools.vitruv.domains.uml;visibility:=reexport,

--- a/bundles/tools.vitruv.applications.util.temporary/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.util.temporary/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Temporary Utils
 Comment: This project is only temporary, as the utils will be moved to their respective domains!
 Bundle-SymbolicName: tools.vitruv.applications.util.temporary
 Automatic-Module-Name: tools.vitruv.applications.util.temporary
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Require-Bundle: tools.vitruv.domains.uml,
  tools.vitruv.domains.java,
  tools.vitruv.domains.pcm,

--- a/bundles/tools.vitruv.applications.util.temporary/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.util.temporary/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Vitruv Temporary Utils
 Comment: This project is only temporary, as the utils will be moved to their respective domains!
 Bundle-SymbolicName: tools.vitruv.applications.util.temporary
 Automatic-Module-Name: tools.vitruv.applications.util.temporary
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Require-Bundle: tools.vitruv.domains.uml,
  tools.vitruv.domains.java,
  tools.vitruv.domains.pcm,

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>features</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>features</artifactId>

--- a/features/tools.vitruv.applications.cbs.commonalities.feature/feature.xml
+++ b/features/tools.vitruv.applications.cbs.commonalities.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.cbs.commonalities.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.cbs.commonalities.feature/feature.xml
+++ b/features/tools.vitruv.applications.cbs.commonalities.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.cbs.commonalities.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.pcmjava.ejbtransformations.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmjava.ejbtransformations.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmjava.ejbtransformations.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">
@@ -21,7 +21,7 @@
 
    <includes
          id="tools.vitruv.applications.pcmjava.feature"
-         version="0.2.0.qualifier"/>
+         version="0.2.0"/>
 
    <requires>
       <import plugin="org.apache.log4j"/>

--- a/features/tools.vitruv.applications.pcmjava.ejbtransformations.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmjava.ejbtransformations.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmjava.ejbtransformations.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">
@@ -21,7 +21,7 @@
 
    <includes
          id="tools.vitruv.applications.pcmjava.feature"
-         version="0.2.0"/>
+         version="0.3.0.qualifier"/>
 
    <requires>
       <import plugin="org.apache.log4j"/>

--- a/features/tools.vitruv.applications.pcmjava.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmjava.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmjava.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.pcmjava.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmjava.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmjava.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.pcmjava.pojotransformations.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmjava.pojotransformations.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmjava.pojotransformations.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">
@@ -21,7 +21,7 @@
 
    <includes
          id="tools.vitruv.applications.pcmjava.feature"
-         version="0.2.0"/>
+         version="0.3.0.qualifier"/>
 
    <requires>
       <import plugin="com.google.guava"/>

--- a/features/tools.vitruv.applications.pcmjava.pojotransformations.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmjava.pojotransformations.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmjava.pojotransformations.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">
@@ -21,7 +21,7 @@
 
    <includes
          id="tools.vitruv.applications.pcmjava.feature"
-         version="0.2.0.qualifier"/>
+         version="0.2.0"/>
 
    <requires>
       <import plugin="com.google.guava"/>

--- a/features/tools.vitruv.applications.pcmumlclass.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmumlclass.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmumlclass.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.pcmumlclass.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmumlclass.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmumlclass.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.pcmumlcomponents.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmumlcomponents.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmumlcomponents.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.pcmumlcomponents.feature/feature.xml
+++ b/features/tools.vitruv.applications.pcmumlcomponents.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.pcmumlcomponents.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.umlclassumlcomponents.feature/feature.xml
+++ b/features/tools.vitruv.applications.umlclassumlcomponents.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.umlclassumlcomponents.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.umlclassumlcomponents.feature/feature.xml
+++ b/features/tools.vitruv.applications.umlclassumlcomponents.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.umlclassumlcomponents.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.umljava.feature/feature.xml
+++ b/features/tools.vitruv.applications.umljava.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.umljava.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.umljava.feature/feature.xml
+++ b/features/tools.vitruv.applications.umljava.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.umljava.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.util.temporary.feature/feature.xml
+++ b/features/tools.vitruv.applications.util.temporary.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.util.temporary.feature"
       label="%featureName"
-      version="0.2.0"
+      version="0.3.0.qualifier"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/features/tools.vitruv.applications.util.temporary.feature/feature.xml
+++ b/features/tools.vitruv.applications.util.temporary.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="tools.vitruv.applications.util.temporary.feature"
       label="%featureName"
-      version="0.2.0.qualifier"
+      version="0.2.0"
       provider-name="%providerName"
       license-feature="tools.vitruv.license.feature"
       license-feature-version="1.0.0">

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>applications-cbs-parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>releng/tools.vitruv.applications.cbs.parent</relativePath>
 	</parent>
 	<artifactId>parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>applications-cbs-parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>releng/tools.vitruv.applications.cbs.parent</relativePath>
 	</parent>
 	<artifactId>parent</artifactId>

--- a/releng/tools.vitruv.applications.cbs.frameworkwrapper/META-INF/MANIFEST.MF
+++ b/releng/tools.vitruv.applications.cbs.frameworkwrapper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: tools.vitruv.applications.cbs.frameworkwrapper
 Bundle-SymbolicName: tools.vitruv.applications.cbs.frameworkwrapper
 Automatic-Module-Name: tools.vitruv.applications.cbs.frameworkwrapper
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Require-Bundle: tools.vitruv.dsls.reactions,
  tools.vitruv.dsls.mappings,
  tools.vitruv.dsls.mirbase,

--- a/releng/tools.vitruv.applications.cbs.frameworkwrapper/META-INF/MANIFEST.MF
+++ b/releng/tools.vitruv.applications.cbs.frameworkwrapper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: tools.vitruv.applications.cbs.frameworkwrapper
 Bundle-SymbolicName: tools.vitruv.applications.cbs.frameworkwrapper
 Automatic-Module-Name: tools.vitruv.applications.cbs.frameworkwrapper
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Require-Bundle: tools.vitruv.dsls.reactions,
  tools.vitruv.dsls.mappings,
  tools.vitruv.dsls.mirbase,

--- a/releng/tools.vitruv.applications.cbs.frameworkwrapper/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.frameworkwrapper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tools.vitruv</groupId>
         <artifactId>applications-cbs-parent</artifactId>
-        <version>0.2.0-SNAPSHOT</version>
+        <version>0.2.0</version>
         <relativePath>../tools.vitruv.applications.cbs.parent</relativePath>
     </parent>
     <artifactId>tools.vitruv.applications.cbs.frameworkwrapper</artifactId>

--- a/releng/tools.vitruv.applications.cbs.frameworkwrapper/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.frameworkwrapper/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>tools.vitruv</groupId>
         <artifactId>applications-cbs-parent</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0-SNAPSHOT</version>
         <relativePath>../tools.vitruv.applications.cbs.parent</relativePath>
     </parent>
     <artifactId>tools.vitruv.applications.cbs.frameworkwrapper</artifactId>

--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -9,19 +9,19 @@
 		<version>1.1.0</version>
 	</parent>
 	<artifactId>applications-cbs-parent</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>0.2.0</version>
 	<packaging>pom</packaging>
 
 	<repositories>
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/nightly/framework/</url>
+			<url>https://vitruv-tools.github.io/updatesite/release/framework/2.0.1/</url>
 		</repository>
 		<repository>
 			<id>Vitruv Domains</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/</url>
+			<url>https://vitruv-tools.github.io/updatesite/release/domains/cbs/2.0.0/</url>
 		</repository>
 		<repository>
 			<id>Palladiosimulator</id>
@@ -127,7 +127,7 @@
 							<dependency>
 								<groupId>tools.vitruv</groupId>
 								<artifactId>tools.vitruv.applications.cbs.frameworkwrapper</artifactId>
-								<version>0.2.0-SNAPSHOT</version>
+								<version>0.2.0</version>
 							</dependency>
 							<dependency>
 								<groupId>org.eclipse.xtend</groupId>

--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -9,19 +9,19 @@
 		<version>1.1.0</version>
 	</parent>
 	<artifactId>applications-cbs-parent</artifactId>
-	<version>0.2.0</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<repositories>
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/release/framework/2.0.1/</url>
+			<url>https://vitruv-tools.github.io/updatesite/nightly/framework/</url>
 		</repository>
 		<repository>
 			<id>Vitruv Domains</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/release/domains/cbs/2.0.0/</url>
+			<url>https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/</url>
 		</repository>
 		<repository>
 			<id>Palladiosimulator</id>
@@ -127,7 +127,7 @@
 							<dependency>
 								<groupId>tools.vitruv</groupId>
 								<artifactId>tools.vitruv.applications.cbs.frameworkwrapper</artifactId>
-								<version>0.2.0</version>
+								<version>0.3.0-SNAPSHOT</version>
 							</dependency>
 							<dependency>
 								<groupId>org.eclipse.xtend</groupId>

--- a/releng/tools.vitruv.applications.cbs.updatesite/category.xml
+++ b/releng/tools.vitruv.applications.cbs.updatesite/category.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/tools.vitruv.applications.util.temporary.feature_0.2.0.jar" id="tools.vitruv.applications.util.temporary.feature" version="0.2.0">
+   <feature url="features/tools.vitruv.applications.util.temporary.feature_0.3.0.qualifier.jar" id="tools.vitruv.applications.util.temporary.feature" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.util.temporary.feature.source" version="0.2.0">
+   <feature id="tools.vitruv.applications.util.temporary.feature.source" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.pcmjava.pojotransformations.feature_0.2.0.jar" id="tools.vitruv.applications.pcmjava.pojotransformations.feature" version="0.2.0">
+   <feature url="features/tools.vitruv.applications.pcmjava.pojotransformations.feature_0.3.0.qualifier.jar" id="tools.vitruv.applications.pcmjava.pojotransformations.feature" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.pcmjava.pojotransformations.feature.source" version="0.2.0">
+   <feature id="tools.vitruv.applications.pcmjava.pojotransformations.feature.source" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.umljava.feature_0.2.0.jar" id="tools.vitruv.applications.umljava.feature" version="0.2.0">
+   <feature url="features/tools.vitruv.applications.umljava.feature_0.3.0.qualifier.jar" id="tools.vitruv.applications.umljava.feature" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.umlclassumlcomponents.feature_0.2.0.jar" id="tools.vitruv.applications.umlclassumlcomponents.feature" version="0.2.0">
+   <feature url="features/tools.vitruv.applications.umlclassumlcomponents.feature_0.3.0.qualifier.jar" id="tools.vitruv.applications.umlclassumlcomponents.feature" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.umljava.feature.source" version="0.2.0">
+   <feature id="tools.vitruv.applications.umljava.feature.source" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.pcmjava.ejbtransformations.feature_0.2.0.jar" id="tools.vitruv.applications.pcmjava.ejbtransformations.feature" version="0.2.0">
+   <feature url="features/tools.vitruv.applications.pcmjava.ejbtransformations.feature_0.3.0.qualifier.jar" id="tools.vitruv.applications.pcmjava.ejbtransformations.feature" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.pcmjava.ejbtransformations.feature.source" version="0.2.0">
+   <feature id="tools.vitruv.applications.pcmjava.ejbtransformations.feature.source" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.pcmumlcomponents.feature_0.2.0.jar" id="tools.vitruv.applications.pcmumlcomponents.feature" version="0.2.0">
+   <feature url="features/tools.vitruv.applications.pcmumlcomponents.feature_0.3.0.qualifier.jar" id="tools.vitruv.applications.pcmumlcomponents.feature" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.pcmumlcomponents.feature.source" version="0.2.0">
+   <feature id="tools.vitruv.applications.pcmumlcomponents.feature.source" version="0.3.0.qualifier">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
    <category-def name="Vitruv Applications for Component-based Systems" label="Vitruv Applications for Component-based Systems">
@@ -39,6 +39,6 @@
       </description>
    </category-def>
    <repository-reference location="http://kit-sdq.github.io/updatesite/nightly/asem/" enabled="true" />
-   <repository-reference location="http://vitruv-tools.github.io/updatesite/release/framework/2.0.1/" enabled="true" />
-   <repository-reference location="http://vitruv-tools.github.io/updatesite/release/domains/cbs/2.0.0/" enabled="true" />
+   <repository-reference location="http://vitruv-tools.github.io/updatesite/nightly/framework/" enabled="true" />
+   <repository-reference location="http://vitruv-tools.github.io/updatesite/nightly/domains/cbs/" enabled="true" />
 </site>

--- a/releng/tools.vitruv.applications.cbs.updatesite/category.xml
+++ b/releng/tools.vitruv.applications.cbs.updatesite/category.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/tools.vitruv.applications.util.temporary.feature_0.2.0.qualifier.jar" id="tools.vitruv.applications.util.temporary.feature" version="0.2.0.qualifier">
+   <feature url="features/tools.vitruv.applications.util.temporary.feature_0.2.0.jar" id="tools.vitruv.applications.util.temporary.feature" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.util.temporary.feature.source" version="0.2.0.qualifier">
+   <feature id="tools.vitruv.applications.util.temporary.feature.source" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.pcmjava.pojotransformations.feature_0.2.0.qualifier.jar" id="tools.vitruv.applications.pcmjava.pojotransformations.feature" version="0.2.0.qualifier">
+   <feature url="features/tools.vitruv.applications.pcmjava.pojotransformations.feature_0.2.0.jar" id="tools.vitruv.applications.pcmjava.pojotransformations.feature" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.pcmjava.pojotransformations.feature.source" version="0.2.0.qualifier">
+   <feature id="tools.vitruv.applications.pcmjava.pojotransformations.feature.source" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.umljava.feature_0.2.0.qualifier.jar" id="tools.vitruv.applications.umljava.feature" version="0.2.0.qualifier">
+   <feature url="features/tools.vitruv.applications.umljava.feature_0.2.0.jar" id="tools.vitruv.applications.umljava.feature" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.umlclassumlcomponents.feature_0.2.0.qualifier.jar" id="tools.vitruv.applications.umlclassumlcomponents.feature" version="0.2.0.qualifier">
+   <feature url="features/tools.vitruv.applications.umlclassumlcomponents.feature_0.2.0.jar" id="tools.vitruv.applications.umlclassumlcomponents.feature" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.umljava.feature.source" version="0.2.0.qualifier">
+   <feature id="tools.vitruv.applications.umljava.feature.source" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.pcmjava.ejbtransformations.feature_0.2.0.qualifier.jar" id="tools.vitruv.applications.pcmjava.ejbtransformations.feature" version="0.2.0.qualifier">
+   <feature url="features/tools.vitruv.applications.pcmjava.ejbtransformations.feature_0.2.0.jar" id="tools.vitruv.applications.pcmjava.ejbtransformations.feature" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.pcmjava.ejbtransformations.feature.source" version="0.2.0.qualifier">
+   <feature id="tools.vitruv.applications.pcmjava.ejbtransformations.feature.source" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature url="features/tools.vitruv.applications.pcmumlcomponents.feature_0.2.0.qualifier.jar" id="tools.vitruv.applications.pcmumlcomponents.feature" version="0.2.0.qualifier">
+   <feature url="features/tools.vitruv.applications.pcmumlcomponents.feature_0.2.0.jar" id="tools.vitruv.applications.pcmumlcomponents.feature" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
-   <feature id="tools.vitruv.applications.pcmumlcomponents.feature.source" version="0.2.0.qualifier">
+   <feature id="tools.vitruv.applications.pcmumlcomponents.feature.source" version="0.2.0">
       <category name="Vitruv Applications for Component-based Systems"/>
    </feature>
    <category-def name="Vitruv Applications for Component-based Systems" label="Vitruv Applications for Component-based Systems">
@@ -39,6 +39,6 @@
       </description>
    </category-def>
    <repository-reference location="http://kit-sdq.github.io/updatesite/nightly/asem/" enabled="true" />
-   <repository-reference location="http://vitruv-tools.github.io/updatesite/nightly/framework/" enabled="true" />
-   <repository-reference location="http://vitruv-tools.github.io/updatesite/nightly/domains/cbs/" enabled="true" />
+   <repository-reference location="http://vitruv-tools.github.io/updatesite/release/framework/2.0.1/" enabled="true" />
+   <repository-reference location="http://vitruv-tools.github.io/updatesite/release/domains/cbs/2.0.0/" enabled="true" />
 </site>

--- a/releng/tools.vitruv.applications.cbs.updatesite/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>applications-cbs-parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../tools.vitruv.applications.cbs.parent</relativePath>
 	</parent>
 	

--- a/releng/tools.vitruv.applications.cbs.updatesite/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>applications-cbs-parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../tools.vitruv.applications.cbs.parent</relativePath>
 	</parent>
 	

--- a/tests/pcmjava/pom.xml
+++ b/tests/pcmjava/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>pcmjava-tests</artifactId>

--- a/tests/pcmjava/pom.xml
+++ b/tests/pcmjava/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>tests</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>pcmjava-tests</artifactId>

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.editortests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.editortests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java EJB Application Editor Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ejbtransformations.editortests;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.ejbtransformations.editortests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.testutils,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.editortests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.editortests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java EJB Application Editor Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.ejbtransformations.editortests;singleton:=true
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.ejbtransformations.editortests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.testutils,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java POJO Application Editor Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations.editortests
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations.editortests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.jdt.core,
  org.eclipse.text,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java POJO Application Editor Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations.editortests
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations.editortests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.jdt.core,
  org.eclipse.text,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java POJO Application Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations.tests
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.emf.transaction,
  tools.vitruv.testutils,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java POJO Application Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.pojotransformations.tests
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.emf.transaction,
  tools.vitruv.testutils,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java Tests Utilities
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.tests.util
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.tests.util
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.apache.log4j,
  org.junit.jupiter.api,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruvius PCM-Java Tests Utilities
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.tests.util
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.tests.util
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.apache.log4j,
  org.junit.jupiter.api,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.tests
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  org.junit.platform.runner,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-Java Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmjava.tests
 Automatic-Module-Name: tools.vitruv.applications.pcmjava.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  org.junit.platform.runner,

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0</version>
+		<version>0.3.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>0.2.0-SNAPSHOT</version>
+		<version>0.2.0</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<artifactId>tests</artifactId>

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Vendor: vitruv.tools
 Bundle-Name: Vitruvius CBS Commonalities Tests
 Bundle-SymbolicName: tools.vitruv.applications.cbs.commonalities.tests
 Automatic-Module-Name: tools.vitruv.applications.cbs.commonalities.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib, 
  tools.vitruv.applications.cbs.commonalities,

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Vendor: vitruv.tools
 Bundle-Name: Vitruvius CBS Commonalities Tests
 Bundle-SymbolicName: tools.vitruv.applications.cbs.commonalities.tests
 Automatic-Module-Name: tools.vitruv.applications.cbs.commonalities.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.xtend.lib, 
  tools.vitruv.applications.cbs.commonalities,

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Mappings Application Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass.mapping.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Fragment-Host: tools.vitruv.applications.pcmumlclass.mapping
 Require-Bundle: tools.vitruv.applications.util.temporary,
  org.eclipse.emf.compare,

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Mappings Application Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass.mapping.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Fragment-Host: tools.vitruv.applications.pcmumlclass.mapping
 Require-Bundle: tools.vitruv.applications.util.temporary,
  org.eclipse.emf.compare,

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Application Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Automatic-Module-Name: tools.vitruv.applications.pcmumlclass.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.vitruv.testutils,

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Class Application Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlclass.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Automatic-Module-Name: tools.vitruv.applications.pcmumlclass.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.vitruv.testutils,

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Components Application Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents.tests
 Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: tools.vitruv.applications.pcmumlcomponents
 Require-Bundle: org.junit.jupiter.api,

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv PCM-UML Components Application Tests
 Bundle-SymbolicName: tools.vitruv.applications.pcmumlcomponents.tests
 Automatic-Module-Name: tools.vitruv.applications.pcmumlcomponents.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: tools.vitruv.applications.pcmumlcomponents
 Require-Bundle: org.junit.jupiter.api,

--- a/tests/tools.vitruv.applications.transitivechange.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.transitivechange.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Transitive Transformation Tests between PCM, Java, and UML Class
 Bundle-SymbolicName: tools.vitruv.applications.transitivechange.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Automatic-Module-Name: tools.vitruv.applications.transitivechange.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/tests/tools.vitruv.applications.transitivechange.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.transitivechange.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Transitive Transformation Tests between PCM, Java, and UML Class
 Bundle-SymbolicName: tools.vitruv.applications.transitivechange.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Automatic-Module-Name: tools.vitruv.applications.transitivechange.tests
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML Class-UML Components Tests
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.tests
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: tools.vitruv.applications.umlclassumlcomponents
 Require-Bundle: org.junit.jupiter.api,

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML Class-UML Components Tests
 Bundle-SymbolicName: tools.vitruv.applications.umlclassumlcomponents.tests
 Automatic-Module-Name: tools.vitruv.applications.umlclassumlcomponents.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Fragment-Host: tools.vitruv.applications.umlclassumlcomponents
 Require-Bundle: org.junit.jupiter.api,

--- a/tests/tools.vitruv.applications.umljava.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.umljava.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML-Java Tests
 Bundle-SymbolicName: tools.vitruv.applications.umljava.tests
 Automatic-Module-Name: tools.vitruv.applications.umljava.tests
-Bundle-Version: 0.2.0.qualifier
+Bundle-Version: 0.2.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.applications.umljava,

--- a/tests/tools.vitruv.applications.umljava.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.umljava.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Vitruv UML-Java Tests
 Bundle-SymbolicName: tools.vitruv.applications.umljava.tests
 Automatic-Module-Name: tools.vitruv.applications.umljava.tests
-Bundle-Version: 0.2.0
+Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.applications.umljava,


### PR DESCRIPTION
This is the PR for incubation release 0.2.0.
It depends on [framework](https://github.com/vitruv-tools/Vitruv) version 2.0.1 and [domains](https://github.com/vitruv-tools/Vitruv-Domains-ComponentBasedSystems) version 2.0.0.
