### PR TITLE
Transformation Fixes

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -970,6 +970,7 @@ routine addRequiredRole(pcm::OperationRequiredRole requiredRole) {
 		val javaClass = retrieve java::Class corresponding to requiredRole.requiringEntity_RequiredRole
 	}
 	action {
+		add correspondence between javaClass and requiredRole
 		// TODO HK this should be partly in the context of the compilation unit
 		val requiredInterfaceImport = create java::ClassifierImport and initialize {
 			addImportToCompilationUnitOfClassifier(requiredInterfaceImport, javaClass, requiredInterface);
@@ -1016,19 +1017,20 @@ routine addParameterAndAssignmentToConstructor(pcm::NamedElement parameterCorres
 reaction DeletedRequiredRole {
 	after element pcm::OperationRequiredRole removed from pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
 	call {
-		removeRequiredRole(oldValue, affectedEObject as RepositoryComponent);
+		removeRequiredRole(oldValue);
 	}
 }
 
-routine removeRequiredRole(pcm::RequiredRole requiredRole, pcm::InterfaceRequiringEntity requiringEntity) {
+routine removeRequiredRole(pcm::RequiredRole requiredRole) {
 	match {
 		val requiredInterfaceImport = retrieve java::ClassifierImport corresponding to requiredRole
 		val requiredInterfaceField = retrieve java::Field corresponding to requiredRole
-		val javaClass = retrieve java::Class corresponding to requiringEntity
+		val javaClass = retrieve java::Class corresponding to requiredRole
 	}
 	action {
 		delete requiredInterfaceImport
 		delete requiredInterfaceField
+		remove correspondence between javaClass and requiredRole
 		call {
 			for (ctor : javaClass.members.filter(typeof(Constructor))) {
 				removeParameterToFieldAssignmentFromConstructor(ctor, requiredRole.entityName);
@@ -1078,7 +1080,7 @@ routine removeCorrespondingParameterFromConstructor(java::Constructor ctor, pcm:
 routine reinitializeOperationRequiredRole(pcm::OperationRequiredRole requiredRole) {
 	action {
 		call {
-			removeRequiredRole(requiredRole, requiredRole.requiringEntity_RequiredRole);
+			removeRequiredRole(requiredRole);
 			addRequiredRole(requiredRole);
 		}
 	}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -348,7 +348,7 @@ routine createComponentImplementation(pcm::RepositoryComponent component) {
 	}
 	action {
 		call {
-			createJavaPackage(component, repositoryPackage, component.entityName, null);
+			createOrFindJavaPackage(component, repositoryPackage, component.entityName, null);
 			createImplementationForComponent(component);
 		}
 	}
@@ -698,8 +698,9 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 	action {
 		val javaPackage = create java::Package and initialize {
 			if (parentPackage !== null) {
-				javaPackage.namespaces += parentPackage.namespaces;
-				javaPackage.namespaces += parentPackage.name;
+				val newNamespaces = new ArrayList(parentPackage.namespaces)
+				newNamespaces += parentPackage.name
+				javaPackage.namespaces += newNamespaces;
 			}
 			javaPackage.name = packageName.toFirstLower;
 			persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage));
@@ -717,13 +718,30 @@ routine renameJavaPackage(pcm::NamedElement sourceElementMappedToPackage, java::
 	}
 	action {
 		update javaPackage {
-			javaPackage.namespaces.clear();
-			if (parentPackage !== null) {
-				javaPackage.namespaces += parentPackage.namespaces;
-				javaPackage.namespaces += parentPackage.name;
+			var modified = false
+			if (parentPackage === null) {
+				if (!javaPackage.namespaces.empty) {
+					modified = true
+				}
+				javaPackage.namespaces.clear()
 			}
-			javaPackage.name = packageName;
-			persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage));
+			
+			if (parentPackage !== null) {
+				val newNamespaces = new ArrayList(parentPackage.namespaces)
+				newNamespaces += parentPackage.name
+				if (javaPackage.namespaces != newNamespaces) {
+					javaPackage.namespaces.clear()
+					javaPackage.namespaces += newNamespaces;
+					modified = true
+				}
+			}
+			if (javaPackage.name != packageName) {
+				javaPackage.name = packageName
+				modified = true	
+			}
+			if (modified) {
+				persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage))
+			}
 		}
 	}
 }
@@ -807,9 +825,10 @@ routine addMissingClassifierCorrespondence(pcm::NamedElement pcmElement, java::C
 routine createCompilationUnit(pcm::NamedElement sourceElementMappedToClass, java::ConcreteClassifier classifier, java::Package containingPackage) {
 	action {
 		val compilationUnit = create java::CompilationUnit and initialize {
-			compilationUnit.namespaces += containingPackage.namespaces;
-			compilationUnit.namespaces += containingPackage.name;
-			compilationUnit.name = classifier.name + ".java";
+			val newNamespaces = new ArrayList(containingPackage.namespaces)
+			newNamespaces += containingPackage.name
+			compilationUnit.namespaces += newNamespaces
+			compilationUnit.name = containingPackage.namespacesAsString + containingPackage.name + "." + classifier.name.toFirstUpper + ".java"
 			compilationUnit.classifiers += classifier;
 			persistProjectRelative(sourceElementMappedToClass, compilationUnit, buildJavaFilePath(compilationUnit));
 		}
@@ -826,14 +845,27 @@ routine renameJavaClassifier(pcm::NamedElement classSourceElement, java::Package
 	}
 	action {
 		update javaClassifier {
-			javaClassifier.name = className.toFirstUpper;
+			if (javaClassifier.name != className.toFirstUpper) {
+				javaClassifier.name = className.toFirstUpper
+			}
 		}
 		update compilationUnit {
-			compilationUnit.name = className.toFirstUpper + ".java";
-			compilationUnit.namespaces.clear;
-			compilationUnit.namespaces += containingPackage.namespaces;
-			compilationUnit.namespaces += containingPackage.name;
-			persistProjectRelative(classSourceElement, compilationUnit, buildJavaFilePath(compilationUnit));
+			var modified = false
+			val newName = containingPackage.namespacesAsString + containingPackage.name + "." + className.toFirstUpper + ".java"
+			if (compilationUnit.name != newName) {
+				compilationUnit.name = newName
+				modified = true
+			}
+			val newNamespaces = new ArrayList(containingPackage.namespaces)
+			newNamespaces += containingPackage.name
+			if (compilationUnit.namespaces != newNamespaces) {
+				compilationUnit.namespaces.clear
+				compilationUnit.namespaces += newNamespaces
+				modified = true
+			}
+			if (modified) {
+				persistProjectRelative(classSourceElement, compilationUnit, buildJavaFilePath(compilationUnit))
+			}
 		}
 	}
 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -26,16 +26,15 @@ import org.palladiosimulator.pcm.repository.CompositeDataType
 import org.palladiosimulator.pcm.repository.OperationInterface
 import org.palladiosimulator.pcm.repository.OperationProvidedRole
 import org.palladiosimulator.pcm.repository.OperationSignature
-import org.palladiosimulator.pcm.repository.RepositoryComponent
 import org.palladiosimulator.pcm.repository.RepositoryPackage
 import org.palladiosimulator.pcm.system.SystemPackage
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
 import static tools.vitruv.applications.pcmjava.util.pcm2java.Pcm2JavaHelper.*
-import static tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 
+import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
 import static extension tools.vitruv.framework.util.bridges.JavaHelper.claimOneOrNone
 
@@ -718,27 +717,13 @@ routine renameJavaPackage(pcm::NamedElement sourceElementMappedToPackage, java::
 	}
 	action {
 		update javaPackage {
-			var modified = false
-			if (parentPackage === null) {
-				if (!javaPackage.namespaces.empty) {
-					modified = true
-				}
-				javaPackage.namespaces.clear()
-			}
-			
+			val newNamespaces = newArrayList 
 			if (parentPackage !== null) {
-				val newNamespaces = new ArrayList(parentPackage.namespaces)
+				newNamespaces += parentPackage.namespaces
 				newNamespaces += parentPackage.name
-				if (javaPackage.namespaces != newNamespaces) {
-					javaPackage.namespaces.clear()
-					javaPackage.namespaces += newNamespaces;
-					modified = true
-				}
 			}
-			if (javaPackage.name != packageName) {
-				javaPackage.name = packageName
-				modified = true	
-			}
+			var modified = javaPackage.updateNamespaces(newNamespaces)
+			modified = javaPackage.updateName(packageName) || modified
 			if (modified) {
 				persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage))
 			}
@@ -845,24 +830,14 @@ routine renameJavaClassifier(pcm::NamedElement classSourceElement, java::Package
 	}
 	action {
 		update javaClassifier {
-			if (javaClassifier.name != className.toFirstUpper) {
-				javaClassifier.name = className.toFirstUpper
-			}
+			javaClassifier.updateName(className.toFirstUpper)
 		}
 		update compilationUnit {
-			var modified = false
-			val newName = containingPackage.namespacesAsString + containingPackage.name + "." + className.toFirstUpper + ".java"
-			if (compilationUnit.name != newName) {
-				compilationUnit.name = newName
-				modified = true
-			}
 			val newNamespaces = new ArrayList(containingPackage.namespaces)
 			newNamespaces += containingPackage.name
-			if (compilationUnit.namespaces != newNamespaces) {
-				compilationUnit.namespaces.clear
-				compilationUnit.namespaces += newNamespaces
-				modified = true
-			}
+			var modified = compilationUnit.updateNamespaces(newNamespaces)
+			val newName = getCompilationUnitName(containingPackage, className.toFirstUpper)
+			modified = compilationUnit.updateName(newName) || modified
 			if (modified) {
 				persistProjectRelative(classSourceElement, compilationUnit, buildJavaFilePath(compilationUnit))
 			}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
@@ -5,7 +5,6 @@ import org.emftext.language.java.members.Constructor
 import org.emftext.language.java.modifiers.ModifiersFactory
 import org.palladiosimulator.pcm.core.composition.AssemblyContext
 import org.palladiosimulator.pcm.repository.BasicComponent
-import org.palladiosimulator.pcm.repository.RepositoryComponent
 import org.palladiosimulator.pcm.system.System
 import tools.vitruv.framework.userinteraction.UserInteractionOptions.WindowModality
 
@@ -169,6 +168,7 @@ routine pcm2javaCommon::addRequiredRole(pcm::OperationRequiredRole requiredRole)
 		val javaClass = retrieve java::Class corresponding to requiredRole.requiringEntity_RequiredRole
 	}
 	action {
+		add correspondence between javaClass and requiredRole
 		// depInject: start
 		val requiredInterfaceImport = create java::ClassifierImport
 		val requiredInterfaceField = create java::Field
@@ -193,7 +193,7 @@ reaction pcm2javaCommon::DeletedRequiredRole {
 	// depInject: slightly different trigger
 	after element pcm::OperationRequiredRole deleted and removed from pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
 	call {
-		removeRequiredRole(oldValue, affectedEObject as RepositoryComponent);
+		removeRequiredRole(oldValue);
 	}
 }
 
@@ -202,7 +202,7 @@ reaction ChangeOperationRequiredRoleEntity {
 	after element replaced at pcm::OperationRequiredRole[requiringEntity_RequiredRole]
 	call {
 		val requiredRole = affectedEObject;
-		removeRequiredRole(requiredRole, oldValue);
+		removeRequiredRole(requiredRole);
 		addRequiredRole(requiredRole);
 	}
 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/src/tools/vitruv/applications/pcmjava/ejbtransformations/pcm2java/Pcm2EjbJava.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/src/tools/vitruv/applications/pcmjava/ejbtransformations/pcm2java/Pcm2EjbJava.reactions
@@ -2,7 +2,6 @@ import org.eclipse.emf.ecore.util.EcoreUtil
 import org.emftext.language.java.modifiers.ModifiersFactory
 import org.palladiosimulator.pcm.repository.BasicComponent
 import org.palladiosimulator.pcm.repository.OperationInterface
-import org.palladiosimulator.pcm.repository.RepositoryComponent
 
 import static tools.vitruv.applications.pcmjava.util.pcm2java.Pcm2JavaHelper.*
 
@@ -152,19 +151,20 @@ reaction pcm2javaCommon::DeletedRequiredRole {
 	// ejb: slightly different trigger
 	after element pcm::OperationRequiredRole deleted and removed from pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
 	call {
-		removeRequiredRole(oldValue, affectedEObject as RepositoryComponent);
+		removeRequiredRole(oldValue);
 	}
 }
 
-routine pcm2javaCommon::removeRequiredRole(pcm::RequiredRole requiredRole, pcm::InterfaceRequiringEntity requiringEntity) {
+routine pcm2javaCommon::removeRequiredRole(pcm::RequiredRole requiredRole) {
 	match {
 		val requiredInterfaceImport = retrieve java::ClassifierImport corresponding to requiredRole
 		val requiredInterfaceField = retrieve java::Field corresponding to requiredRole
-		val javaClass = retrieve java::Class corresponding to requiringEntity
+		val javaClass = retrieve java::Class corresponding to requiredRole
 	}
 	action {
 		delete requiredInterfaceImport
 		delete requiredInterfaceField
+		remove correspondence between javaClass and requiredRole
 		// ejb: removed 'remove-parameter' code
 	}
 }
@@ -174,7 +174,7 @@ reaction ChangeOperationRequiredRoleEntity {
 	after element replaced at pcm::OperationRequiredRole[requiringEntity_RequiredRole]
 	call {
 		val requiredRole = affectedEObject;
-		removeRequiredRole(requiredRole, oldValue);
+		removeRequiredRole(requiredRole);
 		addRequiredRole(requiredRole);
 	}
 }

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/src/tools/vitruv/applications/pcmjava/util/java2pcm/TypeReferenceCorrespondenceHelper.xtend
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/src/tools/vitruv/applications/pcmjava/util/java2pcm/TypeReferenceCorrespondenceHelper.xtend
@@ -16,14 +16,6 @@ import org.emftext.language.java.types.PrimitiveType
 import org.emftext.language.java.types.Short
 import org.emftext.language.java.types.TypeReference
 import org.emftext.language.java.types.Void
-import org.emftext.language.java.types.impl.BooleanImpl
-import org.emftext.language.java.types.impl.ByteImpl
-import org.emftext.language.java.types.impl.CharImpl
-import org.emftext.language.java.types.impl.DoubleImpl
-import org.emftext.language.java.types.impl.FloatImpl
-import org.emftext.language.java.types.impl.IntImpl
-import org.emftext.language.java.types.impl.LongImpl
-import org.emftext.language.java.types.impl.ShortImpl
 import org.palladiosimulator.pcm.core.entity.NamedElement
 import org.palladiosimulator.pcm.repository.CollectionDataType
 import org.palladiosimulator.pcm.repository.CompositeDataType
@@ -32,8 +24,6 @@ import org.palladiosimulator.pcm.repository.PrimitiveDataType
 import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.util.datatypes.ClaimableHashMap
-import tools.vitruv.framework.util.datatypes.ClaimableMap
 
 import static extension tools.vitruv.framework.correspondence.CorrespondenceModelUtil.*
 import tools.vitruv.framework.userinteraction.UserInteractor
@@ -50,38 +40,21 @@ class TypeReferenceCorrespondenceHelper {
 
 	static final Logger logger = Logger.getLogger(TypeReferenceCorrespondenceHelper.simpleName)
 
-	static val ClaimableMap<Class<? extends PrimitiveType>, DataType> primitveTypeMappingMap = new ClaimableHashMap
-
-	private def static initPrimitiveTypeMap() {
-		if (!primitveTypeMappingMap.empty) {
-			return
+	private def static DataType claimPCMDataTypeForJaMoPPPrimitiveType(PrimitiveType primitiveJavaType) {
+		switch primitiveJavaType {
+			Void: null
+			Boolean: PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("BOOL")
+			Byte: PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("BYTE")
+			Char: PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("CHAR")
+			Double: PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("DOUBLE")
+			Int: PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT")
+			Long: PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT")
+			Float: PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("DOUBLE")
+			Short: PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT")
+			default: throw new IllegalStateException("No PCM type for Java type '" + primitiveJavaType.eClass.name + "' defined")
 		}
-		primitveTypeMappingMap.put(Boolean, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("BOOL"))
-		primitveTypeMappingMap.put(BooleanImpl, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("BOOL"))
-		primitveTypeMappingMap.put(Byte, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("BYTE"))
-		primitveTypeMappingMap.put(ByteImpl, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("BYTE"))
-		primitveTypeMappingMap.put(Char, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("CHAR"))
-		primitveTypeMappingMap.put(CharImpl, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("CHAR"))
-		primitveTypeMappingMap.put(Double, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("DOUBLE"))
-		primitveTypeMappingMap.put(DoubleImpl, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("DOUBLE"))
-		primitveTypeMappingMap.put(Int, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT"))
-		primitveTypeMappingMap.put(IntImpl, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT"))
-		primitveTypeMappingMap.put(Long, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT"))
-		primitveTypeMappingMap.put(LongImpl, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT"))
-		primitveTypeMappingMap.put(Float, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("DOUBLE"))
-		primitveTypeMappingMap.put(FloatImpl, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("DOUBLE"))
-		primitveTypeMappingMap.put(Short, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT"))
-		primitveTypeMappingMap.put(ShortImpl, PrimitiveTypesRepositoryLoader.getPrimitiveDataTypes.get("INT"))
 	}
-
-	private synchronized def static DataType claimPCMDataTypeForJaMoPPPrimitiveType(PrimitiveType primitiveType) {
-		if (primitiveType instanceof Void) {
-			return null
-		}
-		initPrimitiveTypeMap()
-		return primitveTypeMappingMap.claimValueForKey(primitiveType.class)
-	}
-
+	
 	def static DataType getCorrespondingPCMDataTypeForTypeReference(TypeReference typeReference,
 		CorrespondenceModel correspondenceModel, UserInteractor userInteractor, Repository repo, long arrayDimension) {
 		var DataType pcmDataType = getDataTypeFromTypeReference(typeReference, correspondenceModel, userInteractor,

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/src/tools/vitruv/applications/pcmjava/util/pcm2java/DataTypeCorrespondenceHelper.xtend
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.util/src/tools/vitruv/applications/pcmjava/util/pcm2java/DataTypeCorrespondenceHelper.xtend
@@ -4,9 +4,6 @@ import org.palladiosimulator.pcm.repository.CollectionDataType
 import org.palladiosimulator.pcm.repository.CompositeDataType
 import org.palladiosimulator.pcm.repository.DataType
 import org.palladiosimulator.pcm.repository.PrimitiveDataType
-import org.palladiosimulator.pcm.repository.PrimitiveTypeEnum
-import tools.vitruv.framework.util.datatypes.ClaimableHashMap
-import tools.vitruv.framework.util.datatypes.ClaimableMap
 import org.apache.log4j.Logger
 import org.emftext.language.java.classifiers.ClassifiersFactory
 import org.emftext.language.java.classifiers.ConcreteClassifier
@@ -18,7 +15,6 @@ import static extension tools.vitruv.framework.correspondence.CorrespondenceMode
 import tools.vitruv.framework.correspondence.CorrespondenceModel
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import static tools.vitruv.domains.java.util.JavaModificationUtil.*
-import org.eclipse.emf.ecore.util.EcoreUtil
 import edu.kit.ipd.sdq.activextendannotations.Utility
 
 /**
@@ -34,29 +30,22 @@ import edu.kit.ipd.sdq.activextendannotations.Utility
  */
 @Utility
 class DataTypeCorrespondenceHelper {
-
 	static final Logger logger = Logger.getLogger(DataTypeCorrespondenceHelper.simpleName)
 
-	static val ClaimableMap<PrimitiveTypeEnum, Type> primitveTypeMappingMap = new ClaimableHashMap<PrimitiveTypeEnum, Type>()
-
-	private def static initPrimitiveTypeMap() {
-		if (!primitveTypeMappingMap.empty) {
-			return
+	static def Type claimJaMoPPTypeForPrimitiveDataType(PrimitiveDataType primitivePcmType) {
+		switch primitivePcmType.type {
+			case BOOL: TypesFactory.eINSTANCE.createBoolean
+			case BYTE: TypesFactory.eINSTANCE.createByte
+			case CHAR: TypesFactory.eINSTANCE.createChar
+			case DOUBLE: TypesFactory.eINSTANCE.createDouble
+			case INT: TypesFactory.eINSTANCE.createInt
+			case LONG: TypesFactory.eINSTANCE.createLong
+			case STRING: { 
+				val stringClassifier = ClassifiersFactory.eINSTANCE.createClass
+				stringClassifier.setName("String")
+				return stringClassifier
+			}
 		}
-		val stringClassifier = ClassifiersFactory.eINSTANCE.createClass
-		stringClassifier.setName("String")
-		primitveTypeMappingMap.put(PrimitiveTypeEnum.BOOL, TypesFactory.eINSTANCE.createBoolean)
-		primitveTypeMappingMap.put(PrimitiveTypeEnum.BYTE, TypesFactory.eINSTANCE.createByte)
-		primitveTypeMappingMap.put(PrimitiveTypeEnum.CHAR, TypesFactory.eINSTANCE.createChar)
-		primitveTypeMappingMap.put(PrimitiveTypeEnum.DOUBLE, TypesFactory.eINSTANCE.createDouble)
-		primitveTypeMappingMap.put(PrimitiveTypeEnum.INT, TypesFactory.eINSTANCE.createInt)
-		primitveTypeMappingMap.put(PrimitiveTypeEnum.LONG, TypesFactory.eINSTANCE.createLong)
-		primitveTypeMappingMap.put(PrimitiveTypeEnum.STRING, stringClassifier)
-	}
-
-	synchronized def static Type claimJaMoPPTypeForPrimitiveDataType(PrimitiveDataType pdt) {
-		initPrimitiveTypeMap()
-		return EcoreUtil.copy(primitveTypeMappingMap.claimValueForKey(pdt.type))
 	}
 
 	static def TypeReference claimUniqueCorrespondingJaMoPPDataTypeReference(DataType dataType,

--- a/bundles/tools.vitruv.applications.cbs.commonalities/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/META-INF/MANIFEST.MF
@@ -15,6 +15,7 @@ Require-Bundle: tools.vitruv.framework.applications,
  tools.vitruv.domains.pcm;visibility:=reexport,
  tools.vitruv.domains.uml;visibility:=reexport,
  tools.vitruv.domains.java;visibility:=reexport,
- edu.kit.ipd.sdq.activextendannotations
+ edu.kit.ipd.sdq.activextendannotations,
+ tools.vitruv.applications.util.temporary
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: tools.vitruv.applications.cbs.commonalities

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaPackageCompilationUnitsOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaPackageCompilationUnitsOperator.xtend
@@ -15,6 +15,7 @@ import static com.google.common.base.Preconditions.*
 import static tools.vitruv.framework.util.XtendAssertHelper.*
 
 import static extension tools.vitruv.extensions.dslruntime.commonalities.helper.IntermediateModelHelper.*
+import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 
 // TODO Some duplication with JavaSubPackagesOperator
 @ReferenceMappingOperator(
@@ -88,11 +89,8 @@ class JavaPackageCompilationUnitsOperator extends AbstractReferenceMappingOperat
 		validateObject(object)
 		val Package package = (container as Package)
 		val CompilationUnit compilationUnit = (object as CompilationUnit)
-		// TODO Only update namespaces if not already matching?
 		logger.trace('''Inserting Java CompilationUnit «compilationUnit» into package '«package.packageString»'.''')
-		compilationUnit.namespaces.clear
-		compilationUnit.namespaces += package.namespaces
-		compilationUnit.namespaces += package.name
+		compilationUnit.updateNamespaces(package)
 
 		val resourceBridge = correspondenceModel.getCorrespondingResourceBridge(compilationUnit)
 		assertTrue(resourceBridge !== null)

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaSubPackagesOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaSubPackagesOperator.xtend
@@ -20,6 +20,8 @@ import static tools.vitruv.framework.util.XtendAssertHelper.*
 import static extension java.nio.file.Files.*
 import static extension tools.vitruv.extensions.dslruntime.commonalities.helper.IntermediateModelHelper.*
 
+import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
+
 @ReferenceMappingOperator(
 	name = 'javaSubPackages',
 	isMultiValued = true,
@@ -92,9 +94,7 @@ class JavaSubPackagesOperator extends AbstractReferenceMappingOperator {
 		val Package subPackage = (object as Package)
 		// TODO Only update namespaces if not already matching?
 		logger.trace('''Inserting Java package '«subPackage.packageString»' into package '«package.packageString»'.''')
-		subPackage.namespaces.clear
-		subPackage.namespaces += package.namespaces
-		subPackage.namespaces += package.name
+		subPackage.updateNamespaces(package)
 
 		val resourceBridge = correspondenceModel.getCorrespondingResourceBridge(subPackage)
 		assertTrue(resourceBridge !== null)

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaVisibilityConditionOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaVisibilityConditionOperator.xtend
@@ -38,8 +38,10 @@ class JavaVisibilityConditionOperator extends AbstractSingleArgumentConditionOpe
 	override enforce() {
 		val modifiers = leftAnnotableAndModifiable.annotationsAndModifiers
 		val newModifiers = modifiers.setVisibility(rightVisibility)
-		modifiers.clear
-		modifiers += newModifiers
+		if (modifiers != newModifiers) {
+			modifiers.clear
+			modifiers += newModifiers
+		}
 	}
 
 	override check() {

--- a/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/pcm2uml/PcmToUml.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/pcm2uml/PcmToUml.reactions
@@ -558,8 +558,10 @@ routine addOperationProvidedRoleInterface(pcm::OperationProvidedRole pcmRole, pc
 	}
 	action {
 		update interfaceRealization {
-			interfaceRealization.suppliers.clear()
-			interfaceRealization.suppliers += umlInterface
+			if (interfaceRealization.suppliers != #[umlInterface]) {
+				interfaceRealization.suppliers.clear()
+				interfaceRealization.suppliers += umlInterface	
+			}
 		}
 	}
 }
@@ -606,8 +608,10 @@ routine addOperationRequiredRoleInterface(pcm::OperationRequiredRole pcmRole, pc
 	}
 	action {
 		update umlUsage {
-			umlUsage.suppliers.clear()
-			umlUsage.suppliers += umlInterface
+			if (umlUsage.suppliers != #[umlInterface]) {
+				umlUsage.suppliers.clear()
+				umlUsage.suppliers += umlInterface	
+			}
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -527,15 +527,15 @@ routine addUmlElementToModelOrPackage(java::CompilationUnit jCompUnit, uml::Clas
 	}
     action {
        call {
-      		val uPackage = if (jCompUnit.namespaces.nullOrEmpty) {
+            val uPackage = if (jCompUnit.namespaces.nullOrEmpty) {
                 uModel
             } else {
                 findUmlPackage(uModel, jCompUnit.namespaces.last)
             }
             
             if (uPackage !== uClassifier.package) {
-            	addUmlElementToPackage(uClassifier, uPackage)
-           	}
+                addUmlElementToPackage(uClassifier, uPackage)
+            }
         }
     }
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -149,9 +149,6 @@ routine potentiallyMoveClass(java::CompilationUnit compUnit) {
 	}
 	action {
 		call {
-			if (umlClass.package !== null) {
-				umlClass.package.packagedElements -= umlClass
-			}
 			addUmlElementToModelOrPackage(compUnit, umlClass)
 		}
 	}
@@ -530,11 +527,15 @@ routine addUmlElementToModelOrPackage(java::CompilationUnit jCompUnit, uml::Clas
 	}
     action {
        call {
-            if (jCompUnit.namespaces.nullOrEmpty) {
-                addUmlElementToPackage(uClassifier, uModel)
+      		val uPackage = if (jCompUnit.namespaces.nullOrEmpty) {
+                uModel
             } else {
-                addUmlElementToPackage(uClassifier, findUmlPackage(uModel, jCompUnit.namespaces.last))
+                findUmlPackage(uModel, jCompUnit.namespaces.last)
             }
+            
+            if (uPackage !== uClassifier.package) {
+            	addUmlElementToPackage(uClassifier, uPackage)
+           	}
         }
     }
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -34,7 +34,7 @@ reaction UmlClassCreated {
     after element uml::Class created and inserted in uml::Package[packagedElement]
     call createOrFindJavaClass(newValue)
 }
-
+	
 routine createOrFindJavaClass(uml::Classifier umlClassifier) {
     match{
         require absence of java::Class corresponding to umlClassifier
@@ -98,7 +98,7 @@ routine createJavaCompilationUnit(uml::Classifier umlClassifier, java::ConcreteC
         }
         update jPackage {
             jPackage.ifPresent [
-				compilationUnits += javaCompilationUnit
+                compilationUnits += javaCompilationUnit
             ]
         }
         add correspondence between umlClassifier and javaCompilationUnit
@@ -152,18 +152,17 @@ routine renameJavaClassifier(uml::Classifier umlClassifier) {
             javaClassifier.name = umlClassifier.name
         }
         update javaCompilationUnit {
-        	var modified = false
-			modified = javaCompilationUnit.updateNamespaces(jPackage)
-			val newName = getCompilationUnitName(jPackage, javaClassifier.name)
+            var modified = javaCompilationUnit.updateNamespaces(jPackage)
+            val newName = getCompilationUnitName(jPackage, javaClassifier.name)
             modified = javaCompilationUnit.updateName(newName) || modified
             if (modified) {
-            	persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit));
+                persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit));
             }
         }
         call jPackage.ifPresent[
-        	if (!compilationUnits.contains(javaCompilationUnit)) {
-				compilationUnits += javaCompilationUnit
-			}
+            if (!compilationUnits.contains(javaCompilationUnit)) {
+                compilationUnits += javaCompilationUnit
+            }
         ]
     }
 }
@@ -599,28 +598,28 @@ routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
     }
     action {
         call {
-        	var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList)
-        	modified = jPackage.updateName(uPackage.name) || modified 
+            var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList)
+            modified = jPackage.updateName(uPackage.name) || modified 
             if (modified) {
-            	persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
+                persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
                 for (compUnit : jPackage.compilationUnits) {
                     changePackageOfJavaCompilationUnit(jPackage, compUnit, uNamespace)
                 }
-	            // TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
-            	for (nestedPackage : uPackage.nestedPackages) {
-	                renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
-            	}
+                // TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
+                for (nestedPackage : uPackage.nestedPackages) {
+                    renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
+                }
             }
-		}
+        }
     }
 }
 
 routine changePackageOfJavaCompilationUnit(java::Package jPackage, java::CompilationUnit jCompUnit, uml::Namespace uNamespace) {
     action {
         update jCompUnit {
-        	if (jCompUnit.updateNamespaces(jPackage)) {
-        		persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))	
-        	}
+            if (jCompUnit.updateNamespaces(jPackage)) {
+                persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))	
+            }
         }
     }
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -90,17 +90,16 @@ routine createJavaCompilationUnit(uml::Classifier umlClassifier, java::ConcreteC
     }
     action {
         val javaCompilationUnit = create java::CompilationUnit and initialize {
-            if (jPackage.present) {
-                javaCompilationUnit.namespaces += jPackage.get.javaPackageAsStringList
-            }
-            javaCompilationUnit.name = jClassifier.name + ".java";
-            javaCompilationUnit.classifiers += jClassifier;
-            persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit));
+            javaCompilationUnit.updateNamespaces(jPackage)
+            val name = getCompilationUnitName(jPackage, jClassifier.name)
+            javaCompilationUnit.updateName(name)
+            javaCompilationUnit.classifiers += jClassifier
+            persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit))
         }
-        call {
-            if (jPackage.present) {
-                jPackage.get.compilationUnits += javaCompilationUnit
-            }
+        update jPackage {
+            jPackage.ifPresent [
+				compilationUnits += javaCompilationUnit
+            ]
         }
         add correspondence between umlClassifier and javaCompilationUnit
     }
@@ -120,18 +119,18 @@ routine moveJavaClassifier(uml::Classifier umlClassifier, uml::Package umlPackag
 	}
 	action {
 		update javaCompilationUnit {
-			javaCompilationUnit.namespaces.clear
-			javaPackage.ifPresent [
-				javaCompilationUnit.namespaces += javaPackageAsStringList
-			]
-			//TODO: updating the compilation unit's name should not be needed 
-			//it is currently necessary as the name is incorrectly resolved to <oldPackageName>.<correctName> after the classifier got removed from its old package
-			javaCompilationUnit.name = javaClassifier.name + ".java"
-			persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit));
+			var modified = javaCompilationUnit.updateNamespaces(javaPackage)
+			val newName = getCompilationUnitName(javaPackage, javaClassifier.name)
+			modified = javaCompilationUnit.updateName(newName) || modified
+			if (modified) {
+				persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit));
+			}
 			
 		}
 		call javaPackage.ifPresent [
-			compilationUnits += javaCompilationUnit
+			if (!compilationUnits.contains(javaCompilationUnit)) {
+				compilationUnits += javaCompilationUnit
+			}
 		]
     }
 }
@@ -150,17 +149,22 @@ routine renameJavaClassifier(uml::Classifier umlClassifier) {
     }
     action {
         update javaClassifier {
-            javaClassifier.name = umlClassifier.name;
+            javaClassifier.name = umlClassifier.name
         }
         update javaCompilationUnit {
-            if (jPackage.present) {
-                javaCompilationUnit.namespaces.clear();
-                javaCompilationUnit.namespaces += jPackage.get.javaPackageAsStringList
+        	var modified = false
+			modified = javaCompilationUnit.updateNamespaces(jPackage)
+			val newName = getCompilationUnitName(jPackage, javaClassifier.name)
+            modified = javaCompilationUnit.updateName(newName) || modified
+            if (modified) {
+            	persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit));
             }
-            javaCompilationUnit.name = umlClassifier.name + ".java";
-            persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit));
         }
-        call jPackage.ifPresent[compilationUnits += javaCompilationUnit]
+        call jPackage.ifPresent[
+        	if (!compilationUnits.contains(javaCompilationUnit)) {
+				compilationUnits += javaCompilationUnit
+			}
+        ]
     }
 }
 
@@ -594,32 +598,29 @@ routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
         check uPackage.name != jPackage.name || uPackage.umlParentNamespaceAsStringList != jPackage.namespaces
     }
     action {
-        update jPackage {
-            jPackage.namespaces.clear
-            jPackage.namespaces += uPackage.umlParentNamespaceAsStringList
-            jPackage.name = uPackage.name
-            persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
-        }
         call {
-            if (uPackage.name != jPackage.name) {
+        	var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList)
+        	modified = jPackage.updateName(uPackage.name) || modified 
+            if (modified) {
+            	persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
                 for (compUnit : jPackage.compilationUnits) {
                     changePackageOfJavaCompilationUnit(jPackage, compUnit, uNamespace)
                 }
+	            // TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
+            	for (nestedPackage : uPackage.nestedPackages) {
+	                renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
+            	}
             }
-            // TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
-            for (nestedPackage : uPackage.nestedPackages) {
-                renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
-            }
-        }
+		}
     }
 }
 
 routine changePackageOfJavaCompilationUnit(java::Package jPackage, java::CompilationUnit jCompUnit, uml::Namespace uNamespace) {
     action {
         update jCompUnit {
-            jCompUnit.namespaces.clear
-            jCompUnit.namespaces += jPackage.javaPackageAsStringList
-            persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))
+        	if (jCompUnit.updateNamespaces(jPackage)) {
+        		persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))	
+        	}
         }
     }
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -17,6 +17,7 @@ import static extension tools.vitruv.applications.util.temporary.uml.UmlClassifi
 import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import static extension tools.vitruv.framework.util.bridges.JavaHelper.claimOneOrNone
+import static java.util.List.copyOf
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -602,11 +603,11 @@ routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
             modified = jPackage.updateName(uPackage.name) || modified 
             if (modified) {
                 persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
-                for (compUnit : jPackage.compilationUnits) {
+                for (compUnit : copyOf(jPackage.compilationUnits)) {
                     changePackageOfJavaCompilationUnit(jPackage, compUnit, uNamespace)
                 }
                 // TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
-                for (nestedPackage : uPackage.nestedPackages) {
+                for (nestedPackage : copyOf(uPackage.nestedPackages)) {
                     renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
                 }
             }

--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaContainerAndClassifierUtil.xtend
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaContainerAndClassifierUtil.xtend
@@ -29,6 +29,9 @@ import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
+import java.util.Optional
+import org.emftext.language.java.commons.NamespaceAwareElement
+import static java.util.Collections.emptyList
 
 /**
  * Class for java classifier, package and compilation unit util functions
@@ -277,4 +280,42 @@ class JavaContainerAndClassifierUtil {
     def static String getLastPackageName(String packageName) { // TODO TS technically not depending on Java domain
         return packageName?.substring(packageName.indexOf('.') + 1)
     }
+    
+    def static String getCompilationUnitName(Package containingPackage, String className) {
+    	'''«IF containingPackage !== null»«containingPackage.namespacesAsString»«containingPackage.name».«ENDIF»«className».java'''
+    }
+    
+    def static String getCompilationUnitName(Optional<Package> containingPackage, String className) {
+    	getCompilationUnitName(if (containingPackage.present) containingPackage.get else null, className)
+    }
+    
+    def static boolean updateNamespaces(NamespaceAwareElement elementToChange, List<String> newNamespaces) {
+		if (newNamespaces != elementToChange.namespaces) {
+			elementToChange.namespaces.clear
+			elementToChange.namespaces += newNamespaces
+			return true
+		}
+		return false
+    }
+    
+    def static boolean updateNamespaces(NamespaceAwareElement elementToChange, Optional<Package> containingPackage) {
+    	if (containingPackage.present) {
+    		elementToChange.updateNamespaces(containingPackage.get)
+    	} else {
+    		elementToChange.updateNamespaces(emptyList)
+    	}
+    }
+    
+    def static boolean updateNamespaces(NamespaceAwareElement elementToChange, Package containingPackage) {
+   		return elementToChange.updateNamespaces(containingPackage.javaPackageAsStringList)
+    }
+    
+    def static boolean updateName(NamedElement elementToChange, String newName) {
+    	if (newName != elementToChange.name) {
+    		elementToChange.name = newName
+    		return true
+    	}
+    	return false
+    }
+    
 }

--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaContainerAndClassifierUtil.xtend
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaContainerAndClassifierUtil.xtend
@@ -41,281 +41,285 @@ import static java.util.Collections.emptyList
 @Utility
 class JavaContainerAndClassifierUtil {
 
-    /**
-     * Creates and return a  new java class with the given name, visibility and modifiers
-     * The new class is not contained in a compilation unit.
-     * @param name the name of the class
-     * @param visibility the visibility of the class
-     * @param abstr if the class should be abstract
-     * @param fin if the class should be final
-     * @return the new class with the given attributes
-     */
-    def static createJavaClass(String name, JavaVisibility visibility, boolean abstr, boolean fin) {
-        val jClass = ClassifiersFactory.eINSTANCE.createClass
-        setName(jClass, name)
-        setJavaVisibilityModifier(jClass, visibility)
-        setAbstract(jClass, abstr)
-        setFinal(jClass, fin)
-        return jClass
-    }
+	/**
+	 * Creates and return a  new java class with the given name, visibility and modifiers
+	 * The new class is not contained in a compilation unit.
+	 * @param name the name of the class
+	 * @param visibility the visibility of the class
+	 * @param abstr if the class should be abstract
+	 * @param fin if the class should be final
+	 * @return the new class with the given attributes
+	 */
+	def static createJavaClass(String name, JavaVisibility visibility, boolean abstr, boolean fin) {
+		val jClass = ClassifiersFactory.eINSTANCE.createClass
+		setName(jClass, name)
+		setJavaVisibilityModifier(jClass, visibility)
+		setAbstract(jClass, abstr)
+		setFinal(jClass, fin)
+		return jClass
+	}
 
-    /**
-     * Creates a new java package
-     * @param name the name of the new package
-     * @param containingPackage the super package of the new package or null if it is the default package
-     * @return the new package
-     */
-    def static createJavaPackage(String name, Package containingPackage) {
-        val jPackage = ContainersFactory.eINSTANCE.createPackage
-        setName(jPackage, name)
-        jPackage.namespaces += getJavaPackageAsStringList(containingPackage)
-        return jPackage
-    }
+	/**
+	 * Creates a new java package
+	 * @param name the name of the new package
+	 * @param containingPackage the super package of the new package or null if it is the default package
+	 * @return the new package
+	 */
+	def static createJavaPackage(String name, Package containingPackage) {
+		val jPackage = ContainersFactory.eINSTANCE.createPackage
+		setName(jPackage, name)
+		jPackage.namespaces += getJavaPackageAsStringList(containingPackage)
+		return jPackage
+	}
 
-    /**
-     * Creates a new java interface with the given name and list of super interfaces
-     * The created interface is not contained in a compilation unit.
-     * @param name the name of the interface
-     * @param superInterfaces the superinterfaces of the interface
-     * @return the new interface
-     */
-    def static createJavaInterface(String name, List<Interface> superInterfaces) {
-        val jInterface = ClassifiersFactory.eINSTANCE.createInterface
-        setName(jInterface, name)
-        jInterface.makePublic
-        if (!superInterfaces.nullOrEmpty) {
-            jInterface.extends.addAll(createNamespaceReferenceFromList(superInterfaces))
-        }
-        return jInterface
-    }
+	/**
+	 * Creates a new java interface with the given name and list of super interfaces
+	 * The created interface is not contained in a compilation unit.
+	 * @param name the name of the interface
+	 * @param superInterfaces the superinterfaces of the interface
+	 * @return the new interface
+	 */
+	def static createJavaInterface(String name, List<Interface> superInterfaces) {
+		val jInterface = ClassifiersFactory.eINSTANCE.createInterface
+		setName(jInterface, name)
+		jInterface.makePublic
+		if (!superInterfaces.nullOrEmpty) {
+			jInterface.extends.addAll(createNamespaceReferenceFromList(superInterfaces))
+		}
+		return jInterface
+	}
 
-    /**
-     * Creats a new java enum with the given properties
-     * The created Enum is not contained in a compilationunit.
-     * @param name the name of the enum
-     * @param visibility the visibility of the enum
-     * @param constantsList list of enum constants for the enum
-     * @return the new enum
-     */
-    def static createJavaEnum(String name, JavaVisibility visibility, List<EnumConstant> constantsList) {
-        val jEnum = ClassifiersFactory.eINSTANCE.createEnumeration
-        setName(jEnum, name)
-        setJavaVisibilityModifier(jEnum, visibility)
-        addEnumConstantIfNotNull(jEnum, constantsList)
-        return jEnum
-    }
+	/**
+	 * Creats a new java enum with the given properties
+	 * The created Enum is not contained in a compilationunit.
+	 * @param name the name of the enum
+	 * @param visibility the visibility of the enum
+	 * @param constantsList list of enum constants for the enum
+	 * @return the new enum
+	 */
+	def static createJavaEnum(String name, JavaVisibility visibility, List<EnumConstant> constantsList) {
+		val jEnum = ClassifiersFactory.eINSTANCE.createEnumeration
+		setName(jEnum, name)
+		setJavaVisibilityModifier(jEnum, visibility)
+		addEnumConstantIfNotNull(jEnum, constantsList)
+		return jEnum
+	}
 
-    /**
-     * Add constantList to the enum constants of the given jEnum if constantsList is not null or empty
-     * 
-     */
-    def static addEnumConstantIfNotNull(Enumeration jEnum, List<EnumConstant> constantsList) {
-        if (!constantsList.nullOrEmpty) {
-            jEnum.constants.addAll(constantsList)
-        }
-    }
+	/**
+	 * Add constantList to the enum constants of the given jEnum if constantsList is not null or empty
+	 * 
+	 */
+	def static addEnumConstantIfNotNull(Enumeration jEnum, List<EnumConstant> constantsList) {
+		if (!constantsList.nullOrEmpty) {
+			jEnum.constants.addAll(constantsList)
+		}
+	}
 
-    /**
-     * Creates a java compilation unit with the given naem
-     * The method automatically sets the .java FileExtension for the compilation unit name
-     * There are no classifiers in the compilation unit yet.
-     * @param nameWithoutFileExtension the name without .java file extension
-     * @return the new compilation unit
-     */
-    def static createEmptyCompilationUnit(String nameWithoutFileExtension) {
-        val cu = ContainersFactory.eINSTANCE.createCompilationUnit
-        cu.name = nameWithoutFileExtension + ".java"
-        return cu
-    }
+	/**
+	 * Creates a java compilation unit with the given naem
+	 * The method automatically sets the .java FileExtension for the compilation unit name
+	 * There are no classifiers in the compilation unit yet.
+	 * @param nameWithoutFileExtension the name without .java file extension
+	 * @return the new compilation unit
+	 */
+	def static createEmptyCompilationUnit(String nameWithoutFileExtension) {
+		val cu = ContainersFactory.eINSTANCE.createCompilationUnit
+		cu.name = nameWithoutFileExtension + ".java"
+		return cu
+	}
 
-    def static createJavaCompilationUnitWithClassifierInPackage(ConcreteClassifier jClassifier, Package jPackage) {
-        val compUnit = createEmptyCompilationUnit(jClassifier.name)
-        compUnit.classifiers += jClassifier
-        compUnit.namespaces.addAll(getJavaPackageAsStringList(jPackage))
-        return compUnit
-    }
+	def static createJavaCompilationUnitWithClassifierInPackage(ConcreteClassifier jClassifier, Package jPackage) {
+		val compUnit = createEmptyCompilationUnit(jClassifier.name)
+		compUnit.classifiers += jClassifier
+		compUnit.namespaces.addAll(getJavaPackageAsStringList(jPackage))
+		return compUnit
+	}
 
-    /**
-     * Removes all classifiers of the iterator which has the same name as the given classifier classif
-     * @param iter iterator of typreferences
-     * @param classif classifier that shoud be removed from the iterator
-     */
-    def static removeClassifierFromIterator(Iterator<TypeReference> iter, ConcreteClassifier classif) {
-        while (iter.hasNext) {
-            val type = (iter.next as NamespaceClassifierReference).classifierReferences.head.target
-            if (classif.name.equals(type.name)) {
-                iter.remove
-            }
-        }
-    }
+	/**
+	 * Removes all classifiers of the iterator which has the same name as the given classifier classif
+	 * @param iter iterator of typreferences
+	 * @param classif classifier that shoud be removed from the iterator
+	 */
+	def static removeClassifierFromIterator(Iterator<TypeReference> iter, ConcreteClassifier classif) {
+		while (iter.hasNext) {
+			val type = (iter.next as NamespaceClassifierReference).classifierReferences.head.target
+			if (classif.name.equals(type.name)) {
+				iter.remove
+			}
+		}
+	}
 
-    /**
-     * For org.example.package it will return [org, example, package]
-     * Returns empty list if jPackage is the default package.
-     */
-    def static getJavaPackageAsStringList(Package jPackage) {
-        if (jPackage === null || jPackage.name.nullOrEmpty) { // Defaultpackage
-            return Collections.<String>emptyList()
-        }
-        val packageStringList = new ArrayList<String>()
-        packageStringList.addAll(jPackage.namespaces)
-        packageStringList += jPackage.name
-        return packageStringList
-    }
+	/**
+	 * For org.example.package it will return [org, example, package]
+	 * Returns empty list if jPackage is the default package.
+	 */
+	def static getJavaPackageAsStringList(Package jPackage) {
+		if (jPackage === null || jPackage.name.nullOrEmpty) { // Defaultpackage
+			return Collections.<String>emptyList()
+		}
+		val packageStringList = new ArrayList<String>()
+		packageStringList.addAll(jPackage.namespaces)
+		packageStringList += jPackage.name
+		return packageStringList
+	}
 
-    def static Field getJavaAttributeByName(Class jClass, String attributeName) {
-        val candidates = jClass.members.filter(Field)
-        for (member : candidates) {
-            if (member.name == attributeName) {
-                return member
-            }
-        }
-        return null
-    }
+	def static Field getJavaAttributeByName(Class jClass, String attributeName) {
+		val candidates = jClass.members.filter(Field)
+		for (member : candidates) {
+			if (member.name == attributeName) {
+				return member
+			}
+		}
+		return null
+	}
 
-    def static Constructor getFirstJavaConstructor(Class jClass) {
-        val candidates = jClass.members.filter(Constructor)
-        if (!candidates.nullOrEmpty) {
-            return candidates.head
-        } else {
-            return null
-        }
-    }
+	def static Constructor getFirstJavaConstructor(Class jClass) {
+		val candidates = jClass.members.filter(Constructor)
+		if (!candidates.nullOrEmpty) {
+			return candidates.head
+		} else {
+			return null
+		}
+	}
 
-    def static removeJavaClassifierFromPackage(Package jPackage, ConcreteClassifier jClassifier) {
-        val iter = jPackage.compilationUnits.iterator
-        while (iter.hasNext) {
-            if (iter.next.name.equals(jClassifier.name)) {
-                iter.remove
-            }
-        }
-    }
+	def static removeJavaClassifierFromPackage(Package jPackage, ConcreteClassifier jClassifier) {
+		val iter = jPackage.compilationUnits.iterator
+		while (iter.hasNext) {
+			if (iter.next.name.equals(jClassifier.name)) {
+				iter.remove
+			}
+		}
+	}
 
-    def static File createPackageInfo(String directory, String packageName) {
-        val file = new File(directory + "/package-info.java")
-        file.createNewFile
-        val writer = new PrintWriter(file)
-        writer.println("package " + packageName + "")
-        writer.close
-        return file
-    }
+	def static File createPackageInfo(String directory, String packageName) {
+		val file = new File(directory + "/package-info.java")
+		file.createNewFile
+		val writer = new PrintWriter(file)
+		writer.println("package " + packageName + "")
+		writer.close
+		return file
+	}
 
-    /**
-     * Finds and retrieves a specific {@link ConcreteClassifier} that is contained in a {@link Package}.
-     * The {@link ConcreteClassifier} is found by name, ignoring the capitalization of the first letter.
-     * @param name is the name of the desired {@link ConcreteClassifier}, the first letter can be upper and lower case.
-     * @param javaPackage is the specific {@link Package} to search in.
-     * @param classifierType specifies the class of the desired {@link ConcreteClassifier}, e.g. {@link Interface}.
-     * @return the found classifier, or null if there is no matching classifer.
-     * @throws IllegalStateException if there are multiple classifers in the package with a matching name.
-     */
-    static def <T extends ConcreteClassifier> T findClassifier(String name, Package javaPackage, java.lang.Class<T> classifierType) {
-        val matchingClassifiers = javaPackage.compilationUnits.map[it.classifiers].flatten.filter(classifierType).filter[it.name.toFirstUpper == name.toFirstUpper]
-        if (matchingClassifiers.size > 1) throw new IllegalStateException("Multiple matching classifers were found: " + matchingClassifiers)
-        return matchingClassifiers.head
-    }
-    
-    def static Package getContainingPackageFromCorrespondenceModel(Classifier classifier,
-        CorrespondenceModel correspondenceModel) {
-        var namespace = classifier.containingCompilationUnit.namespacesAsString
-        if (namespace.endsWith("$") || namespace.endsWith(".")) {
-            namespace = namespace.substring(0, namespace.length - 1)
-        }
-        val finalNamespace = namespace
-        var Set<Package> packagesWithCorrespondences = correspondenceModel.
-            getAllEObjectsOfTypeInCorrespondences(Package)
-        val packagesWithNamespace = packagesWithCorrespondences.filter [ pack |
-            finalNamespace.equals(pack.namespacesAsString + pack.name)
-        ]
-        if (null !== packagesWithNamespace && 0 < packagesWithNamespace.size &&
-            null !== packagesWithNamespace.iterator.next) {
-            return packagesWithNamespace.iterator.next
-        }
-        return null
-    }
+	/**
+	 * Finds and retrieves a specific {@link ConcreteClassifier} that is contained in a {@link Package}.
+	 * The {@link ConcreteClassifier} is found by name, ignoring the capitalization of the first letter.
+	 * @param name is the name of the desired {@link ConcreteClassifier}, the first letter can be upper and lower case.
+	 * @param javaPackage is the specific {@link Package} to search in.
+	 * @param classifierType specifies the class of the desired {@link ConcreteClassifier}, e.g. {@link Interface}.
+	 * @return the found classifier, or null if there is no matching classifer.
+	 * @throws IllegalStateException if there are multiple classifers in the package with a matching name.
+	 */
+	static def <T extends ConcreteClassifier> T findClassifier(String name, Package javaPackage,
+		java.lang.Class<T> classifierType) {
+		val matchingClassifiers = javaPackage.compilationUnits.map[it.classifiers].flatten.filter(classifierType).filter [
+			it.name.toFirstUpper == name.toFirstUpper
+		]
+		if(matchingClassifiers.size > 1) throw new IllegalStateException("Multiple matching classifers were found: " +
+			matchingClassifiers)
+		return matchingClassifiers.head
+	}
 
-    /**
-     * Returns the namespace of the compilation unit where the given object is directly or indirectly contained
-     */
-    def static dispatch List<String> getJavaNamespace(CompilationUnit compUnit) {
-        return compUnit.namespaces
-    }
+	def static Package getContainingPackageFromCorrespondenceModel(Classifier classifier,
+		CorrespondenceModel correspondenceModel) {
+		var namespace = classifier.containingCompilationUnit.namespacesAsString
+		if (namespace.endsWith("$") || namespace.endsWith(".")) {
+			namespace = namespace.substring(0, namespace.length - 1)
+		}
+		val finalNamespace = namespace
+		var Set<Package> packagesWithCorrespondences = correspondenceModel.
+			getAllEObjectsOfTypeInCorrespondences(Package)
+		val packagesWithNamespace = packagesWithCorrespondences.filter [ pack |
+			finalNamespace.equals(pack.namespacesAsString + pack.name)
+		]
+		if (null !== packagesWithNamespace && 0 < packagesWithNamespace.size &&
+			null !== packagesWithNamespace.iterator.next) {
+			return packagesWithNamespace.iterator.next
+		}
+		return null
+	}
 
-    def static dispatch List<String> getJavaNamespace(ConcreteClassifier classifier) {
-        return getJavaNamespace(classifier.eContainer as CompilationUnit)
-    }
+	/**
+	 * Returns the namespace of the compilation unit where the given object is directly or indirectly contained
+	 */
+	def static dispatch List<String> getJavaNamespace(CompilationUnit compUnit) {
+		return compUnit.namespaces
+	}
 
-    def static dispatch List<String> getJavaNamespace(NamedElement element) {
-        throw new IllegalArgumentException("Unsupported type for retrieving namespace: " + element)
-    }
+	def static dispatch List<String> getJavaNamespace(ConcreteClassifier classifier) {
+		return getJavaNamespace(classifier.eContainer as CompilationUnit)
+	}
 
-    def static dispatch List<String> getJavaNamespace(Void element) {
-        throw new IllegalArgumentException("Can not retrieve namespace for " + element)
-    }
+	def static dispatch List<String> getJavaNamespace(NamedElement element) {
+		throw new IllegalArgumentException("Unsupported type for retrieving namespace: " + element)
+	}
 
-    def static dispatch CompilationUnit getContainingCompilationUnit(ConcreteClassifier classifier) {
-        return classifier.eContainer as CompilationUnit
-    }
+	def static dispatch List<String> getJavaNamespace(Void element) {
+		throw new IllegalArgumentException("Can not retrieve namespace for " + element)
+	}
 
-    def static dispatch CompilationUnit getContainingCompilationUnit(Member mem) {
-        return getContainingCompilationUnit(mem.eContainer as ConcreteClassifier)
-    }
+	def static dispatch CompilationUnit getContainingCompilationUnit(ConcreteClassifier classifier) {
+		return classifier.eContainer as CompilationUnit
+	}
 
-    def static dispatch CompilationUnit getContainingCompilationUnit(Parameter param) {
-        return getContainingCompilationUnit(param.eContainer as Member)
-    }
+	def static dispatch CompilationUnit getContainingCompilationUnit(Member mem) {
+		return getContainingCompilationUnit(mem.eContainer as ConcreteClassifier)
+	}
 
-    def static dispatch CompilationUnit getContainingCompilationUnit(NamedElement element) {
-        throw new IllegalArgumentException("Unsupported type for retrieving compilation unit: " + element)
-    }
+	def static dispatch CompilationUnit getContainingCompilationUnit(Parameter param) {
+		return getContainingCompilationUnit(param.eContainer as Member)
+	}
 
-    def static dispatch CompilationUnit getContainingCompilationUnit(Void element) {
-        throw new IllegalArgumentException("Can not retrieve compilation unit for " + element)
-    }
+	def static dispatch CompilationUnit getContainingCompilationUnit(NamedElement element) {
+		throw new IllegalArgumentException("Unsupported type for retrieving compilation unit: " + element)
+	}
 
-    def static String getRootPackageName(String packageName) { // TODO TS technically not depending on Java domain
-        return packageName?.split("\\.")?.get(0)
-    }
+	def static dispatch CompilationUnit getContainingCompilationUnit(Void element) {
+		throw new IllegalArgumentException("Can not retrieve compilation unit for " + element)
+	}
 
-    def static String getLastPackageName(String packageName) { // TODO TS technically not depending on Java domain
-        return packageName?.substring(packageName.indexOf('.') + 1)
-    }
-    
-    def static String getCompilationUnitName(Package containingPackage, String className) {
-    	'''«IF containingPackage !== null»«containingPackage.namespacesAsString»«containingPackage.name».«ENDIF»«className».java'''
-    }
-    
-    def static String getCompilationUnitName(Optional<Package> containingPackage, String className) {
-    	getCompilationUnitName(if (containingPackage.present) containingPackage.get else null, className)
-    }
-    
-    def static boolean updateNamespaces(NamespaceAwareElement elementToChange, List<String> newNamespaces) {
+	def static String getRootPackageName(String packageName) { // TODO TS technically not depending on Java domain
+		return packageName?.split("\\.")?.get(0)
+	}
+
+	def static String getLastPackageName(String packageName) { // TODO TS technically not depending on Java domain
+		return packageName?.substring(packageName.indexOf('.') + 1)
+	}
+
+	def static String getCompilationUnitName(Package containingPackage, String className) {
+		'''«IF containingPackage !== null»«containingPackage.namespacesAsString»«containingPackage.name».«ENDIF»«className».java'''
+	}
+
+	def static String getCompilationUnitName(Optional<Package> containingPackage, String className) {
+		getCompilationUnitName(if(containingPackage.present) containingPackage.get else null, className)
+	}
+
+	def static boolean updateNamespaces(NamespaceAwareElement elementToChange, List<String> newNamespaces) {
 		if (newNamespaces != elementToChange.namespaces) {
 			elementToChange.namespaces.clear
 			elementToChange.namespaces += newNamespaces
 			return true
 		}
 		return false
-    }
-    
-    def static boolean updateNamespaces(NamespaceAwareElement elementToChange, Optional<Package> containingPackage) {
-    	if (containingPackage.present) {
-    		elementToChange.updateNamespaces(containingPackage.get)
-    	} else {
-    		elementToChange.updateNamespaces(emptyList)
-    	}
-    }
-    
-    def static boolean updateNamespaces(NamespaceAwareElement elementToChange, Package containingPackage) {
-   		return elementToChange.updateNamespaces(containingPackage.javaPackageAsStringList)
-    }
-    
-    def static boolean updateName(NamedElement elementToChange, String newName) {
-    	if (newName != elementToChange.name) {
-    		elementToChange.name = newName
-    		return true
-    	}
-    	return false
-    }
-    
+	}
+
+	def static boolean updateNamespaces(NamespaceAwareElement elementToChange, Optional<Package> containingPackage) {
+		if (containingPackage.present) {
+			elementToChange.updateNamespaces(containingPackage.get)
+		} else {
+			elementToChange.updateNamespaces(emptyList)
+		}
+	}
+
+	def static boolean updateNamespaces(NamespaceAwareElement elementToChange, Package containingPackage) {
+		return elementToChange.updateNamespaces(containingPackage.javaPackageAsStringList)
+	}
+
+	def static boolean updateName(NamedElement elementToChange, String newName) {
+		if (newName != elementToChange.name) {
+			elementToChange.name = newName
+			return true
+		}
+		return false
+	}
+
 }

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/SystemConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/SystemConceptTest.xtend
@@ -111,7 +111,7 @@ class SystemConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		]
 		propagate
 
-		var umlSystemPkg = umlModel.createNestedPackage(SYSTEM_NAME)
+		var umlSystemPkg = umlModel.createNestedPackage(SYSTEM_NAME.toFirstLower)
 
 		userInteraction.addNextSingleSelection(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__SYSTEM)
 		userInteraction.addNextSingleSelection(Java2PcmUserSelection.SELECT_SYSTEM.selection)


### PR DESCRIPTION
Fixes several shortcomings of the diverse transformations.

- Matches an existing package realizing a component in PCM->Java. By now, a package was created again, which did not lead to a failure because resolution was performed by TUIDs which are the same. Moving to UUIDs, this implementation leads to a failure.
- Properly sets the name of a `CompilationUnit`. In several cases, we set the `name` to the file name instead of the fully qualified name. Although JaMoPP accepts and properly serializes that, JaMoPP actually loads `CompilationUnit`s with a fully qualified `name`, such that several checks fail or workarounds have been built.
- Checks Java namespaces for equivalence before removing and inserting the same ones.
- Fixes a mistakes in the test for PCM systems transformed to Java, which created a package starting with an uppercase letter.

:warning: Depends on https://github.com/vitruv-tools/Vitruv-Domains-ComponentBasedSystems/pull/90