### PR TITLE
Reenable Test Case

### DIFF
--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/RepositoryConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/RepositoryConceptTest.xtend
@@ -12,7 +12,6 @@ import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
 
 import static org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Disabled
 import java.nio.file.Path
 import org.emftext.language.java.containers.ContainersPackage
 
@@ -153,7 +152,6 @@ class RepositoryConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		umlModel.checkNumberOfJavaPackages
 	}
 
-	@Disabled("Some system-specific bug to be investigated")
 	@Test
 	def void testDeleteRepositoryConcept_PCM() {
 		var pcmRepository = RepositoryFactory.eINSTANCE.createRepository() => [


### PR DESCRIPTION
This PR reenables the test case disabled in #131. The reason for failing seems to related to system/environment specifics. We investigate the cause and how to solve it in this PR.