### PR TITLE
Correct UML Repository Package Removal and Improve Tests

### DIFF
--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/DefaultLiterals.java
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/DefaultLiterals.java
@@ -44,6 +44,6 @@ public final class DefaultLiterals {
 	public static final int USER_DISAMBIGUATE_REPOSITORY_SYSTEM__NOTHING = 2;
 
 	public static final String WARNING_MULTIPLE_COMPOSITE_DATA_TYPE_CANDIDATES = "Found multiple possible CompositeDatatype correspondence candidates in the datatypes package for uml::Class =  ";
-	public static final String WARNING_IPRE_IMPLEMENTATION_REMOVED = "An IPRE implementation class (Component or System) has been removed from its corresct package. This is against the convention. uml::Class = ";
+	public static final String WARNING_IPRE_IMPLEMENTATION_REMOVED = "An IPRE implementation class (Component or System) has been removed from its correct package. This is against the convention. uml::Class = ";
 	public static final String WARNING_NESTED_COLLECTION_DATA_TYPE = "The innerType of a pcm::CollectionDataType has been set to another CollectionDataType. This can not be propagated to UML. pcm::CollectionDataType[innerType_CollectionDataType] = ";
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -157,8 +157,8 @@ routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 					.message(DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
 
 			if (deleteCorrespondingUmlRepository) {// DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL_YES
-				umlContractsPkg.ifPresent[destroy]
-				umlDatatypesPkg.ifPresent[destroy]
+				umlContractsPkg.ifPresent[umlRepositoryPkg.packagedElements -= it]
+				umlDatatypesPkg.ifPresent[umlRepositoryPkg.packagedElements -= it]
 				umlRepositoryPkg.destroy // delete parent package last to allow the recorder to notice the child package deletion
 			}
 		}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -133,7 +133,7 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 			if (correspondingEObject instanceof NamedElement) {
 				final NamedElement jaMoPPElement = (NamedElement) correspondingEObject;
 				assertTrue(jaMoPPElement.getName().contains(expectedName),
-						"The name of the jamopp element does not contain the expected name");
+						"The name of the jamopp element '" + jaMoPPElement.getName() + "' does not contain the expected name '" +  expectedName + "'");
 				jaMoPPElements.add(jaMoPPElement);
 			} else {
 				// expected name should be null

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlPackageTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlPackageTest.xtend
@@ -80,6 +80,8 @@ class JavaToUmlPackageTest extends JavaToUmlTransformationTest {
 
 		val uPackage = getCorrespondingPackage(jPackageLevel1)
 		val uClass = getCorrespondingClass(javaClass)
+		assertNotNull(uClass, "UML class")
+		assertNotNull(uPackage, "UML package")
 		assertUmlPackageableElementIsInPackage(uClass, uPackage)
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlPackageTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlPackageTest.xtend
@@ -76,6 +76,8 @@ class JavaToUmlPackageTest extends JavaToUmlTransformationTest {
 
 		val uPackage = getCorrespondingPackage(jPackageLevel1)
 		val uClass = getCorrespondingClass(javaClass)
+		assertNotNull(uClass, "UML class")
+		assertNotNull(uPackage, "UML package")
 		assertUmlPackageableElementIsInPackage(uClass, uPackage)
 	}
 


### PR DESCRIPTION
Minor improvements to the removal of packages (leads to missing UUIDs after merging https://github.com/vitruv-tools/Vitruv/pull/438 otherwise) and messages and checks in tests.