### PR TITLE
Improve Validation of Package Deletion

### DIFF
--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaPackageTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaPackageTest.xtend
@@ -5,13 +5,17 @@ import org.eclipse.uml2.uml.VisibilityKind
 
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
+import static tools.vitruv.domains.java.util.JavaPersistenceHelper.buildJavaFilePath
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertFalse
+import java.nio.file.Path
+import org.emftext.language.java.containers.ContainersFactory
 
 /**
  * This test class contains basic test cases for package creation, renaming and deletion.
@@ -34,7 +38,6 @@ class UmlToJavaPackageTest extends UmlToJavaTransformationTest {
 		uPackageLevel1 = createUmlPackageAndAddToSuperPackage(PACKAGE_LEVEL_1, rootElement)
 		createUmlClassAndAddToPackage(uPackageLevel1, CLASS_NAME, VisibilityKind.PUBLIC_LITERAL, false, false)
 		propagate
-
 	}
 
 	@Test
@@ -46,7 +49,6 @@ class UmlToJavaPackageTest extends UmlToJavaTransformationTest {
 		val jPackage = getCorrespondingPackage(uPackage)
 		assertEquals(PACKAGE_NAME, jPackage.name)
 		assertPackageEquals(uPackage, jPackage)
-
 	}
 
 	@Test
@@ -58,23 +60,23 @@ class UmlToJavaPackageTest extends UmlToJavaTransformationTest {
 		val jPackageLevel2 = getCorrespondingPackage(uPackageLevel2)
 		assertEquals(PACKAGE_LEVEL_2, jPackageLevel2.name)
 		assertPackageEquals(uPackageLevel2, jPackageLevel2)
-
 	}
 
 	@Test
-	def testDeletePackage() { // Delete or Refactoring java packages seems to lead to problems
-		var jPackage = getCorrespondingPackage(uPackageLevel1)
-		assertNotNull(jPackage)
-
+	def void testDeletePackage() {
+		val expectedPackagePath = buildJavaFilePath(ContainersFactory.eINSTANCE.createPackage => [name = PACKAGE_LEVEL_1])
+		assertNotNull(getCorrespondingPackage(uPackageLevel1), "Corresponding Java package does not exist")
+		assertFalse(resourceAt(Path.of(expectedPackagePath)).contents.empty, "Java package does not exist")
+		
 		uPackageLevel1.destroy
 		propagate
-
-		jPackage = getCorrespondingPackage(uPackageLevel1)
-		assertNull(jPackage)
+		
+		renewResourceCache
+		assertTrue(resourceAt(Path.of(expectedPackagePath)).contents.empty, "Java package still exists")
 	}
 
 	@Test
-	def testRenamePackage() { // Delete or Refactoring java packages seems to lead to problems
+	def testRenamePackage() {
 		uPackageLevel1.name = PACKAGE_RENAMED
 		propagate
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaPackageTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaPackageTest.xtend
@@ -5,12 +5,16 @@ import org.eclipse.uml2.uml.VisibilityKind
 
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
+import static tools.vitruv.domains.java.util.JavaPersistenceHelper.buildJavaFilePath
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertFalse
+import java.nio.file.Path
+import org.emftext.language.java.containers.ContainersFactory
 
 /**
  * This test class contains basic test cases for package creation, renaming and deletion.
@@ -31,7 +35,6 @@ class UmlToJavaPackageTest extends UmlToJavaTransformationTest {
 		uPackageLevel1 = createUmlPackageAndAddToSuperPackage(PACKAGE_LEVEL_1, rootElement)
 		createUmlClassAndAddToPackage(uPackageLevel1, CLASS_NAME, VisibilityKind.PUBLIC_LITERAL, false, false)
 		propagate
-
 	}
 
 	@Test
@@ -42,7 +45,6 @@ class UmlToJavaPackageTest extends UmlToJavaTransformationTest {
 		val jPackage = getCorrespondingPackage(uPackage)
 		assertEquals(PACKAGE_NAME, jPackage.name)
 		assertPackageEquals(uPackage, jPackage)
-
 	}
 
 	@Test
@@ -53,23 +55,23 @@ class UmlToJavaPackageTest extends UmlToJavaTransformationTest {
 		val jPackageLevel2 = getCorrespondingPackage(uPackageLevel2)
 		assertEquals(PACKAGE_LEVEL_2, jPackageLevel2.name)
 		assertPackageEquals(uPackageLevel2, jPackageLevel2)
-
 	}
 
 	@Test
-	def testDeletePackage() { // Delete or Refactoring java packages seems to lead to problems
-		var jPackage = getCorrespondingPackage(uPackageLevel1)
-		assertNotNull(jPackage)
-
+	def void testDeletePackage() {
+		val expectedPackagePath = buildJavaFilePath(ContainersFactory.eINSTANCE.createPackage => [name = PACKAGE_LEVEL_1])
+		assertNotNull(getCorrespondingPackage(uPackageLevel1), "Corresponding Java package does not exist")
+		assertFalse(resourceAt(Path.of(expectedPackagePath)).contents.empty, "Java package does not exist")
+		
 		uPackageLevel1.destroy
 		propagate
-
-		jPackage = getCorrespondingPackage(uPackageLevel1)
-		assertNull(jPackage)
+		
+		renewResourceCache
+		assertTrue(resourceAt(Path.of(expectedPackagePath)).contents.empty, "Java package still exists")
 	}
 
 	@Test
-	def testRenamePackage() { // Delete or Refactoring java packages seems to lead to problems
+	def testRenamePackage() {
 		uPackageLevel1.name = PACKAGE_RENAMED
 		propagate
 


### PR DESCRIPTION
Check (non-)existence of a package before and after its deletion through change propagation.
It especially prepares for the correspondence model requiring UUIDs for objects (https://github.com/vitruv-tools/Vitruv/pull/438), as correspondence resolution for deleted objects will throw an exception then.