### PR TITLE
Use correspondences for Java Accessors

### DIFF
--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -311,6 +311,8 @@ reaction JavaElementMadePackagePrivate {
 routine changeUmlNamedElementVisibility(java::AnnotableAndModifiable jElem, java::Modifier mod) {
     match {
         val uElem = retrieve uml::NamedElement corresponding to jElem
+        	with !(jElem instanceof org.emftext.language.java.members.ClassMethod 
+        		&& uElem instanceof org.eclipse.uml2.uml.Property)
     }
     action {
         update uElem {
@@ -333,6 +335,8 @@ reaction JavaCompilationUnitRenamed {
 routine renameUmlNamedElement(java::NamedElement jElement) {
     match {
         val uElement = retrieve uml::NamedElement corresponding to jElement
+        	with !(jElement instanceof org.emftext.language.java.members.ClassMethod 
+        		&& uElement instanceof org.eclipse.uml2.uml.Property)
     }
     action {
         update uElement {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
@@ -4,8 +4,9 @@ import org.emftext.language.java.members.Field
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
 
-import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimNotMany
+import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
+import tools.vitruv.applications.umljava.uml2java.UmlToJavaTag
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -44,8 +45,8 @@ routine createOrFindJavaAttribute(uml::Classifier uClassifier, uml::Property uml
                 createJavaAttribute(uClassifier, umlAttribute) 
             } else {
                 addAttributeCorrespondence(umlAttribute, foundField)
-                createJavaGetter(foundField)
-                createJavaSetter(foundField)
+                createOrFindJavaGetter(umlAttribute, foundField)
+                createOrFindJavaSetter(umlAttribute, foundField)
             }
         }
     }
@@ -61,6 +62,8 @@ routine createJavaAttribute(uml::Classifier uClassifier, uml::Property umlAttrib
     match {
         val jClassifier = retrieve java::ConcreteClassifier corresponding to uClassifier
         require absence of java::Field corresponding to umlAttribute
+        require absence of java::Method corresponding to umlAttribute tagged with UmlToJavaTag.GETTER
+        require absence of java::Method corresponding to umlAttribute tagged with UmlToJavaTag.SETTER
     }
     action {
         val javaAttribute = create java::Field and initialize {
@@ -72,8 +75,8 @@ routine createJavaAttribute(uml::Classifier uClassifier, uml::Property umlAttrib
         }
         add correspondence between umlAttribute and javaAttribute
         call {
-            createJavaGetter(javaAttribute)
-            createJavaSetter(javaAttribute)
+        	createOrFindJavaGetter(umlAttribute, javaAttribute)
+        	createOrFindJavaSetter(umlAttribute, javaAttribute)
 			changeJavaAttributeType(umlAttribute)
         }
     }
@@ -92,16 +95,13 @@ reaction UmlAttributeDeletedFromDataType {
 routine deleteJavaAttribute(uml::Property umlAttr, uml::Classifier umlClassifier) {
     match {
         val jAttr = retrieve java::Field corresponding to umlAttr
-        val jClass = retrieve optional java::Class corresponding to umlClassifier
+        val jGetter = retrieve optional java::ClassMethod corresponding to umlAttr tagged with UmlToJavaTag.GETTER
+        val jSetter = retrieve optional java::ClassMethod corresponding to umlAttr tagged with UmlToJavaTag.SETTER
     }
     action {
-        call {
-        	jClass.ifPresent [
-        		removeJavaGettersOfAttribute(jAttr)
-	            removeJavaSettersOfAttribute(jAttr)
-        	]
-        }
         delete jAttr
+        delete jGetter?.get
+        delete jSetter?.get
     }
 }
 
@@ -142,36 +142,47 @@ routine changeJavaAttributeType(uml::Property uAttribute) {
     match {
         val jAttribute = retrieve java::Field corresponding to uAttribute
         val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uAttribute.type
+        val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlToJavaTag.GETTER
+        val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlToJavaTag.SETTER
     }
     action {
         call {
         	umlToJavaTypePropagation.propagatePropertyTypeChanged(uAttribute, jAttribute, jCustomType.orElse(null))
-
-		    updateAttributeTypeInSetters(jAttribute)
-		    updateAttributeTypeInGetters(jAttribute)
+		    jGetter.ifPresent [ updateAttributeTypeInGetter(it, jAttribute) ]
+		    jSetter.ifPresent [ updateAttributeTypeInSetter(it, jAttribute) ]
         }
     }
 }
 
 
-routine createJavaGetter(java::Field jAttribute) {
+routine createOrFindJavaGetter(uml::Property uAttribute, java::Field jAttribute) {
     action {
         call {
-            if (!javaGetterForAttributeExists(jAttribute)) {
-                createGetterForAttribute(jAttribute)
+        	var javaGetter = getJavaGettersOfAttribute(jAttribute).head
+            if (javaGetter === null) {
+            	javaGetter = createGetterForAttribute(jAttribute)
             }
+            createAccessorCorrespondence(uAttribute, javaGetter, UmlToJavaTag.GETTER)
         }
     }
 }
 
-routine createJavaSetter(java::Field jAttribute) {
+routine createOrFindJavaSetter(uml::Property uAttribute, java::Field jAttribute) {
     action {
         call {
-            if (!javaSetterForAttributeExists(jAttribute)) {
-                createSetterForAttribute(jAttribute)
+        	var javaSetter = getJavaSettersOfAttribute(jAttribute).head
+            if (javaSetter === null) {
+            	javaSetter = createSetterForAttribute(jAttribute)
             }
+            createAccessorCorrespondence(uAttribute, javaSetter, UmlToJavaTag.SETTER)
         }
     }
+}
+
+routine createAccessorCorrespondence(uml::Property uAttribute, java::ClassMethod jMethod, String tag) {
+	action {
+		add correspondence between uAttribute and jMethod tagged with tag
+	}
 }
 
 reaction UmlAttributeRenamed {
@@ -182,12 +193,14 @@ reaction UmlAttributeRenamed {
 routine renameJavaAttribute(String newName, String oldName, uml::Property uAttribute) {
     match {
         val jAttribute = retrieve java::Field corresponding to uAttribute
+        val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlToJavaTag.GETTER
+        val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlToJavaTag.SETTER
     }
     action {
         call {
             jAttribute.name = uAttribute.name
-            renameGettersOfAttribute(jAttribute, oldName)
-            renameSettersOfAttribute(jAttribute, oldName)
+            jGetter.ifPresent [ renameGetterOfAttribute(it, jAttribute) ]
+            jSetter.ifPresent [ renameSetter(it, jAttribute, oldName) ]
         }
     }
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -187,6 +187,7 @@ reaction UmlFeatureMadeStatic {
 routine setStatic(uml::Feature uFeat) {
     match {
         val jMod = retrieve java::AnnotableAndModifiable corresponding to uFeat
+        	with !(uFeat instanceof org.eclipse.uml2.uml.Property && jMod instanceof ClassMethod)
     }
     action {
         val staticMod = create java::Static
@@ -281,6 +282,7 @@ reaction UmlElementVisibilityChanged {
 routine changeJavaElementVisibility(uml::NamedElement uElem) {
     match {
         val jElem = retrieve java::AnnotableAndModifiable corresponding to uElem
+        	with !(uElem instanceof org.eclipse.uml2.uml.Property && jElem instanceof ClassMethod)
     }
     action {
         update jElem {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTag.java
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTag.java
@@ -1,0 +1,10 @@
+package tools.vitruv.applications.umljava.uml2java;
+
+public final class UmlToJavaTag {
+	public static final String GETTER = "getter";
+	public static final String SETTER = "setter";
+	
+	public static final String[] ACCESSORS = {GETTER, SETTER};
+	
+	private UmlToJavaTag() { }
+}

--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaMemberAndParameterUtil.xtend
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaMemberAndParameterUtil.xtend
@@ -146,6 +146,7 @@ class JavaMemberAndParameterUtil {
     def static createGetterForAttribute(Field jAttribute) {
         val jGetter = createJavaGetterForAttribute(jAttribute, JavaVisibility.PUBLIC)
         jAttribute.containingConcreteClassifier.members += jGetter
+        return jGetter
     }
 
     /**
@@ -155,6 +156,7 @@ class JavaMemberAndParameterUtil {
     def static createSetterForAttribute(Field jAttribute) {
         val jSetter = createJavaSetterForAttribute(jAttribute, JavaVisibility.PUBLIC)
         jAttribute.containingConcreteClassifier.members += jSetter
+        return jSetter
     }
 
     /**
@@ -332,39 +334,6 @@ class JavaMemberAndParameterUtil {
         return getJavaClassMethodsWithName(jClass, buildGetterName(jAttributeName))
     }
 
-    def static removeJavaGettersOfAttribute(Field jAttribute) {
-        val getters = getJavaGettersOfAttribute(jAttribute)
-        if (!getters.nullOrEmpty) {
-            for (getter : getters) {
-                EcoreUtil.remove(getter)
-            }
-        }
-    }
-
-    def static removeJavaSettersOfAttribute(Field jAttribute) {
-        val setters = getJavaSettersOfAttribute(jAttribute)
-        if (!setters.nullOrEmpty) {
-            for (setter : setters) {
-                EcoreUtil.remove(setter)
-            }
-        }
-    }
-
-    /**
-     * Checks the containing class of the given attribute for existing setters with the old attribute name.
-     * Renames the setters to the new attribute name.
-     * 
-     * @param jAttributeWithNewName the Attribute with the new name
-     * @param the name of jAttribute before it was renamed
-     */
-    def static renameSettersOfAttribute(Field jAttributeWithNewName, String oldName) {
-        val setters = getJavaSettersOfAttribute(jAttributeWithNewName.containingConcreteClassifier, oldName)
-        for (setter : setters) {
-            renameSetter(setter, jAttributeWithNewName, oldName)
-        }
-
-    }
-
     /**
      * Renames the given setter so that it matches the name of the given attribute
      * @param oldName the name of jAttribute before it was renamed
@@ -375,14 +344,6 @@ class JavaMemberAndParameterUtil {
         for (expStatement : setter.statements.filter(ExpressionStatement)) {
             val selfReference = getAttributeSelfReferenceInExpressionStatement(expStatement, oldName)
             selfReference?.setTarget(jAttribute)
-        }
-
-    }
-
-    def static updateAttributeTypeInSetters(Field jAttribute) {
-        val setters = getJavaSettersOfAttribute(jAttribute)
-        for (setter : setters) {
-            updateAttributeTypeInSetter(setter, jAttribute)
         }
     }
 
@@ -402,18 +363,6 @@ class JavaMemberAndParameterUtil {
     }
 
     /**
-     * Renames all getters of the attribute that are contained in class of the attribute
-     * 
-     * @param jAttribute the attribute with the new name
-     */
-    def static renameGettersOfAttribute(Field jAttribute, String oldName) {
-        val getters = getJavaGettersOfAttribute(jAttribute.containingConcreteClassifier, oldName)
-        for (getter : getters) {
-            renameGetterOfAttribute(getter, jAttribute)
-        }
-    }
-
-    /**
      * Renames the given getter so that it matches the name of the given attribute
      * Assumption: standard getter that only returns the attribute
      */
@@ -422,17 +371,6 @@ class JavaMemberAndParameterUtil {
         val returnStatement = getter.statements.filter(Return).head
         if (returnStatement !== null) {
             returnStatement.returnValue = createSelfReferenceToAttribute(jAttribute)
-        }
-    }
-
-    /**
-     * Searches all getters of the given attribute in the same containing class
-     * and matches the return type of the getters to the type of the attribute.
-     * 
-     */
-    def static updateAttributeTypeInGetters(Field jAttribute) {
-        for (getter : getJavaGettersOfAttribute(jAttribute)) {
-            updateAttributeTypeInGetter(getter, jAttribute)
         }
     }
 


### PR DESCRIPTION
Currently, the UML -> Java reactions use heuristics to find the getters and setters of some attribute. However, we already have a construct to model this explicitly, namely *tagged correspondences*. This pull request updates the existing reactions to use correspondences for getters and setters.
By using explicit correspondences, we do not need to iterate over all methods of some class to find the possibly existing accessors and can correctly react to more actions like a rename of an accessor.
Furthermore, for future work we could identify getters / setters in Java -> UML transformations and create a correspondence to the correct UML attribute. Currently, when creating a Java accessor method, a UML method is created.