### PR TITLE
Remove Transactional Change Executions

### DIFF
--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/FieldMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/FieldMappingTransformationTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.ecore.EObject;
@@ -136,35 +135,27 @@ public class FieldMappingTransformationTest extends Java2PcmPackageMappingTransf
 	}
 
 	private void assertOperationRequiredRole(final OperationRequiredRole operationRequiredRole) throws Throwable {
-		this.getVirtualModel().executeCommand(new Callable<Void>() {
+		Set<EObject> correspondingEObjects;
+		try {
+			correspondingEObjects = CorrespondenceModelUtil.getCorrespondingEObjects(
+					FieldMappingTransformationTest.this.getCorrespondenceModel(), operationRequiredRole);
 
-			@Override
-			public Void call() throws Exception {
-				Set<EObject> correspondingEObjects;
-				try {
-					correspondingEObjects = CorrespondenceModelUtil.getCorrespondingEObjects(
-							FieldMappingTransformationTest.this.getCorrespondenceModel(), operationRequiredRole);
-
-					boolean fieldFound = false;
-					for (final EObject correspondingEObject : correspondingEObjects) {
-						if (correspondingEObject instanceof Field) {
-							fieldFound = true;
-						} else {
-							fail("OperationRequiredRole should correspond to field only, but corresonds also to: "
-									+ correspondingEObject);
-						}
-					}
-					assertTrue(fieldFound, "OperationRequiredRole does not correspond to a field");
-				} catch (final Throwable e) {
-					if (e instanceof Exception) {
-						throw (Exception) e;
-					}
-					throw new RuntimeException(e);
+			boolean fieldFound = false;
+			for (final EObject correspondingEObject : correspondingEObjects) {
+				if (correspondingEObject instanceof Field) {
+					fieldFound = true;
+				} else {
+					fail("OperationRequiredRole should correspond to field only, but corresonds also to: "
+							+ correspondingEObject);
 				}
-				return null;
 			}
-		});
-
+			assertTrue(fieldFound, "OperationRequiredRole does not correspond to a field");
+		} catch (final Throwable e) {
+			if (e instanceof Exception) {
+				throw (Exception) e;
+			}
+			throw new RuntimeException(e);
+		}
 	}
 
 	private InnerDeclaration renameFieldInClass(final String className, final String fieldName,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/MethodMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/MethodMappingTransformationTest.java
@@ -1,7 +1,5 @@
 package tools.vitruv.applications.pcmjava.pojotransformations.editortests.java2pcm;
 
-import java.util.concurrent.Callable;
-
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.text.edits.DeleteEdit;
@@ -77,21 +75,14 @@ public class MethodMappingTransformationTest extends Java2PcmPackageMappingTrans
 				"OperationSignature " + opSig + " is not in OperationInterface " + opInterface);
 		this.assertPCMNamedElement(opSig, expectedName);
 
-		this.getVirtualModel().executeCommand(new Callable<Void>() {
-
-			@Override
-			public Void call() {
-				Method jaMoPPMethod;
-				try {
-					jaMoPPMethod = claimOne(CorrespondenceModelUtil.getCorrespondingEObjectsByType(
-							MethodMappingTransformationTest.this.getCorrespondenceModel(), opSig, Method.class));
-				} catch (final Throwable e) {
-					throw new RuntimeException(e);
-				}
-				MethodMappingTransformationTest.this.assertDataTypeName(jaMoPPMethod.getTypeReference(),
-						opSig.getReturnType__OperationSignature());
-				return null;
-			}
-		});
+		Method jaMoPPMethod;
+		try {
+			jaMoPPMethod = claimOne(CorrespondenceModelUtil.getCorrespondingEObjectsByType(
+					MethodMappingTransformationTest.this.getCorrespondenceModel(), opSig, Method.class));
+		} catch (final Throwable e) {
+			throw new RuntimeException(e);
+		}
+		MethodMappingTransformationTest.this.assertDataTypeName(jaMoPPMethod.getTypeReference(),
+				opSig.getReturnType__OperationSignature());
 	}
 }

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/CompositeDataTypeMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/CompositeDataTypeMappingTransformationTest.java
@@ -1,7 +1,5 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository;
 
-import java.util.concurrent.Callable;
-
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.pcm.repository.CompositeDataType;
 import org.palladiosimulator.pcm.repository.InnerDeclaration;
@@ -42,19 +40,12 @@ public class CompositeDataTypeMappingTransformationTest extends Pcm2JavaTransfor
 		final InnerDeclaration innerDec = this.addInnerDeclaration(cdt, repo);
 		propagate();
 
-		this.getVirtualModel().executeCommand(new Callable<Void>() {
-
-			@Override
-			public Void call() throws Exception {
-				try {
-					CompositeDataTypeMappingTransformationTest.this.assertDataTypeCorrespondence(cdt);
-					CompositeDataTypeMappingTransformationTest.this.assertInnerDeclaration(innerDec);
-				} catch (final Throwable e) {
-					throw new RuntimeException(e);
-				}
-				return null;
-			}
-		});
+		try {
+			CompositeDataTypeMappingTransformationTest.this.assertDataTypeCorrespondence(cdt);
+			CompositeDataTypeMappingTransformationTest.this.assertInnerDeclaration(innerDec);
+		} catch (final Throwable e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@Test

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ComponentTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ComponentTest.xtend
@@ -68,10 +68,7 @@ class ComponentTest extends AbstractComp2ClassTest {
 		val umlClass2 = UMLFactory.eINSTANCE.createClass()
 		umlClass2.name = CLASS_NAME2
 		// Add new Class to Package in transaction:
-		virtualModel.executeCommand([
-			classPackage.packagedElements += umlClass2
-			return null
-		])
+		classPackage.packagedElements += umlClass2
 
 		// Remove Component		
 		assertTrue(rootElement.packagedElements.contains(umlComp))
@@ -102,10 +99,7 @@ class ComponentTest extends AbstractComp2ClassTest {
 		val umlClass2 = UMLFactory.eINSTANCE.createClass()
 		umlClass2.name = CLASS_NAME2
 		// Add new Class to Package in transaction:
-		virtualModel.executeCommand([
-			classPackage.packagedElements += umlClass2
-			return null
-		])
+		classPackage.packagedElements += umlClass2
 
 		// Remove Component		
 		assertTrue(rootElement.packagedElements.contains(umlComp))


### PR DESCRIPTION
Depends on https://github.com/vitruv-tools/Vitruv/pull/435 and adapts to the removal of the `TransactionalEditingDomain` and related interface methods.