### PR TITLE
Do not Resolve Java Types in Foreign Resource Sets

### DIFF
--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/CBSCommonalitiesExecutionTest.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/CBSCommonalitiesExecutionTest.xtend
@@ -48,6 +48,10 @@ abstract class CBSCommonalitiesExecutionTest extends LegacyVitruvApplicationTest
 		override getTestResource(String resourcePathInExecutingProject) {
 			validationResourceSet.getResource(URI.createURI(resourcePathInExecutingProject), true)
 		}
+		
+		override <T extends EObject> T at(Class<T> type, URI uri) {
+			type.cast(validationResourceSet.getEObject(uri, true))
+		}
 
 		override createAndSynchronizeModel(String modelPathInProject, EObject rootElement) {
 			val resource = resourceAt(Path.of(modelPathInProject)).startRecordingChanges => [

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/cbs/java/JavaCompositeDataTypeTestModels.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/cbs/java/JavaCompositeDataTypeTestModels.xtend
@@ -113,7 +113,7 @@ class JavaCompositeDataTypeTestModels extends JavaTestModelsBase implements Comp
 			val datatypeClass = newJavaCompositeDataTypeClass => [
 				members += newJavaElementField => [
 					name = STRING_ELEMENT_NAME
-					typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+					typeReference = referenceJamoppType(String)
 				]
 			]
 			val compilationUnit = datatypesPackage.newCompilationUnit(datatypeClass)
@@ -144,7 +144,7 @@ class JavaCompositeDataTypeTestModels extends JavaTestModelsBase implements Comp
 				]
 				members += newJavaElementField => [
 					name = STRING_ELEMENT_NAME
-					typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+					typeReference = referenceJamoppType(String)
 				]
 			]
 			val compilationUnit = datatypesPackage.newCompilationUnit(datatypeClass)

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/cbs/java/JavaOperationTestModels.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/cbs/java/JavaOperationTestModels.xtend
@@ -8,7 +8,6 @@ import org.emftext.language.java.types.TypesFactory
 import tools.vitruv.applications.cbs.commonalities.tests.cbs.OperationTest
 import tools.vitruv.applications.cbs.commonalities.tests.util.VitruvApplicationTestAdapter
 import tools.vitruv.applications.cbs.commonalities.tests.util.java.JavaTestModelsBase
-import tools.vitruv.domains.java.util.JavaModificationUtil
 
 import static extension tools.vitruv.applications.cbs.commonalities.tests.util.java.JavaModelHelper.*
 
@@ -81,7 +80,7 @@ class JavaOperationTestModels extends JavaTestModelsBase implements OperationTes
 
 			val compilationUnit = contractsPackage.newCompilationUnit(newJavaInterface => [
 				members += newJavaInterfaceMethod => [
-					typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+					typeReference = referenceJamoppType(String)
 				]
 			])
 
@@ -150,7 +149,7 @@ class JavaOperationTestModels extends JavaTestModelsBase implements OperationTes
 				members += newJavaInterfaceMethod => [
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])
@@ -177,7 +176,7 @@ class JavaOperationTestModels extends JavaTestModelsBase implements OperationTes
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])
@@ -208,7 +207,7 @@ class JavaOperationTestModels extends JavaTestModelsBase implements OperationTes
 					typeReference = TypesFactory.eINSTANCE.createInt
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/oo/java/JavaClassMethodTestModels.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/oo/java/JavaClassMethodTestModels.xtend
@@ -201,7 +201,7 @@ class JavaClassMethodTestModels extends JavaTestModelsBase implements ClassMetho
 			val javaPackage = newJavaPackage
 			val javaCompilationUnit = javaPackage.newCompilationUnit(newJavaClass => [
 				members += newJavaClassMethod => [
-					typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+					typeReference = referenceJamoppType(String)
 				]
 			])
 			return #[
@@ -298,7 +298,7 @@ class JavaClassMethodTestModels extends JavaTestModelsBase implements ClassMetho
 				members += newJavaClassMethod => [
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])
@@ -362,7 +362,7 @@ class JavaClassMethodTestModels extends JavaTestModelsBase implements ClassMetho
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = CLASS_PARAMETER_NAME
@@ -394,7 +394,7 @@ class JavaClassMethodTestModels extends JavaTestModelsBase implements ClassMetho
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = CLASS_PARAMETER_NAME
@@ -428,7 +428,7 @@ class JavaClassMethodTestModels extends JavaTestModelsBase implements ClassMetho
 					typeReference = TypesFactory.eINSTANCE.createInt
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/oo/java/JavaClassPropertyTestModels.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/oo/java/JavaClassPropertyTestModels.xtend
@@ -10,7 +10,6 @@ import org.emftext.language.java.types.TypesFactory
 import tools.vitruv.applications.cbs.commonalities.tests.oo.ClassPropertyTest
 import tools.vitruv.applications.cbs.commonalities.tests.util.VitruvApplicationTestAdapter
 import tools.vitruv.applications.cbs.commonalities.tests.util.java.JavaTestModelsBase
-import tools.vitruv.domains.java.util.JavaModificationUtil
 
 import static extension tools.vitruv.applications.cbs.commonalities.tests.util.java.JavaModelHelper.*
 
@@ -197,7 +196,7 @@ class JavaClassPropertyTestModels extends JavaTestModelsBase implements ClassPro
 			val javaCompilationUnit = javaPackage.newCompilationUnit(newJavaClass => [
 				members += newJavaField => [
 					name = STRING_PROPERTY_NAME
-					typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+					typeReference = referenceJamoppType(String)
 				]
 			])
 			return #[

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/oo/java/JavaConstructorTestModels.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/oo/java/JavaConstructorTestModels.xtend
@@ -184,7 +184,7 @@ class JavaConstructorTestModels extends JavaTestModelsBase implements Constructo
 				members += newJavaConstructor => [
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])
@@ -248,7 +248,7 @@ class JavaConstructorTestModels extends JavaTestModelsBase implements Constructo
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = CLASS_PARAMETER_NAME
@@ -279,7 +279,7 @@ class JavaConstructorTestModels extends JavaTestModelsBase implements Constructo
 				members += newJavaConstructor => [
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/oo/java/JavaInterfaceMethodTestModels.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/oo/java/JavaInterfaceMethodTestModels.xtend
@@ -108,7 +108,7 @@ class JavaInterfaceMethodTestModels extends JavaTestModelsBase implements Interf
 			val javaPackage = newJavaPackage
 			val javaCompilationUnit = javaPackage.newCompilationUnit(newJavaInterface => [
 				members += newJavaInterfaceMethod => [
-					typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+					typeReference = referenceJamoppType(String)
 				]
 			])
 			return #[
@@ -205,7 +205,7 @@ class JavaInterfaceMethodTestModels extends JavaTestModelsBase implements Interf
 				members += newJavaInterfaceMethod => [
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])
@@ -269,7 +269,7 @@ class JavaInterfaceMethodTestModels extends JavaTestModelsBase implements Interf
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = CLASS_PARAMETER_NAME
@@ -301,7 +301,7 @@ class JavaInterfaceMethodTestModels extends JavaTestModelsBase implements Interf
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 					parameters += newJavaOrdinaryParameter => [
 						name = CLASS_PARAMETER_NAME
@@ -335,7 +335,7 @@ class JavaInterfaceMethodTestModels extends JavaTestModelsBase implements Interf
 					typeReference = TypesFactory.eINSTANCE.createInt
 					parameters += newJavaOrdinaryParameter => [
 						name = STRING_PARAMETER_NAME
-						typeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(String.name)
+						typeReference = referenceJamoppType(String)
 					]
 				]
 			])

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/util/VitruvApplicationTestAdapter.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/util/VitruvApplicationTestAdapter.xtend
@@ -2,6 +2,7 @@ package tools.vitruv.applications.cbs.commonalities.tests.util
 
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.emf.common.util.URI
 
 /**
  * Interface to internals of {@link VitruvApplicationTest} for testing
@@ -12,6 +13,8 @@ interface VitruvApplicationTestAdapter {
 	def Resource getResourceAt(String modelPathInProject)
 
 	def Resource getTestResource(String resourcePath)
+	
+	def <T extends EObject> T at(Class<T> type, URI uri)
 
 	def void createAndSynchronizeModel(String modelPathInProject, EObject rootElement)
 

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/util/java/JavaTestModelsBase.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/util/java/JavaTestModelsBase.xtend
@@ -2,14 +2,26 @@ package tools.vitruv.applications.cbs.commonalities.tests.util.java
 
 import tools.vitruv.applications.cbs.commonalities.tests.util.DomainTestModelsBase
 import tools.vitruv.applications.cbs.commonalities.tests.util.VitruvApplicationTestAdapter
+import tools.vitruv.domains.java.util.JavaModificationUtil
+import org.emftext.language.java.classifiers.ConcreteClassifier
+import org.emftext.language.java.JavaUniquePathConstructor
 
 class JavaTestModelsBase extends DomainTestModelsBase {
-
 	new(VitruvApplicationTestAdapter vitruvApplicationTestAdapter) {
 		super(vitruvApplicationTestAdapter)
 	}
 
 	override protected createModelTester() {
 		return new JavaModelTester(vitruvApplicationTestAdapter)
+	}
+	
+	def referenceJamoppType(Class<?> type) {
+		referenceJamoppType(type.name)
+	}
+	
+	def referenceJamoppType(String fullyQualifiedName) {
+		JavaModificationUtil.createNamespaceClassifierReference(
+			ConcreteClassifier.at(JavaUniquePathConstructor.getClassifierURI(fullyQualifiedName))
+		)
 	}
 }


### PR DESCRIPTION
Together with https://github.com/vitruv-tools/Vitruv-Domains-ComponentBasedSystems/pull/88, this brings the execution time of the Commonalities tests down to 2m58s from 4m59s on my machine.