### PR TITLE
UML Class-Components Fixes and Transaction Tests

### DIFF
--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
@@ -485,26 +485,33 @@ reaction PackageRenamed {
 
 routine routinePackageRenamed(umlclass::Package classPackage, String newName, String oldName) {
 	action {
-		call {
-			//Check if Package rename is illegal
-			//This is the case if it's the DataType package or gets its name, or if it has a corresponding Component
-			//Renaming the Component is not possible as renaming the Class would be required too
-			val comps = correspondenceModel.getCorrespondingEObjects(#[classPackage]).flatten.filter(Component)
-			var Component comp = if(!comps.isEmpty) comps.get(0) else null		
-			if ((oldName == CLASS_DATATYPES_PACKAGE_NAME) || (comp !== null) || (newName == CLASS_DATATYPES_PACKAGE_NAME)) {
-				//Revert rename currently not possible
-				//TODO: Add a rollback once Vitruvius can handle it
-			}
-			//Therefore use temporary hack:
-			if (oldName == CLASS_DATATYPES_PACKAGE_NAME)
+		// Revert illegal package name change
+		update classPackage {
+			if (oldName == CLASS_DATATYPES_PACKAGE_NAME) {
 				classPackage.name = CLASS_DATATYPES_PACKAGE_NAME
-			else if ((newName == CLASS_DATATYPES_PACKAGE_NAME) && (oldName !== null)) {
-				//Check for pre-exisitnce of the DataTypePackage:
-				val dataTypePackageExistence = classPackage.model.packagedElements.filter(Package).filter[name==CLASS_DATATYPES_PACKAGE_NAME]
-				if (!dataTypePackageExistence.isEmpty) 
-					classPackage.name = "DefaultPackageName"
+			} else if (newName == CLASS_DATATYPES_PACKAGE_NAME && oldName !== null) {
+				// Check for pre-existence of the DataTypePackage
+				val dataTypePackageExistence = classPackage.model.packagedElements.filter(Package).filter[name == CLASS_DATATYPES_PACKAGE_NAME]
+				if (!dataTypePackageExistence.isEmpty) {
+					classPackage.name = oldName
+				}
 			}
-				
+		}
+		call updateCorrespondingComponent(classPackage, oldName)
+	}
+}
+
+routine updateCorrespondingComponent(umlclass::Package classPackage, String oldName) {
+	match {
+		val component = retrieve umlcomp::Component corresponding to classPackage
+	}
+	action {
+		update component {
+			// Packages for components have to end with the package suffix
+			if (!classPackage.name.endsWith(PACKAGE_SUFFIX)) {
+				classPackage.name = oldName
+			}
+			component.name = classPackage.name.substring(0, classPackage.name.length - PACKAGE_SUFFIX.length)
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
@@ -417,10 +417,14 @@ routine createdPackage(umlclass::Package classPackage) {
 			//Get list of existing components as options for dialog
 			val componentsList = compModel.packagedElements.filter(Component).toList
 			if (!componentsList.isEmpty) { 
-				val options = componentsList.map[e | e.name] 			
-				val selection = userInteractor.modalTextUserinteracting(question, options)		
-				//Use selection to assign new package
-				val umlComp = componentsList.get(selection)
+				val options = componentsList.map[e | e.name]
+				val umlComp = if (options.size > 1) { 			
+					val selection = userInteractor.modalTextUserinteracting(question, options)
+					componentsList.get(selection)
+				} else {
+					componentsList.get(0)
+				}
+				warnIfPackageLinkedToComponent(umlComp)
 				assignNewPackage(classPackage, umlComp)
 			} else {
 				userInteractor.notificationDialogBuilder.message("No available Component found")
@@ -431,20 +435,25 @@ routine createdPackage(umlclass::Package classPackage) {
 	}
 }
 
-routine assignNewPackage(umlclass::Package newPackage, umlclass::Component umlComponent) { //TODO rewrite this to fit new package linking
+routine warnIfPackageLinkedToComponent(umlclass::Component umlComponent) {
+	match {
+		val correspondingPackage = retrieve umlclass::Package corresponding to umlComponent 
+	}
 	action {
 		call {
-			val packages = correspondenceModel.getCorrespondingEObjects(#[umlComponent]).flatten.filter(Package)
-			var Package oldPackage = if(!packages.isEmpty) packages.get(0) else null			
-			
-			if (oldPackage === null) {
-				correspondenceModel.createAndAddCorrespondence(#[umlComponent], #[newPackage])
-			} else {
-				val String errorMsg = "Chosen Component is already linked to existing Package '" + oldPackage.name + "'."
-				userInteractor.notificationDialogBuilder.message(errorMsg).windowModality(WindowModality.MODELESS)
-				    .startInteraction()
-			}
+			val String errorMsg = "Chosen Component is already linked to existing Package '" + correspondingPackage.name + "'."
+			userInteractor.notificationDialogBuilder.message(errorMsg).windowModality(WindowModality.MODELESS)
+			    .startInteraction()
 		}
+	} 
+}
+
+routine assignNewPackage(umlclass::Package newPackage, umlclass::Component umlComponent) {
+	match {
+		require absence of umlclass::Package corresponding to umlComponent 
+	}
+	action {
+		add correspondence between umlComponent and newPackage
 	} 
 }
 

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
@@ -166,7 +166,10 @@ routine createDataTypeForClass(umlclass::Class umlClass) {
 
 reaction RenameClass {
 	after attribute replaced at umlclass::Class[name]
-	call renameComponent(affectedEObject)
+	call {
+		renameComponent(affectedEObject)
+		renameDataType(affectedEObject)
+	}
 }
 
 routine renameComponent(umlclass::Class umlClass) { 
@@ -180,6 +183,16 @@ routine renameComponent(umlclass::Class umlClass) {
 	}
 }
 
+routine renameDataType(umlclass::Class umlClass) { 
+	match {
+		val umlDataType = retrieve umlcomp::DataType corresponding to umlClass
+	}
+	action { 
+		update umlDataType {
+			umlDataType.name = umlClass.name
+		}
+	}
+}
 
 reaction DeletedClass{
 	after element umlclass::Class deleted and removed from umlclass::Package[packagedElement]

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
@@ -140,11 +140,7 @@ routine createUmlComponentForClass(umlclass::Class umlClass) {
 			compModel.packagedElements += umlComp
 		
 		add correspondence between umlClass and umlComp
-		
-		call {
-			val classPackage = umlClass.package
-			correspondenceModel.createAndAddCorrespondence(#[umlComp], #[classPackage])
-		}
+		add correspondence between umlComp and umlClass.package
 	}
 }
 

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/AbstractClass2CompTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/AbstractClass2CompTest.xtend
@@ -1,124 +1,13 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.class2comp
 
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.uml2.uml.Class
-import org.eclipse.uml2.uml.Component
-import org.eclipse.uml2.uml.Model
-import org.eclipse.uml2.uml.Package
-import org.eclipse.uml2.uml.UMLFactory
 import tools.vitruv.applications.umlclassumlcomponents.class2comp.UmlClass2UmlCompChangePropagation
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
-import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
-import org.junit.jupiter.api.BeforeEach
-import tools.vitruv.testutils.LegacyVitruvApplicationTest
-import java.nio.file.Path
+import tools.vitruv.applications.umlclassumlcomponents.tests.util.AbstractUmlClassCompTest
 
-import static org.junit.jupiter.api.Assertions.assertEquals
-
-abstract class AbstractClass2CompTest extends LegacyVitruvApplicationTest {
-
-	protected def Model getRootElement() {
-		return Model.from(MODEL_NAME.projectModelPath)
-	}
+abstract class AbstractClass2CompTest extends AbstractUmlClassCompTest {
 
 	override protected getChangePropagationSpecifications() {
 		return #[new UmlClass2UmlCompChangePropagation()]
 	}
 
-	// SaveAndSynchronize & commit all pending userInteractions
-	protected def saveAndSynchronizeWithInteractions(EObject object) {
-		propagate()
-		userInteraction.assertAllInteractionsOccurred()
-	}
-
-	@BeforeEach
-	def protected setup() {
-		initializeTestModel()
-	}
-
-	protected def void initializeTestModel() {
-		val umlModel = UMLFactory.eINSTANCE.createModel() => [
-			name = MODEL_NAME
-		]
-		resourceAt(MODEL_NAME.projectModelPath).startRecordingChanges => [
-			contents += umlModel
-		]
-		propagate
-	}
-
-	private def Path getProjectModelPath(String modelName) {
-		Path.of(FOLDER_NAME).resolve(modelName + "." + MODEL_FILE_EXTENSION)
-	}
-
-	/***************
-	 * Assert Helper:*
-	 ****************/
-	package def Component assertComponentForClass(Class umlClass, String name) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlClass]).flatten
-		assertEquals(1, correspondingElements.size)
-		val umlComponent = correspondingElements.get(0)
-		assertTypeAndName(umlComponent, Component, name)
-		return umlComponent as Component
-	}
-
-	package def Component assertPackageLinkedToComponent(Package classPackage, String componentName) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classPackage]).flatten.filter(
-			Component)
-		assertEquals(1, correspondingElements.size)
-		val umlComponent = correspondingElements.get(0)
-		assertTypeAndName(umlComponent, Component, componentName)
-		return umlComponent
-	}
-
-	/*****************
-	 * Creation Helper:*
-	 ******************/
-	package def Class createClassWithoutInteraction(String name) {
-		val classPackage = createPackage(name + PACKAGE_SUFFIX)
-		return createClassWithoutInteraction(name, classPackage)
-	}
-
-	package def Class createClassWithoutInteraction(String name, Package classPackage) {
-		val umlClass = UMLFactory.eINSTANCE.createClass()
-		umlClass.name = name
-		classPackage.packagedElements += umlClass
-
-		return umlClass
-	}
-
-	package def Class createClass(String name, int createComponent) {
-		val classPackage = createPackage(name + PACKAGE_SUFFIX)
-		return createClass(name, classPackage, createComponent)
-	}
-
-	package def Class createClass(String name, Package classPackage, int createComponent) {
-		val umlClass = createClassWithoutInteraction(name, classPackage)
-
-		// Decide whether to create corresponding Component or not:
-		userInteraction.onMultipleChoiceSingleSelection [message.contains('''Should '«name»' be represented by a Component?''')]
-			.respondWithChoiceAt(createComponent)
-
-		return umlClass
-	}
-
-	package def Package createPackage(String name) {
-		createPackage(name, 1, -1)
-	}
-
-	package def Package createPackage(String name, int createComponent, int componentSelection) {
-		val classPackage = UMLFactory.eINSTANCE.createPackage()
-		classPackage.name = name + PACKAGE_SUFFIX
-		rootElement.packagedElements += classPackage
-
-		// Decide whether to link this Package to an existing Component
-		userInteraction.onMultipleChoiceSingleSelection [message.contains('''link this Package '«classPackage.name»' to an existing Component''')]
-			.respondWithChoiceAt(createComponent)
-		if (componentSelection >= 0) {
-			userInteraction.onMultipleChoiceSingleSelection [message.contains('''Choose an existing Component''')]
-				.respondWithChoiceAt(componentSelection)
-		}
-
-		return classPackage
-	}
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/Class2CompIntegrationTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/Class2CompIntegrationTest.xtend
@@ -1,6 +1,5 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.class2comp
 
-import java.util.Collections
 import org.eclipse.uml2.uml.InterfaceRealization
 import org.eclipse.uml2.uml.Model
 import org.eclipse.uml2.uml.NamedElement
@@ -18,25 +17,19 @@ import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertTrue
 import java.nio.file.Path
-import org.eclipse.emf.ecore.EObject
 
 class Class2CompIntegrationTest extends AbstractClass2CompTest {
 
-	override protected setup() {
-		// Don't initialize a model here, as we are loading and creating one
+	override protected isInitializeTestModel() {
+		return false
 	}
 
 	def Model integrationTest(String fileName) {
-		resourceAt(Path.of(OUTPUT_NAME)).startRecordingChanges => [
-			contents += EObject.from(fileName.testModelResource)
+		resourceAt(Path.of(OUTPUT_NAME)).propagate [
+			contents += Model.from(fileName.testModelResource)
 		]
-		propagate()
-		userInteraction.assertAllInteractionsOccurred()
 
-		val umlModel = correspondenceModel.getAllEObjectsOfTypeInCorrespondences(Model).get(0)
-		umlModel.eResource.save(Collections.EMPTY_MAP)
-
-		return umlModel
+		return Model.from(Path.of(OUTPUT_NAME))
 	}
 
 	/*******
@@ -44,13 +37,9 @@ class Class2CompIntegrationTest extends AbstractClass2CompTest {
 	 ********/
 	@Test
 	def void integrationTestWith2Classses() {
-		userInteraction
-			// 2x Decide to create an empty Package:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// 2x Decide to create a Component for the Class:
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")
+		userInteraction // 2x Decide to create an empty Package:
+		.onNextMultipleChoiceSingleSelection.respondWith("No").onNextMultipleChoiceSingleSelection.respondWith("No") // 2x Decide to create a Component for the Class:
+		.onNextMultipleChoiceSingleSelection.respondWith("Yes").onNextMultipleChoiceSingleSelection.respondWith("Yes")
 
 		val umlModel = integrationTest("TestModel2Classes.uml")
 
@@ -76,13 +65,10 @@ class Class2CompIntegrationTest extends AbstractClass2CompTest {
 
 	@Test
 	def void integrationTestWithClassAndDataType() {
-		userInteraction
-			// 2x Decide to create an empty Package:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// Decide to create a Class as a DataType (no Interactions)
-			// Decide to create a Component for the Class:
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")	
+		userInteraction // 2x Decide to create an empty Package:
+		.onNextMultipleChoiceSingleSelection.respondWith("No").onNextMultipleChoiceSingleSelection.respondWith("No") // Decide to create a Class as a DataType (no Interactions)
+		// Decide to create a Component for the Class:
+		.onNextMultipleChoiceSingleSelection.respondWith("Yes")
 
 		val umlModel = integrationTest("TestModel1Class1Datatype.uml")
 
@@ -97,10 +83,9 @@ class Class2CompIntegrationTest extends AbstractClass2CompTest {
 
 	@Test
 	def void integrationTestWithClassAndDataTypeWithPropertyAndOperation() {
-		userInteraction
-			// Decide to create an empty Package:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// Decide to create a Class as a DataType (no Interactions)
+		userInteraction // Decide to create an empty Package:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")
+		// Decide to create a Class as a DataType (no Interactions)
 		val umlModel = integrationTest("TestModel1DatatypeWithPropertyAndOperation.uml")
 
 		// Validate expected contents:
@@ -119,13 +104,9 @@ class Class2CompIntegrationTest extends AbstractClass2CompTest {
 
 	@Test
 	def void integrationTestWithTestModel2ClassesAndRequiredAndProvidedInterface() {
-		userInteraction
-			// 2x Decide to create an empty Package:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// 2x Decide to create a Component for the Class:
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")	
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")		
+		userInteraction // 2x Decide to create an empty Package:
+		.onNextMultipleChoiceSingleSelection.respondWith("No").onNextMultipleChoiceSingleSelection.respondWith("No") // 2x Decide to create a Component for the Class:
+		.onNextMultipleChoiceSingleSelection.respondWith("Yes").onNextMultipleChoiceSingleSelection.respondWith("Yes")
 
 		val umlModel = integrationTest("TestModel2ClassesWithInterfaceRequiredAndProvided.uml")
 
@@ -160,15 +141,12 @@ class Class2CompIntegrationTest extends AbstractClass2CompTest {
 
 	@Test
 	def void integrationTestAllCombined() {
-		userInteraction
-			// 3x Decide to create an empty Package:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// Decide to create a Class as a DataType (no Interactions)
+		userInteraction // 3x Decide to create an empty Package:
+		.onNextMultipleChoiceSingleSelection.respondWith("No").onNextMultipleChoiceSingleSelection.respondWith("No").
+			onNextMultipleChoiceSingleSelection.respondWith("No") // Decide to create a Class as a DataType (no Interactions)
 			// 2x Decide to create a Component for the Class:
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")
+			.onNextMultipleChoiceSingleSelection.respondWith("Yes").onNextMultipleChoiceSingleSelection.
+			respondWith("Yes")
 
 		val umlModel = integrationTest("TestModelAllCombined.uml")
 
@@ -211,15 +189,11 @@ class Class2CompIntegrationTest extends AbstractClass2CompTest {
 
 	@Test
 	def void integrationTestMatthiasSmallExampleClassResult() {
-		userInteraction
-			// 3x Decide to create an empty Package:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// Decide to create a Class as a DataType (no Interactions)
+		userInteraction // 3x Decide to create an empty Package:
+		.onNextMultipleChoiceSingleSelection.respondWith("No").onNextMultipleChoiceSingleSelection.respondWith("No").
+			onNextMultipleChoiceSingleSelection.respondWith("No") // Decide to create a Class as a DataType (no Interactions)
 			// Decide to create a Component for the Class:
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")
-			// Decide to create a Component for the Class:
+			.onNextMultipleChoiceSingleSelection.respondWith("Yes") // Decide to create a Component for the Class:
 			.onNextMultipleChoiceSingleSelection.respondWith("Yes")
 
 		integrationTest("Matthias_small_example_Class_Result.uml")

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/ClassTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/ClassTest.xtend
@@ -1,105 +1,211 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.class2comp
 
 import org.eclipse.uml2.uml.Component
+import org.eclipse.uml2.uml.Package
+import org.eclipse.uml2.uml.Class
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertFalse
-import static org.junit.jupiter.api.Assertions.assertEquals
+import org.eclipse.uml2.uml.UMLFactory
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.CoreMatchers.is
 
 class ClassTest extends AbstractClass2CompTest {
 
-	/*******
-	 * Class:*
-	 ********/
 	@Test
 	def void testCreateComponentForClass() {
-		val umlClass = createClass(CLASS_NAME, 0)
-		saveAndSynchronizeWithInteractions(umlClass)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+			]
+		]
 
-		assertComponentForClass(umlClass, CLASS_NAME)
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(2))
+	}
+
+	@Test
+	def void testCreateComponentForClassInPackageWithNonMatchingName() {
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+			]
+		]
+
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME)
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Test
 	def void testCreate2ComponentsFor2ClassesInSamePackage() {
-		val classPackage = createPackage(CLASS_NAME)
-		val umlClass1 = createClass(CLASS_NAME, classPackage, 0)
-		val umlClass2 = createClassWithoutInteraction(CLASS_NAME2, classPackage)
-		saveAndSynchronizeWithInteractions(rootElement)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME2
+				]
+			]
+		]
 
-		// First Class should have Component
-		assertComponentForClass(umlClass1, CLASS_NAME)
-
-		// Second Class should receive no Component
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlClass2]).flatten
-		assertEquals(0, correspondingElements.size)
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimNoPackagedElementWithName(Component, CLASS_NAME2)
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Test
 	def void testCreate2ComponentsFor2ClassesInDifferentPackages() {
-		val classPackage1 = createPackage(CLASS_NAME)
-		val umlClass1 = createClass(CLASS_NAME, classPackage1, 0)
-		val classPackage2 = createPackage(CLASS_NAME2)
-		val umlClass2 = createClass(CLASS_NAME2, classPackage2, 0)
-		saveAndSynchronizeWithInteractions(rootElement)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME2 + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME2»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+			]
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME2 + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME2
+				]
+			]
+		]
 
-		// Both Classes should have corresponding Components
-		assertComponentForClass(umlClass1, CLASS_NAME)
-		assertPackageLinkedToComponent(classPackage1, CLASS_NAME)
-		assertComponentForClass(umlClass2, CLASS_NAME2)
-		assertPackageLinkedToComponent(classPackage2, CLASS_NAME2)
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME2 + PACKAGE_SUFFIX)
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME2)
+		assertThat(rootElement.packagedElements.size, is(4))
 	}
 
 	@Test
 	def void testCreateNoComponentForClass() {
-		val umlClass = createClass(CLASS_NAME, 1)
-		saveAndSynchronizeWithInteractions(umlClass)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlClass]).flatten
-		assertEquals(0, correspondingElements.size)
-		assertFalse(rootElement.packagedElements.contains(Component))
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimNoPackagedElementWithName(Component, CLASS_NAME)
+		assertThat(rootElement.packagedElements.size, is(1))
 	}
 
 	@Test
 	def void testRenameClass() {
-		val umlClass = createClass("Old", 0)
-		saveAndSynchronizeWithInteractions(umlClass)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+			]
+		]
 
-		// Change name:
-		umlClass.name = "New"
-		saveAndSynchronizeWithInteractions(umlClass)
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX) => [
+				claimPackagedElementWithName(Class, CLASS_NAME) => [
+					name = CLASS_NAME2
+				]
+			]
+		]
 
-		// Check if rename happened in Component:
-		assertComponentForClass(umlClass, "New")
+		rootElement.claimNoPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME2)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Test
 	def void testDeleteClass() {
-		val classPackage = createPackage(CLASS_NAME)
-		val umlClass = createClass(CLASS_NAME, classPackage, 0)
-		saveAndSynchronizeWithInteractions(umlClass)
-		val umlComponent = assertComponentForClass(umlClass, CLASS_NAME)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+			]
+		]
+		assertThat(rootElement.packagedElements.size, is(2))
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
 
-		// Remove Class		
-		assertTrue(classPackage.packagedElements.contains(umlClass))
-		umlClass.destroy()
-		assertFalse(classPackage.packagedElements.contains(umlClass))
-		saveAndSynchronizeWithInteractions(rootElement)
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX) => [
+				claimPackagedElementWithName(Class, CLASS_NAME) => [
+					destroy()
+				]
+			]
+		]
 
-		// Check if Component still exists:		
-		assertFalse(classPackage.packagedElements.contains(umlComponent))
-	}
-
-	@Test
-	def void testCreateComponentForClassInPackage() {
-		val classPackage = createPackage(CLASS_NAME)
-		val umlClass = createClass(CLASS_NAME, classPackage, 0)
-		saveAndSynchronizeWithInteractions(umlClass)
-
-		assertComponentForClass(umlClass, CLASS_NAME)
-		assertPackageLinkedToComponent(classPackage, CLASS_NAME)
+		rootElement.claimNoPackagedElementWithName(Component, CLASS_NAME)
+		assertThat(rootElement.packagedElements.size, is(1))
 	}
 
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/DataTypeTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/DataTypeTest.xtend
@@ -2,115 +2,184 @@ package tools.vitruv.applications.umlclassumlcomponents.tests.class2comp
 
 import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.DataType
-import org.eclipse.uml2.uml.Operation
-import org.eclipse.uml2.uml.Property
+import org.eclipse.uml2.uml.Package
 import org.eclipse.uml2.uml.UMLFactory
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
 import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.CoreMatchers.is
 
 class DataTypeTest extends AbstractClass2CompTest {
 
-	/***********
-	 * DataTypes:*
-	 ************/
 	@Test
 	def void testCreateDataTypeForClass() {
-		val classDataType = createDataTypeClass(CLASS_NAME)
-		saveAndSynchronizeWithInteractions(classDataType)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_DATATYPES_PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classDataType]).flatten
-		assertEquals(1, correspondingElements.size)
-		val compDataType = correspondingElements.get(0)
-		assertTypeAndName(compDataType, DataType, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		rootElement.claimPackagedElementWithName(DataType, CLASS_NAME)
+		assertThat(rootElement.packagedElements.size, is(2))
+	}
+
+	@Test
+	def void testRenameDataType() {
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_DATATYPES_PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+				]
+			]
+		]
+
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		rootElement.claimPackagedElementWithName(DataType, CLASS_NAME)
+		assertThat(rootElement.packagedElements.size, is(2))
+
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME) => [
+				claimPackagedElementWithName(Class, CLASS_NAME) => [
+					name = CLASS_NAME2
+				]
+			]
+		]
+
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		rootElement.claimPackagedElementWithName(DataType, CLASS_NAME2)
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Test
 	def void testAddPropertyToDataType() {
-		val classDataType = createDataTypeClass(CLASS_NAME)
-		saveAndSynchronizeWithInteractions(classDataType)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_DATATYPES_PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					ownedAttributes += UMLFactory.eINSTANCE.createProperty() => [
+						name = PROPERTY_NAME
+					]
+				]
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classDataType]).flatten
-		val compDataType = (correspondingElements.get(0) as DataType)
-		val classProperty = UMLFactory.eINSTANCE.createProperty()
-		classProperty.name = PROPERTY_NAME
-		classDataType.ownedAttributes += classProperty
-		propagate
-
-		assertEquals(1, compDataType.ownedAttributes.size)
-		val compProperty = compDataType.ownedAttributes.get(0)
-		assertTypeAndName(compProperty, Property, PROPERTY_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		val dataType = rootElement.claimPackagedElementWithName(DataType, CLASS_NAME)
+		dataType.claimOwnedAttributeWithName(PROPERTY_NAME)
+		assertThat(dataType.ownedAttributes.size, is(1))
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Test
 	def void testRenameDataTypeProperty() {
-		val classDataType = createDataTypeClass(CLASS_NAME)
-		saveAndSynchronizeWithInteractions(classDataType)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_DATATYPES_PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					ownedAttributes += UMLFactory.eINSTANCE.createProperty() => [
+						name = PROPERTY_NAME
+					]
+				]
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classDataType]).flatten
-		val compDataType = (correspondingElements.get(0) as DataType)
-		val classProperty = UMLFactory.eINSTANCE.createProperty()
-		classProperty.name = "Old"
-		classDataType.ownedAttributes += classProperty
-		propagate
+		val newPropertyName = PROPERTY_NAME + "New"
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME) => [
+				claimPackagedElementWithName(Class, CLASS_NAME) => [
+					claimOwnedAttributeWithName(PROPERTY_NAME) => [
+						name = newPropertyName
+					]
+				]
+			]
+		]
 
-		// Change name:
-		classProperty.name = "New"
-		propagate
-
-		// Check if rename happened in Component Property:
-		val compProperty = compDataType.ownedAttributes.get(0)
-		assertEquals("New", compProperty.name)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		val dataType = rootElement.claimPackagedElementWithName(DataType, CLASS_NAME)
+		dataType.claimOwnedAttributeWithName(newPropertyName)
+		assertThat(dataType.ownedAttributes.size, is(1))
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Test
 	def void testAddOperationToDataType() {
-		val classDataType = createDataTypeClass(CLASS_NAME)
-		saveAndSynchronizeWithInteractions(classDataType)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_DATATYPES_PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					ownedOperations += UMLFactory.eINSTANCE.createOperation() => [
+						name = OPERATION_NAME
+					]
+				]
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classDataType]).flatten
-		val compDataType = (correspondingElements.get(0) as DataType)
-		val classOperation = UMLFactory.eINSTANCE.createOperation()
-		classOperation.name = OPERATION_NAME
-		classDataType.ownedOperations += classOperation
-		propagate
-
-		assertEquals(1, compDataType.ownedOperations.size)
-		val compOperation = compDataType.ownedOperations.get(0)
-		assertTypeAndName(compOperation, Operation, OPERATION_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		val dataType = rootElement.claimPackagedElementWithName(DataType, CLASS_NAME)
+		dataType.claimOwnedOperationWithName(OPERATION_NAME)
+		assertThat(dataType.ownedOperations.size, is(1))
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Test
 	def void testRenameDataTypeOperation() {
-		val classDataType = createDataTypeClass(CLASS_NAME)
-		saveAndSynchronizeWithInteractions(classDataType)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_DATATYPES_PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					ownedOperations += UMLFactory.eINSTANCE.createOperation() => [
+						name = OPERATION_NAME
+					]
+				]
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classDataType]).flatten
-		val compDataType = (correspondingElements.get(0) as DataType)
-		val classOperation = UMLFactory.eINSTANCE.createOperation()
-		classOperation.name = "Old"
-		classDataType.ownedOperations += classOperation
-		propagate
+		val newOperationName = OPERATION_NAME + "New"
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME) => [
+				claimPackagedElementWithName(Class, CLASS_NAME) => [
+					claimOwnedOperationWithName(OPERATION_NAME) => [
+						name = newOperationName
+					]
+				]
+			]
+		]
 
-		// Change name:
-		classOperation.name = "New"
-		propagate
-
-		// Check if rename happened in Component Operation:
-		val compOperation = compDataType.ownedOperations.get(0)
-		assertEquals("New", compOperation.name)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		val dataType = rootElement.claimPackagedElementWithName(DataType, CLASS_NAME)
+		dataType.claimOwnedOperationWithName(newOperationName)
+		assertThat(dataType.ownedOperations.size, is(1))
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
-	/*****************
-	 * Creation Helper:*
-	 ******************/
-	private def Class createDataTypeClass(String name) {
-		val dataTypePackage = createPackage(CLASS_DATATYPES_PACKAGE)
-		val classDataType = createClassWithoutInteraction(name, dataTypePackage)
-		return classDataType
-	}
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/InterfaceTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/InterfaceTest.xtend
@@ -1,240 +1,307 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.class2comp
 
-import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.Interface
-import org.eclipse.uml2.uml.InterfaceRealization
 import org.eclipse.uml2.uml.Package
 import org.eclipse.uml2.uml.UMLFactory
 import org.eclipse.uml2.uml.Usage
+import org.eclipse.uml2.uml.Component
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
 import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertFalse
-import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.is
 
 class InterfaceTest extends AbstractClass2CompTest {
 
-	/*******
-	 * Tests:*
-	 ********/
 	@Test
 	def void testInterfaceRequiredAndProvided() {
-		// Create 2 Components:
-		val classPackage1 = createPackage(CLASS_NAME)
-		val umlClass1 = createClass(CLASS_NAME, classPackage1, 0)
-		val classPackage2 = createPackage(CLASS_NAME2)
-		val umlClass2 = createClass(CLASS_NAME2, classPackage2, 0)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME2 + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME2»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			val model = it
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				val interface = UMLFactory.eINSTANCE.createInterface() => [
+					name = INTERFACE_NAME
+				]
+				packagedElements += interface
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
+						name = INTERFACE_REALIZATION_NAME
+						suppliers += interface
+					]
+				]
 
-		// Create a new Interface in Class Package 1	and provide it here:
-		val classInterface = createInterface(INTERFACE_NAME, classPackage1)
-		val classIFRealizationProv = createInterfaceRealization(INTERFACE_REALIZATION_NAME, umlClass1)
-		classIFRealizationProv.suppliers += classInterface
+			]
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME2 + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME2
+					interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
+						name = INTERFACE_REALIZATION_NAME2
+						suppliers +=
+							model.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX).
+								claimPackagedElementWithName(Interface, INTERFACE_NAME)
+					]
+				]
+			]
+		]
 
-		saveAndSynchronizeWithInteractions(rootElement)
-
-		// Realize the Interface in Class 2:
-		val classIFRealizationReq = createInterfaceRealization(INTERFACE_REALIZATION_NAME2, umlClass2)
-		classIFRealizationReq.suppliers += classInterface
-
-		saveAndSynchronizeWithInteractions(classIFRealizationReq)
-
-		// Assert and get Components:
-		val umlComp1 = assertComponentForClass(umlClass1, CLASS_NAME)
-		val umlComp2 = assertComponentForClass(umlClass2, CLASS_NAME2)
-
-		// Assert Component Interface:
-		val compInterface = assertInterface(classInterface)
-
-		// Assert Component InterfaceRealization:
-		val compIFRealization = assertInterfaceRealization(classIFRealizationProv, INTERFACE_REALIZATION_NAME)
-		// Check for correct provided role setup:
-		assertTrue(compIFRealization.clients.contains(umlComp1))
-		assertTrue(compIFRealization.contract == compInterface)
-		assertTrue(compIFRealization.suppliers.contains(compInterface))
-		assertTrue(umlComp1.interfaceRealizations.contains(compIFRealization))
-
-		// Assert Component Usage:
-		val compUsage = assertUsage(classIFRealizationReq, INTERFACE_REALIZATION_NAME2)
-		// Check for correct required role setup:
-		assertTrue(compUsage.clients.contains(umlComp2))
-		assertTrue(compUsage.suppliers.contains(compInterface))
-		assertTrue(umlComp2.packagedElements.contains(compUsage))
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME2 + PACKAGE_SUFFIX)
+		val component1 = rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		val component2 = rootElement.claimPackagedElementWithName(Component, CLASS_NAME2)
+		val componentInterface = rootElement.claimPackagedElementWithName(Interface,
+			INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
+		component1.claimInterfaceRealization(INTERFACE_REALIZATION_NAME + COMP_IFR_AND_USAGE_SUFFIX, componentInterface)
+		val usage = component2.claimPackagedElementWithName(Usage,
+			INTERFACE_REALIZATION_NAME2 + COMP_IFR_AND_USAGE_SUFFIX)
+		assertThat(usage.suppliers, hasItem(componentInterface))
+		assertThat(usage.suppliers.size, is(1))
+		assertThat(rootElement.packagedElements.size, is(5))
 	}
 
 	@Test
 	def void testInterfaceHasNoReachOutwards() {
-		// Create 2 Components:
-		val classPackage1 = createPackage(CLASS_NAME)
-		val umlClass1 = createClass(CLASS_NAME, classPackage1, 0)
-		val classPackage2 = createPackage(CLASS_NAME2)
-		val umlClass2 = createClass(CLASS_NAME2, classPackage2, 0)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME2 + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME2»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				val interface = UMLFactory.eINSTANCE.createInterface() => [
+					name = INTERFACE_NAME
+				]
+				packagedElements += interface
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
+						name = INTERFACE_REALIZATION_NAME
+						suppliers += interface
+					]
+					interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
+						name = INTERFACE_REALIZATION_NAME2
+						suppliers += interface
+					]
+				]
 
-		// Create a new Interface in Class Package 1	and provide it here:
-		val classInterface = createInterface(INTERFACE_NAME, classPackage1)
-		val classIFRealizationProv = createInterfaceRealization(INTERFACE_REALIZATION_NAME, umlClass1)
-		classIFRealizationProv.suppliers += classInterface
+			]
+		]
 
-		saveAndSynchronizeWithInteractions(rootElement)
-
-		// Realize the Interface in Class 1:
-		// This should result in no executed interface reaction
-		val classIFRealizationReq = createInterfaceRealization(INTERFACE_REALIZATION_NAME2, umlClass1)
-		classIFRealizationReq.suppliers += classInterface
-
-		saveAndSynchronizeWithInteractions(classIFRealizationReq)
-
-		// Assert existence of Components:
-		assertComponentForClass(umlClass1, CLASS_NAME)
-		assertComponentForClass(umlClass2, CLASS_NAME2)
-
-		// There should be no Component Interface:
-		var correspondingElements1 = correspondenceModel.getCorrespondingEObjects(#[classInterface]).flatten.filter(
-			InterfaceRealization)
-		assertEquals(0, correspondingElements1.size)
-
-		// There should be no Component InterfaceRealization:
-		var correspondingElements2 = correspondenceModel.getCorrespondingEObjects(#[classIFRealizationProv]).flatten.
-			filter(InterfaceRealization)
-		assertEquals(0, correspondingElements2.size)
-
-		// There should be no Component Usage:
-		var correspondingElements3 = correspondenceModel.getCorrespondingEObjects(#[classIFRealizationReq]).flatten.
-			filter(InterfaceRealization)
-		assertEquals(0, correspondingElements3.size)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		val component = rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimNoPackagedElementWithName(Interface, INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
+		assertTrue(component.interfaceRealizations.empty)
+		component.claimNoPackagedElementWithName(Usage, INTERFACE_REALIZATION_NAME2 + COMP_IFR_AND_USAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Test
 	def void testInterfaceRemoved() {
-		// ***First create a realized and used Interface***
-		// Create 2 Components:
-		val classPackage1 = createPackage(CLASS_NAME)
-		val umlClass1 = createClass(CLASS_NAME, classPackage1, 0)
-		val classPackage2 = createPackage(CLASS_NAME2)
-		val umlClass2 = createClass(CLASS_NAME2, classPackage2, 0)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME2 + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME2»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			val model = it
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				val interface = UMLFactory.eINSTANCE.createInterface() => [
+					name = INTERFACE_NAME
+				]
+				packagedElements += interface
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
+						name = INTERFACE_REALIZATION_NAME
+						suppliers += interface
+					]
+				]
 
-		// Create a new Interface in Class Package 1	and provide it here:
-		val classInterface = createInterface(INTERFACE_NAME, classPackage1)
-		val classIFRealizationProv = createInterfaceRealization(INTERFACE_REALIZATION_NAME, umlClass1)
-		classIFRealizationProv.suppliers += classInterface
+			]
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME2 + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME2
+					interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
+						name = INTERFACE_REALIZATION_NAME2
+						suppliers +=
+							model.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX).
+								claimPackagedElementWithName(Interface, INTERFACE_NAME)
+					]
+				]
+			]
+		]
 
-		saveAndSynchronizeWithInteractions(rootElement)
+		rootElement => [
+			it.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+			it.claimPackagedElementWithName(Package, CLASS_NAME2 + PACKAGE_SUFFIX)
+			val component1 = it.claimPackagedElementWithName(Component, CLASS_NAME)
+			val component2 = it.claimPackagedElementWithName(Component, CLASS_NAME2)
+			val componentInterface = it.claimPackagedElementWithName(Interface, INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
+			component1.claimInterfaceRealization(INTERFACE_REALIZATION_NAME + COMP_IFR_AND_USAGE_SUFFIX,
+				componentInterface)
+			val usage = component2.claimPackagedElementWithName(Usage,
+				INTERFACE_REALIZATION_NAME2 + COMP_IFR_AND_USAGE_SUFFIX)
+			assertThat(usage.suppliers, hasItem(componentInterface))
+			assertThat(usage.suppliers.size, is(1))
+			assertThat(it.packagedElements.size, is(5))
+		]
 
-		// Realize the Interface in Class 2:
-		val classIFRealizationReq = createInterfaceRealization(INTERFACE_REALIZATION_NAME2, umlClass2)
-		classIFRealizationReq.suppliers += classInterface
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX) => [
+				claimPackagedElementWithName(Interface, INTERFACE_NAME) => [
+					destroy()
+				]
+			]
+		]
 
-		saveAndSynchronizeWithInteractions(classIFRealizationReq)
-
-		// Assert and get Components:
-		assertComponentForClass(umlClass1, CLASS_NAME)
-		val umlComp2 = assertComponentForClass(umlClass2, CLASS_NAME2)
-
-		// Assert Component Interface:
-		val compInterface = assertInterface(classInterface)
-		// Assert Component Usage:
-		val compUsage = assertUsage(classIFRealizationReq, INTERFACE_REALIZATION_NAME2)
-
-		// /***Then remove the Interface***
-		classInterface.destroy
-		saveAndSynchronizeWithInteractions(rootElement)
-		// There should be no corresponding Interface and Usage anymore
-		assertFalse(umlComp2.model.packagedElements.contains(compInterface))
-		assertFalse(umlComp2.packagedElements.contains(compUsage))
+		rootElement => [
+			it.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+			it.claimPackagedElementWithName(Package, CLASS_NAME2 + PACKAGE_SUFFIX)
+			val component1 = it.claimPackagedElementWithName(Component, CLASS_NAME)
+			val component2 = it.claimPackagedElementWithName(Component, CLASS_NAME2)
+			it.claimNoPackagedElementWithName(Interface, INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
+			assertTrue(component1.interfaceRealizations.empty)
+			component2.claimNoPackagedElementWithName(Usage, INTERFACE_REALIZATION_NAME2 + COMP_IFR_AND_USAGE_SUFFIX)
+			assertThat(it.packagedElements.size, is(4))
+		]
 	}
 
 	@Test
 	def void testInterfaceRealizaionRemoved() {
-		// ***First create a realized and used Interface***
-		// Create 2 Components:
-		val classPackage1 = createPackage(CLASS_NAME)
-		val umlClass1 = createClass(CLASS_NAME, classPackage1, 0)
-		val classPackage2 = createPackage(CLASS_NAME2)
-		val umlClass2 = createClass(CLASS_NAME2, classPackage2, 0)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME2 + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME2»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			val model = it
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				val interface = UMLFactory.eINSTANCE.createInterface() => [
+					name = INTERFACE_NAME
+				]
+				packagedElements += interface
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
+						name = INTERFACE_REALIZATION_NAME
+						suppliers += interface
+					]
+				]
 
-		// Create a new Interface in Class Package 1	and provide it here:
-		val classInterface = createInterface(INTERFACE_NAME, classPackage1)
-		val classIFRealizationProv = createInterfaceRealization(INTERFACE_REALIZATION_NAME, umlClass1)
-		classIFRealizationProv.suppliers += classInterface
+			]
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME2 + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME2
+					interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
+						name = INTERFACE_REALIZATION_NAME2
+						suppliers +=
+							model.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX).
+								claimPackagedElementWithName(Interface, INTERFACE_NAME)
+					]
+				]
+			]
+		]
 
-		saveAndSynchronizeWithInteractions(rootElement)
+		rootElement => [
+			it.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+			it.claimPackagedElementWithName(Package, CLASS_NAME2 + PACKAGE_SUFFIX)
+			val component1 = it.claimPackagedElementWithName(Component, CLASS_NAME)
+			val component2 = it.claimPackagedElementWithName(Component, CLASS_NAME2)
+			val componentInterface = it.claimPackagedElementWithName(Interface, INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
+			component1.claimInterfaceRealization(INTERFACE_REALIZATION_NAME + COMP_IFR_AND_USAGE_SUFFIX,
+				componentInterface)
+			val usage = component2.claimPackagedElementWithName(Usage,
+				INTERFACE_REALIZATION_NAME2 + COMP_IFR_AND_USAGE_SUFFIX)
+			assertThat(usage.suppliers, hasItem(componentInterface))
+			assertThat(usage.suppliers.size, is(1))
+			assertThat(it.packagedElements.size, is(5))
+		]
 
-		// Realize the Interface in Class 2:
-		val classIFRealizationReq = createInterfaceRealization(INTERFACE_REALIZATION_NAME2, umlClass2)
-		classIFRealizationReq.suppliers += classInterface
+		// Remove interface usage
+		rootElement.propagate [
+			claimPackagedElementWithName(Component, CLASS_NAME2) => [
+				claimPackagedElementWithName(Usage, INTERFACE_REALIZATION_NAME2 + COMP_IFR_AND_USAGE_SUFFIX) => [
+					destroy()
+				]
+			]
+		]
 
-		saveAndSynchronizeWithInteractions(classIFRealizationReq)
+		rootElement => [
+			it.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+			it.claimPackagedElementWithName(Package, CLASS_NAME2 + PACKAGE_SUFFIX)
+			val component1 = it.claimPackagedElementWithName(Component, CLASS_NAME)
+			val component2 = it.claimPackagedElementWithName(Component, CLASS_NAME2)
+			val componentInterface = it.claimPackagedElementWithName(Interface, INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
+			component1.claimInterfaceRealization(INTERFACE_REALIZATION_NAME + COMP_IFR_AND_USAGE_SUFFIX,
+				componentInterface)
+			component2.claimNoPackagedElementWithName(Usage, INTERFACE_REALIZATION_NAME2 + COMP_IFR_AND_USAGE_SUFFIX)
+			assertThat(it.packagedElements.size, is(5))
+		]
 
-		// Assert and get Components:
-		assertComponentForClass(umlClass1, CLASS_NAME)
-		val umlComp2 = assertComponentForClass(umlClass2, CLASS_NAME2)
+		// Remove interface realization
+		rootElement.propagate [
+			val interface = claimPackagedElementWithName(Interface, INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
+			claimPackagedElementWithName(Component, CLASS_NAME) => [
+				claimInterfaceRealization(INTERFACE_REALIZATION_NAME + COMP_IFR_AND_USAGE_SUFFIX, interface) => [
+					destroy()
+				]
+			]
+		]
 
-		// Assert Component Interface:
-		assertInterface(classInterface)
-		// Assert Component InterfaceRealization:
-		val compIFRealization = assertInterfaceRealization(classIFRealizationProv, INTERFACE_REALIZATION_NAME)
-		// Assert Component Usage:
-		val compUsage = assertUsage(classIFRealizationReq, INTERFACE_REALIZATION_NAME2)
-
-		// /***Then remove the InterfaceRealizaions***
-		classIFRealizationReq.destroy
-		saveAndSynchronizeWithInteractions(rootElement)
-		// There should be no corresponding InterfaceRealization anymore
-		assertFalse(umlComp2.interfaceRealizations.contains(compIFRealization))
-
-		classIFRealizationProv.destroy
-		saveAndSynchronizeWithInteractions(rootElement)
-		// There should be no corresponding InterfaceRealization anymore
-		assertFalse(umlComp2.packagedElements.contains(compUsage))
+		rootElement => [
+			it.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+			it.claimPackagedElementWithName(Package, CLASS_NAME2 + PACKAGE_SUFFIX)
+			val component1 = it.claimPackagedElementWithName(Component, CLASS_NAME)
+			val component2 = it.claimPackagedElementWithName(Component, CLASS_NAME2)
+			val componentInterface = it.claimPackagedElementWithName(Interface, INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
+			component1.claimNoInterfaceRealization(INTERFACE_REALIZATION_NAME + COMP_IFR_AND_USAGE_SUFFIX,
+				componentInterface)
+			component2.claimNoPackagedElementWithName(Usage, INTERFACE_REALIZATION_NAME2 + COMP_IFR_AND_USAGE_SUFFIX)
+			assertThat(it.packagedElements.size, is(5))
+		]
 	}
 
-	/***************
-	 * Assert Helper:*
-	 ****************/
-	private def Interface assertInterface(Interface classInterface) {
-		var correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classInterface]).flatten.filter(
-			Interface)
-		assertEquals(1, correspondingElements.size)
-		val compInterface = correspondingElements.get(0)
-		assertTypeAndName(compInterface, Interface, INTERFACE_NAME + COMP_INTERFACE_SUFFIX)
-		return compInterface
-	}
-
-	private def InterfaceRealization assertInterfaceRealization(InterfaceRealization classIFRealization, String name) {
-		var correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classIFRealization]).flatten.filter(
-			InterfaceRealization)
-		assertEquals(1, correspondingElements.size)
-		val compIFRealization = correspondingElements.get(0)
-		assertTypeAndName(compIFRealization, InterfaceRealization, name + COMP_IFR_AND_USAGE_SUFFIX)
-		return compIFRealization
-	}
-
-	private def Usage assertUsage(InterfaceRealization classIFRealization, String name) {
-		var correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classIFRealization]).flatten.
-			filter(Usage)
-		assertEquals(1, correspondingElements.size)
-		val compUsage = correspondingElements.get(0)
-		assertTypeAndName(compUsage, Usage, name + COMP_IFR_AND_USAGE_SUFFIX)
-		return compUsage
-	}
-
-	/*****************
-	 * Creation Helper:*
-	 ******************/
-	private def Interface createInterface(String name, Package classPackage) {
-		val classInterface = UMLFactory.eINSTANCE.createInterface()
-		classInterface.name = name
-		classPackage.packagedElements += classInterface
-		return classInterface
-	}
-
-	private def InterfaceRealization createInterfaceRealization(String name, Class umlClass) {
-		val classInterfaceRealization = UMLFactory.eINSTANCE.createInterfaceRealization()
-		classInterfaceRealization.name = name
-		classInterfaceRealization.clients += umlClass
-		umlClass.interfaceRealizations += classInterfaceRealization
-		return classInterfaceRealization
-	}
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/ModelTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/ModelTest.xtend
@@ -1,30 +1,17 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.class2comp
 
-import org.eclipse.uml2.uml.Model
-
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
 import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.testutils.matchers.ModelMatchers.isResource
-import java.nio.file.Path
 
 class ModelTest extends AbstractClass2CompTest {
 
-	/*******
-	 * Model:*
-	 ********/
-	// Model creation currently unused due to usage of one singular Model
 	@Test
 	def void testModelCreation() {
-		val modelUri = getUri(Path.of(FOLDER_NAME).resolve(MODEL_NAME + "." + MODEL_FILE_EXTENSION))
-		assertThat(modelUri, isResource)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[rootElement]).flatten
-		assertEquals(1, correspondingElements.size)
-		val umlModel = correspondingElements.get(0)
-		assertTypeAndName(umlModel, Model, MODEL_NAME)
+		assertThat(getUri(MODEL_NAME.projectModelPath), isResource)
+		rootElement // No exception when retrieving root model
 	}
 
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/PackageTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/PackageTest.xtend
@@ -1,120 +1,246 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.class2comp
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
 import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Disabled
 
-import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertFalse
-import static org.junit.jupiter.api.Assertions.assertEquals
 import static tools.vitruv.framework.userinteraction.UserInteractionOptions.NotificationType.INFORMATION
+import org.eclipse.uml2.uml.UMLFactory
+import org.eclipse.uml2.uml.Component
+import org.eclipse.uml2.uml.Package
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.CoreMatchers.is
 
 class PackageTest extends AbstractClass2CompTest {
 
-	/**********
-	 * Packages:*
-	 ***********/
 	@Test
 	def void testCreatePackageWithoutLink() {
-		// Create Component without Package:
-		val umlClass = createClass(CLASS_NAME, 0)
-		saveAndSynchronizeWithInteractions(umlClass)
-		assertComponentForClass(umlClass, CLASS_NAME)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+			]
+		]
 
-		val classPackage = createPackage(CLASS_NAME)
-		saveAndSynchronizeWithInteractions(rootElement)
-
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classPackage]).flatten
-		assertEquals(0, correspondingElements.size)
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(1))
 	}
 
 	@Test
-	def void testPackageIllegalRename1() {
-		// Create Package and try to rename to DataType-Package name:
-		val classPackage = createPackage(PACKAGE_NAME)
-		saveAndSynchronizeWithInteractions(rootElement)
-		classPackage.name = CLASS_DATATYPES_PACKAGE
-		saveAndSynchronizeWithInteractions(rootElement)
+	def void testIllegalRenamePackageToDatatypes() {
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = PACKAGE_NAME
+			]
+		]
 
-		assertFalse(classPackage.name == CLASS_DATATYPES_PACKAGE_NAME)
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, PACKAGE_NAME) => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+			]
+		]
+
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Package, PACKAGE_NAME)
+		assertThat(rootElement.packagedElements.size, is(1))
 	}
 
 	@Test
-	def void testPackageIllegalRename2() {
-		// Create Package and try to overwrite the pre-existing DataType-Package name:
-		val dataTypePackage = createPackage(CLASS_DATATYPES_PACKAGE)
-		val classPackage = createPackage(PACKAGE_NAME)
-		saveAndSynchronizeWithInteractions(rootElement)
-		classPackage.name = CLASS_DATATYPES_PACKAGE
-		saveAndSynchronizeWithInteractions(rootElement)
+	def void testIllegalRenameToExistingDatatypes() {
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_DATATYPES_PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«PACKAGE_NAME»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+			]
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = PACKAGE_NAME
+			]
+		]
 
-		assertFalse(classPackage.name == CLASS_DATATYPES_PACKAGE_NAME)
-		assertTrue(dataTypePackage.name == CLASS_DATATYPES_PACKAGE_NAME)
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		rootElement.claimPackagedElementWithName(Package, PACKAGE_NAME)
+		assertThat(rootElement.packagedElements.size, is(2))
+
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, PACKAGE_NAME) => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+			]
+		]
+
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		rootElement.claimPackagedElementWithName(Package, PACKAGE_NAME)
+		assertThat(rootElement.packagedElements.size, is(2))
 	}
 
 	@Disabled
-	def void testPackageIllegalRename3() {
-		// Create Package with legal DataType-Package name, then try to rename it:
-		val dataTypePackage = createPackage(CLASS_DATATYPES_PACKAGE)
+	def void testIllegalRenameFromDatatypesPackage() {
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.
+				contains('''link this Package '«CLASS_DATATYPES_PACKAGE + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_DATATYPES_PACKAGE_NAME
+			]
+		]
 
-		// Try to rename DataType-Package:
-		dataTypePackage.name = PACKAGE_NAME
-		saveAndSynchronizeWithInteractions(rootElement)
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		assertThat(rootElement.packagedElements.size, is(1))
 
-		assertTrue(dataTypePackage.name == CLASS_DATATYPES_PACKAGE_NAME)
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME) => [
+				name = PACKAGE_NAME
+			]
+		]
+
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
+		assertThat(rootElement.packagedElements.size, is(1))
 	}
 
-//	@Test
-//	public def void testCreatePackageWithLinkSuccess() { //TODO Fix later with new package linking
-//		//Create Component without Package:
-//		val umlClass = createClass(CLASS_NAME, 0)
-//		saveAndSynchronizeWithInteractions(umlClass)
-//		assertComponent(umlClass, CLASS_NAME)
-//		
-//		//Create Package and try to link it:
-//		val classPackage = createPackage(PACKAGE_NAME2, 0, 0)
-//		saveAndSynchronizeWithInteractions(rootElement)
-//		
-//		assertPackageLinkedToComponent(classPackage, COMPONENT_NAME)		
-//	}
-	// TODO implement this
-	// @Test
-	// public def void testCreatePackageWithLinkSuccessMultiOptions() {
-	// assertTrue(false)
-	// }
+	@Test
+	def void testLinkPackageToSingleExistingComponentAndRenameIt() {
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = CLASS_NAME
+			]
+		]
+
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		assertThat(rootElement.packagedElements.size, is(1))
+
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+			]
+		]
+
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(2))
+
+		rootElement.propagate [
+			claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX) => [
+				name = CLASS_NAME2 + PACKAGE_SUFFIX
+			]
+		]
+
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME2)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME2 + PACKAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(2))
+	}
+
+	@Test
+	def void testLinkPackageToSelectedExistingComponentAndRenameIt() {
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = CLASS_NAME
+			]
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = CLASS_NAME2
+			]
+		]
+
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME2)
+		assertThat(rootElement.packagedElements.size, is(2))
+
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("Yes")
+		userInteraction.onMultipleChoiceSingleSelection[message.contains('''Choose an existing Component''')].
+			respondWith(CLASS_NAME)
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+			]
+		]
+
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME2)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(3))
+	}
+
+	@Test
+	def void testNotLinkPackageToAlreadyLinkedComponent() {
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = CLASS_NAME
+			]
+		]
+
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		assertThat(rootElement.packagedElements.size, is(1))
+
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+			]
+		]
+
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(2))
+
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«PACKAGE_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("Yes")
+		userInteraction.acknowledgeNotification [
+			message.contains("Chosen Component is already linked to existing Package")
+		]
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = PACKAGE_NAME + PACKAGE_SUFFIX
+			]
+		]
+
+		userInteraction.assertAllInteractionsOccurred()
+		rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX)
+		rootElement.claimPackagedElementWithName(Package, PACKAGE_NAME + PACKAGE_SUFFIX)
+		assertThat(rootElement.packagedElements.size, is(3))
+	}
+
 	@Test
 	def void testCreatePackageWithLinkButNoComponent() {
-		// Create Package and try to link it no non-existing Component
-		val classPackage = createPackage(PACKAGE_NAME, 0, -1)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("Yes")
 		userInteraction.acknowledgeNotification [
 			notificationType == INFORMATION && message == "No available Component found"
 		]
-		saveAndSynchronizeWithInteractions(classPackage)
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+			]
+		]
 
-		// No links should exist:
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classPackage]).flatten
-		assertEquals(0, correspondingElements.size)
+		userInteraction.assertAllInteractionsOccurred()
+		assertThat(rootElement.packagedElements.size, is(1))
 	}
 
-//	@Test
-//	public def void testCreatePackageWithLinkButComponentHasLink() { //TODO Fix later with new package linking
-//		//Create a Class with a corresponding Component:
-//		val classPackageOld = createPackage(CLASS_NAME)
-//		val umlClass = createClass(CLASS_NAME, classPackageOld, 0)
-//		saveAndSynchronizeWithInteractions(umlClass)
-//		assertComponent(umlClass, CLASS_NAME)		
-//		assertPackageLinkedToComponent(classPackageOld, CLASS_NAME)
-//		
-//		//Create a new Package and try to link it:
-//		val classPackageNew = createPackage(PACKAGE_NAME2, 0, 0)
-//		saveAndSynchronizeWithInteractions(rootElement)
-//		
-//		//No new link should have been created
-//		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[classPackageNew]).flatten
-//		assertEquals(0, correspondingElements.size)
-//		
-//		//Old link should still exist
-//		assertPackageLinkedToComponent(classPackageOld, CLASS_NAME)
-//	}	
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/VisibilityTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/class2comp/VisibilityTest.xtend
@@ -1,34 +1,48 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.class2comp
 
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.uml2.uml.NamedElement
 import org.eclipse.uml2.uml.VisibilityKind
+import org.eclipse.uml2.uml.Package
+import org.eclipse.uml2.uml.Class
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import org.eclipse.uml2.uml.UMLFactory
+import org.eclipse.uml2.uml.Component
 
 class VisibilityTest extends AbstractClass2CompTest {
 
 	@Test
 	def void testVisibilityChange() {
-		val umlClass = createClass(CLASS_NAME, 0)
-		umlClass.visibility = VisibilityKind.PRIVATE_LITERAL
-		saveAndSynchronizeWithInteractions(umlClass)
-		assertVisibility(umlClass)
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''link this Package '«CLASS_NAME + PACKAGE_SUFFIX»' to an existing Component''')
+		].respondWith("No")
+		userInteraction.onMultipleChoiceSingleSelection [
+			message.contains('''Should '«CLASS_NAME»' be represented by a Component?''')
+		].respondWith("Yes")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createPackage() => [
+				name = CLASS_NAME + PACKAGE_SUFFIX
+				packagedElements += UMLFactory.eINSTANCE.createClass() => [
+					name = CLASS_NAME
+					visibility = VisibilityKind.PRIVATE_LITERAL
+				]
+			]
+		]
 
-		umlClass.visibility = VisibilityKind.PUBLIC_LITERAL
-		saveAndSynchronizeWithInteractions(umlClass)
-		assertVisibility(umlClass)
-	}
+		var component = rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		assertEquals(VisibilityKind.PRIVATE_LITERAL, component.visibility)
 
-	private def void assertVisibility(NamedElement element) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[element]).flatten
-		for (EObject corrElement : correspondingElements) {
-			assertTrue((corrElement as NamedElement).visibility == element.visibility)
-		}
+		rootElement.claimPackagedElementWithName(Package, CLASS_NAME + PACKAGE_SUFFIX).propagate [
+			claimPackagedElementWithName(Class, CLASS_NAME) => [
+				visibility = VisibilityKind.PUBLIC_LITERAL
+			]
+		]
 
+		component = rootElement.claimPackagedElementWithName(Component, CLASS_NAME)
+		assertEquals(VisibilityKind.PUBLIC_LITERAL, component.visibility)
 	}
 
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/AbstractComp2ClassTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/AbstractComp2ClassTest.xtend
@@ -1,106 +1,46 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.comp2class
 
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.uml2.uml.Class
-import org.eclipse.uml2.uml.Component
 import org.eclipse.uml2.uml.Model
-import org.eclipse.uml2.uml.Package
-import org.eclipse.uml2.uml.PackageableElement
 import org.eclipse.uml2.uml.UMLFactory
 import tools.vitruv.applications.umlclassumlcomponents.comp2class.UmlComp2UmlClassChangePropagation
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
 import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.BeforeEach
-import tools.vitruv.testutils.LegacyVitruvApplicationTest
 import java.nio.file.Path
 
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertEquals
+import tools.vitruv.testutils.VitruvApplicationTest
 
-abstract class AbstractComp2ClassTest extends LegacyVitruvApplicationTest {
-
-	protected def Model getRootElement() {
-		return Model.from(MODEL_NAME.projectModelPath)
-	}
+abstract class AbstractComp2ClassTest extends VitruvApplicationTest {
 
 	override protected getChangePropagationSpecifications() {
 		return #[new UmlComp2UmlClassChangePropagation()]
 	}
 
-	// SaveAndSynchronize & commit all pending userInteractions
-	protected def saveAndSynchronizeWithInteractions(EObject object) {
-		propagate
-		userInteraction.assertAllInteractionsOccurred()
-	}
-
 	@BeforeEach
-	def protected setup() {
-		initializeTestModel()
-	}
-
-	protected def void initializeTestModel() {
-		val umlModel = UMLFactory.eINSTANCE.createModel() => [
-			name = MODEL_NAME
-		]
-		resourceAt(MODEL_NAME.projectModelPath).startRecordingChanges => [
-			contents += umlModel
-		]
-		propagate
-	}
-
-	private def Path getProjectModelPath(String modelName) {
-		Path.of(FOLDER_NAME).resolve(modelName + "." + MODEL_FILE_EXTENSION)
-	}
-
-	/*****************
-	 * Creation Helper:*
-	 ******************/
-	protected def Component createComponent(String name) {
-		val umlComponent = UMLFactory.eINSTANCE.createComponent()
-		umlComponent.name = name
-		rootElement.packagedElements += umlComponent
-		return umlComponent
-	}
-
-	/***************
-	 * Assert Helper:*
-	 ****************/
-	protected def Class assertClass(PackageableElement compElement, String name) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[compElement]).flatten.filter(Class)
-		assertEquals(1, correspondingElements.size)
-		val umlClass = correspondingElements.get(0)
-		assertTypeAndName(umlClass, Class, name)
-		return umlClass
-	}
-
-	protected def Class assertClassAndPackage(Component umlComp, String name) {
-		return assertClassAndPackage(umlComp, name, name + PACKAGE_SUFFIX, true)
-	}
-
-	protected def Class assertClassAndPackage(PackageableElement compElement, String name, String packageName,
-		Boolean packageCorrCheck) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[compElement]).flatten
-
-		// Check Class
-		val umlClass = correspondingElements.filter(Class).get(0)
-
-		assertTypeAndName(umlClass, Class, name)
-		// Check Package
-		val classPackage = umlClass.package
-		assertEquals(packageName, classPackage.name)
-		val packageOwnedTypes = classPackage.ownedTypes
-		assertTrue(packageOwnedTypes.size >= 1)
-		val classFromPackage = packageOwnedTypes.get(0)
-		assertTypeAndName(classFromPackage, Class, name)
-
-		if (packageCorrCheck) {
-			// Check Package correspondence 
-			val classPackageFromCorrespondence = correspondingElements.filter(Package).get(0)
-			assertTypeAndName(classPackageFromCorrespondence, Package, name + PACKAGE_SUFFIX)
+	def setup() {
+		if (isInitializeTestModel()) {
+			initializeTestModel()
 		}
-		return umlClass
+	}
+	
+	protected def boolean isInitializeTestModel() {
+		return true
+	}
+
+	private def void initializeTestModel() {
+		resourceAt(MODEL_NAME.projectModelPath).propagate [
+			contents += UMLFactory.eINSTANCE.createModel() => [
+				name = MODEL_NAME
+			]
+		]
+	}
+
+	protected def Model getRootElement() {
+		return Model.from(MODEL_NAME.projectModelPath)
+	}
+	
+	protected def Path getProjectModelPath(String modelName) {
+		Path.of(FOLDER_NAME).resolve(modelName + "." + MODEL_FILE_EXTENSION)
 	}
 
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/AbstractComp2ClassTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/AbstractComp2ClassTest.xtend
@@ -1,46 +1,13 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.comp2class
 
-import org.eclipse.uml2.uml.Model
-import org.eclipse.uml2.uml.UMLFactory
 import tools.vitruv.applications.umlclassumlcomponents.comp2class.UmlComp2UmlClassChangePropagation
 
-import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
-import org.junit.jupiter.api.BeforeEach
-import java.nio.file.Path
+import tools.vitruv.applications.umlclassumlcomponents.tests.util.AbstractUmlClassCompTest
 
-import tools.vitruv.testutils.VitruvApplicationTest
-
-abstract class AbstractComp2ClassTest extends VitruvApplicationTest {
+abstract class AbstractComp2ClassTest extends AbstractUmlClassCompTest {
 
 	override protected getChangePropagationSpecifications() {
 		return #[new UmlComp2UmlClassChangePropagation()]
-	}
-
-	@BeforeEach
-	def setup() {
-		if (isInitializeTestModel()) {
-			initializeTestModel()
-		}
-	}
-	
-	protected def boolean isInitializeTestModel() {
-		return true
-	}
-
-	private def void initializeTestModel() {
-		resourceAt(MODEL_NAME.projectModelPath).propagate [
-			contents += UMLFactory.eINSTANCE.createModel() => [
-				name = MODEL_NAME
-			]
-		]
-	}
-
-	protected def Model getRootElement() {
-		return Model.from(MODEL_NAME.projectModelPath)
-	}
-	
-	protected def Path getProjectModelPath(String modelName) {
-		Path.of(FOLDER_NAME).resolve(modelName + "." + MODEL_FILE_EXTENSION)
 	}
 
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/Comp2ClassIntegrationTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/Comp2ClassIntegrationTest.xtend
@@ -47,8 +47,8 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 
 	@Test
 	def void integrationTestWithComponentAnd2DataTypes() {
-		userInteraction// Decide to create a Class for the first DataType:
-		.onNextMultipleChoiceSingleSelection.respondWith("No")// Decide to create a Class for the second DataType:
+		userInteraction // Decide to create a Class for the first DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No") // Decide to create a Class for the second DataType:
 		.onNextMultipleChoiceSingleSelection.respondWith("No")
 
 		val umlModel = integrationTest("TestModelWith2DataTypesAndComponent.uml")
@@ -64,8 +64,8 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 
 	@Test
 	def void integrationTestWithComponentAndDataTypeWithoutClassRepresentation() {
-		userInteraction// Decide to create no corresponding Class for the first DataType:
-		.onNextMultipleChoiceSingleSelection.respondWith("Yes")// Decide to create a Class for the second DataType:
+		userInteraction // Decide to create no corresponding Class for the first DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("Yes") // Decide to create a Class for the second DataType:
 		.onNextMultipleChoiceSingleSelection.respondWith("No")
 
 		val umlModel = integrationTest("TestModelWith2DataTypesAndComponent.uml")
@@ -81,7 +81,7 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 
 	@Test
 	def void integrationTestWithDataTypeWithPropertyAndOperation() {
-		userInteraction// Decide to create a Class for the DataType:
+		userInteraction // Decide to create a Class for the DataType:
 		.onNextMultipleChoiceSingleSelection.respondWith("No")
 
 		val umlModel = integrationTest("TestModelDataTypeWithPropertyAndOperation.uml")
@@ -162,8 +162,8 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 	@Disabled
 	@Test
 	def void integrationTestAllCombined() {
-		userInteraction// Decide to create a Class for the first DataType:
-		.onNextMultipleChoiceSingleSelection.respondWith("No")// Decide to create no corresponding Class for the second DataType:
+		userInteraction // Decide to create a Class for the first DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No") // Decide to create no corresponding Class for the second DataType:
 		.onNextMultipleChoiceSingleSelection.respondWith("Yes")
 
 		val umlModel = integrationTest("TestModelAllCombined.uml")
@@ -209,9 +209,9 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 	@Test
 	def void integrationTestMatthiasSmallExampleComponentResult() {
 		// This model was retrieved out of the BA PCM->Comp as the result of an integration
-		userInteraction// Decide to create a Class for the first DataType:
-		.onNextMultipleChoiceSingleSelection.respondWith("No")// Decide to create a Class for the second DataType:
-		.onNextMultipleChoiceSingleSelection.respondWith("No")// Decide to create a Class for the third DataType:
+		userInteraction // Decide to create a Class for the first DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No") // Decide to create a Class for the second DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No") // Decide to create a Class for the third DataType:
 		.onNextMultipleChoiceSingleSelection.respondWith("No")
 
 		integrationTest("Matthias_small_example_Component_Result.uml")

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/Comp2ClassIntegrationTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/Comp2ClassIntegrationTest.xtend
@@ -1,6 +1,5 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.comp2class
 
-import java.util.Collections
 import org.eclipse.uml2.uml.InterfaceRealization
 import org.eclipse.uml2.uml.Model
 import org.eclipse.uml2.uml.NamedElement
@@ -18,29 +17,21 @@ import org.junit.jupiter.api.Disabled
 
 import static org.junit.jupiter.api.Assertions.assertTrue
 import java.nio.file.Path
-import org.eclipse.emf.ecore.EObject
 
 class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 
-	override protected setup() {
-		// Don't initialize a model here, as we are loading and creating one
+	override protected isInitializeTestModel() {
+		return false
 	}
 
 	def Model integrationTest(String fileName) {
-		resourceAt(Path.of(OUTPUT_NAME)).startRecordingChanges => [
-			contents += EObject.from(fileName.testModelResource)
+		resourceAt(Path.of(OUTPUT_NAME)).propagate [
+			contents += Model.from(fileName.testModelResource)
 		]
-		propagate
 
-		val umlModel = correspondenceModel.getAllEObjectsOfTypeInCorrespondences(Model).get(0)
-		umlModel.eResource.save(Collections.EMPTY_MAP)
-
-		return umlModel
+		return Model.from(Path.of(OUTPUT_NAME))
 	}
 
-	/*******
-	 * Tests:*
-	 ********/
 	@Test
 	def void integrationTestWith2Components() {
 		val umlModel = integrationTest("TestModel2Components.uml")
@@ -56,11 +47,9 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 
 	@Test
 	def void integrationTestWithComponentAnd2DataTypes() {
-		userInteraction
-			// Decide to create a Class for the first DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// Decide to create a Class for the second DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
+		userInteraction// Decide to create a Class for the first DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")// Decide to create a Class for the second DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")
 
 		val umlModel = integrationTest("TestModelWith2DataTypesAndComponent.uml")
 
@@ -75,11 +64,9 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 
 	@Test
 	def void integrationTestWithComponentAndDataTypeWithoutClassRepresentation() {
-		userInteraction
-			// Decide to create no corresponding Class for the first DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")
-			// Decide to create a Class for the second DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
+		userInteraction// Decide to create no corresponding Class for the first DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("Yes")// Decide to create a Class for the second DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")
 
 		val umlModel = integrationTest("TestModelWith2DataTypesAndComponent.uml")
 
@@ -94,9 +81,8 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 
 	@Test
 	def void integrationTestWithDataTypeWithPropertyAndOperation() {
-		userInteraction
-			// Decide to create a Class for the DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
+		userInteraction// Decide to create a Class for the DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")
 
 		val umlModel = integrationTest("TestModelDataTypeWithPropertyAndOperation.uml")
 
@@ -176,11 +162,9 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 	@Disabled
 	@Test
 	def void integrationTestAllCombined() {
-		userInteraction
-			// Decide to create a Class for the first DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// Decide to create no corresponding Class for the second DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("Yes")
+		userInteraction// Decide to create a Class for the first DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")// Decide to create no corresponding Class for the second DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("Yes")
 
 		val umlModel = integrationTest("TestModelAllCombined.uml")
 
@@ -193,7 +177,6 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 		assertCountOfTypeInPackage(modelElements, 2, Class, 1) // Class Package 2 should have 1 Class
 		assertCountOfTypeInPackage(modelElements, 1, Interface, 1) // Class Package 1 should have 1 Interface
 		assertCountOfTypeInPackage(modelElements, 2, Interface, 0) // Class Package 2 should have no Interfaces
-
 		// Check Class 1 for InterfaceRealization and inspect if it's setup correctly:
 		val umlClass = modelElements.filter(Package).get(1).packagedElements.filter(Class).get(0)
 		val iFRealizations = umlClass.interfaceRealizations.map[e|e as NamedElement]
@@ -226,13 +209,10 @@ class Comp2ClassIntegrationTest extends AbstractComp2ClassTest {
 	@Test
 	def void integrationTestMatthiasSmallExampleComponentResult() {
 		// This model was retrieved out of the BA PCM->Comp as the result of an integration
-		userInteraction
-			// Decide to create a Class for the first DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// Decide to create a Class for the second DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
-			// Decide to create a Class for the third DataType:
-			.onNextMultipleChoiceSingleSelection.respondWith("No")
+		userInteraction// Decide to create a Class for the first DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")// Decide to create a Class for the second DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")// Decide to create a Class for the third DataType:
+		.onNextMultipleChoiceSingleSelection.respondWith("No")
 
 		integrationTest("Matthias_small_example_Component_Result.uml")
 

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ComponentTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ComponentTest.xtend
@@ -2,127 +2,155 @@ package tools.vitruv.applications.umlclassumlcomponents.tests.comp2class
 
 import org.eclipse.uml2.uml.UMLFactory
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertFalse
+import org.eclipse.uml2.uml.Component
+import org.eclipse.uml2.uml.Class
+import org.eclipse.uml2.uml.Package
 
 class ComponentTest extends AbstractComp2ClassTest {
 
-	/*******
-	 * Tests:*
-	 ********/
 	@Test
 	def void testCreateClassForComponent() {
-		val umlComp = createComponent(COMP_NAME)
-		propagate
-
-		assertClassAndPackage(umlComp, COMP_NAME)
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = COMP_NAME
+			]
+		]
+		
+		rootElement.claimPackagedElementWithName(Component, COMP_NAME)
+		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
+			claimPackagedElementWithName(Class, COMP_NAME)
 	}
 
 	@Test
 	def void testRenameComponent() {
-		val umlComp = createComponent("Old")
-		propagate
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = COMP_NAME
+			]
+		]
+		
+		val changedCompName = COMP_NAME + "New"
+		rootElement.claimPackagedElementWithName(Component, COMP_NAME).propagate [
+			name = changedCompName
+		]
 
-		// Change name:
-		umlComp.name = "New"
-		propagate
-
-		// Check if rename happened in Class & Package:
-		assertClassAndPackage(umlComp, "New")
+		rootElement.claimNoPackagedElementWithName(Component, COMP_NAME)
+		rootElement.claimNoPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
+		rootElement.claimPackagedElementWithName(Component, changedCompName)
+		rootElement.claimPackagedElementWithName(Package, changedCompName + PACKAGE_SUFFIX).
+			claimPackagedElementWithName(Class, changedCompName)
 	}
 
 	@Test
 	def void testDeleteComponentWithPackage() {
-		val umlComp = createComponent(COMP_NAME)
-		propagate
-
-		val umlClass = assertClassAndPackage(umlComp, COMP_NAME)
-		val classPackage = umlClass.package
-		val classModel = umlClass.model
-
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = COMP_NAME
+			]
+		]
+		
+		rootElement.claimPackagedElementWithName(Component, COMP_NAME)
+		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
+			claimPackagedElementWithName(Class, COMP_NAME)
+		
 		// Remove Component		
-		assertTrue(rootElement.packagedElements.contains(umlComp))
-		umlComp.destroy()
-		assertFalse(rootElement.packagedElements.contains(umlComp))
-		propagate
+		rootElement.propagate [
+			claimPackagedElementWithName(Component, COMP_NAME).destroy()
+		]
 
-		// Check if Class or Package exists:		
-		assertFalse(classPackage.packagedElements.contains(umlClass))
-		assertFalse(classModel.packagedElements.contains(umlClass))
-		assertFalse(classModel.packagedElements.contains(classPackage))
+		rootElement.claimNoPackagedElementWithName(Component, COMP_NAME)
+		rootElement.claimNoPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
 	}
 
 	@Test
 	def void testDeleteComponentWithoutPackage() {
-		val umlComp = createComponent(COMP_NAME)
-		propagate
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = COMP_NAME
+			]
+		]
 
-		val umlClass = assertClassAndPackage(umlComp, COMP_NAME)
-		val classPackage = umlClass.package
-		val classModel = umlClass.model
+		rootElement.claimPackagedElementWithName(Component, COMP_NAME)
+		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
+			claimPackagedElementWithName(Class, COMP_NAME)
 
-		// Package gets more members:
-		val umlClass2 = UMLFactory.eINSTANCE.createClass()
-		umlClass2.name = CLASS_NAME2
-		// Add new Class to Package in transaction:
-		classPackage.packagedElements += umlClass2
+		rootElement.getPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).propagate [
+			// Package gets more members:
+			val umlClass2 = UMLFactory.eINSTANCE.createClass()
+			umlClass2.name = CLASS_NAME2
+			// Add new Class to Package in transaction:
+			packagedElements += umlClass2
+		]
 
 		// Remove Component		
-		assertTrue(rootElement.packagedElements.contains(umlComp))
-		userInteraction.onMultipleChoiceSingleSelection [
-			message.contains("Delete the corresponding Package") && message.contains("and all its contained elements")
-		].respondWith("No")
-		umlComp.destroy()
-		assertFalse(rootElement.packagedElements.contains(umlComp))
-		saveAndSynchronizeWithInteractions(rootElement)
+		rootElement.propagate [
+			userInteraction.onMultipleChoiceSingleSelection [
+				message.contains("Delete the corresponding Package") &&
+					message.contains("and all its contained elements")
+			].respondWith("No")
+			claimPackagedElementWithName(Component, COMP_NAME).destroy()
+		]
 
-		// Check if Class or Package exists:		
-		assertFalse(classPackage.packagedElements.contains(umlClass))
-		assertFalse(classModel.packagedElements.contains(umlClass))
-		assertTrue(classModel.packagedElements.contains(classPackage))
-		assertTrue(classPackage.packagedElements.contains(umlClass2))
+		userInteraction.assertAllInteractionsOccurred()
+
+		rootElement.claimNoPackagedElementWithName(Component, COMP_NAME)
+		val package = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
+		package.claimNoPackagedElementWithName(Class, COMP_NAME)
+		package.claimPackagedElementWithName(Class, CLASS_NAME2)
 	}
 
 	@Test
 	def void testDeleteComponentWithPackageAndContents() {
-		val umlComp = createComponent(COMP_NAME)
-		propagate
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = COMP_NAME
+			]
+		]
+		
+		rootElement.claimPackagedElementWithName(Component, COMP_NAME)
+		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
+			claimPackagedElementWithName(Class, COMP_NAME)
 
-		val umlClass = assertClassAndPackage(umlComp, COMP_NAME)
-		val classPackage = umlClass.package
-		val classModel = umlClass.model
-
-		// Package gets more members:
-		val umlClass2 = UMLFactory.eINSTANCE.createClass()
-		umlClass2.name = CLASS_NAME2
-		// Add new Class to Package in transaction:
-		classPackage.packagedElements += umlClass2
+		rootElement.getPackagedElementWithName(Package, COMP_NAME + " Package").propagate [
+			// Package gets more members:
+			val umlClass2 = UMLFactory.eINSTANCE.createClass()
+			umlClass2.name = CLASS_NAME2
+			// Add new Class to Package in transaction:
+			packagedElements += umlClass2
+		]
 
 		// Remove Component		
-		assertTrue(rootElement.packagedElements.contains(umlComp))
-		userInteraction.onMultipleChoiceSingleSelection [
-			message.contains("Delete the corresponding Package") && message.contains("and all its contained elements")
-		].respondWith("Yes")
-		umlComp.destroy()
-		assertFalse(rootElement.packagedElements.contains(umlComp))
-		saveAndSynchronizeWithInteractions(rootElement)
+		rootElement.propagate [
+			userInteraction.onMultipleChoiceSingleSelection [
+				message.contains("Delete the corresponding Package") &&
+					message.contains("and all its contained elements")
+			].respondWith("Yes")
+			claimPackagedElementWithName(Component, COMP_NAME).destroy()
+		]
+		userInteraction.assertAllInteractionsOccurred()
 
-		// Check if Class or Package exists:		
-		assertFalse(classPackage.packagedElements.contains(umlClass))
-		assertFalse(classModel.packagedElements.contains(umlClass))
-		assertFalse(classModel.packagedElements.contains(classPackage))
-		assertFalse(classModel.packagedElements.contains(umlClass2))
+		rootElement.claimNoPackagedElementWithName(Component, COMP_NAME)
+		rootElement.claimNoPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
 	}
 
 	@Test
 	def void testCreate2ClassFor2Component() {
-		val umlComp1 = createComponent(COMP_NAME)
-		val umlComp2 = createComponent(COMP_NAME2)
-		propagate
-		assertClassAndPackage(umlComp1, COMP_NAME)
-		assertClassAndPackage(umlComp2, COMP_NAME2)
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = COMP_NAME
+			]
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = COMP_NAME2
+			]
+		]
+		rootElement.claimPackagedElementWithName(Component, COMP_NAME)
+		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
+			claimPackagedElementWithName(Class, COMP_NAME)
+		rootElement.claimPackagedElementWithName(Package, COMP_NAME2 + PACKAGE_SUFFIX).
+			claimPackagedElementWithName(Class, COMP_NAME2)
 	}
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ComponentTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ComponentTest.xtend
@@ -19,7 +19,7 @@ class ComponentTest extends AbstractComp2ClassTest {
 				name = COMP_NAME
 			]
 		]
-		
+
 		rootElement.claimPackagedElementWithName(Component, COMP_NAME)
 		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
 			claimPackagedElementWithName(Class, COMP_NAME)
@@ -32,7 +32,7 @@ class ComponentTest extends AbstractComp2ClassTest {
 				name = COMP_NAME
 			]
 		]
-		
+
 		val changedCompName = COMP_NAME + "New"
 		rootElement.claimPackagedElementWithName(Component, COMP_NAME).propagate [
 			name = changedCompName
@@ -52,11 +52,11 @@ class ComponentTest extends AbstractComp2ClassTest {
 				name = COMP_NAME
 			]
 		]
-		
+
 		rootElement.claimPackagedElementWithName(Component, COMP_NAME)
 		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
 			claimPackagedElementWithName(Class, COMP_NAME)
-		
+
 		// Remove Component		
 		rootElement.propagate [
 			claimPackagedElementWithName(Component, COMP_NAME).destroy()
@@ -110,7 +110,7 @@ class ComponentTest extends AbstractComp2ClassTest {
 				name = COMP_NAME
 			]
 		]
-		
+
 		rootElement.claimPackagedElementWithName(Component, COMP_NAME)
 		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
 			claimPackagedElementWithName(Class, COMP_NAME)

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ComponentTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ComponentTest.xtend
@@ -78,7 +78,7 @@ class ComponentTest extends AbstractComp2ClassTest {
 		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
 			claimPackagedElementWithName(Class, COMP_NAME)
 
-		rootElement.getPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).propagate [
+		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).propagate [
 			// Package gets more members:
 			val umlClass2 = UMLFactory.eINSTANCE.createClass()
 			umlClass2.name = CLASS_NAME2
@@ -115,7 +115,7 @@ class ComponentTest extends AbstractComp2ClassTest {
 		rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX).
 			claimPackagedElementWithName(Class, COMP_NAME)
 
-		rootElement.getPackagedElementWithName(Package, COMP_NAME + " Package").propagate [
+		rootElement.claimPackagedElementWithName(Package, COMP_NAME + " Package").propagate [
 			// Package gets more members:
 			val umlClass2 = UMLFactory.eINSTANCE.createClass()
 			umlClass2.name = CLASS_NAME2

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/DataTypeTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/DataTypeTest.xtend
@@ -2,117 +2,117 @@ package tools.vitruv.applications.umlclassumlcomponents.tests.comp2class
 
 import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.DataType
-import org.eclipse.uml2.uml.Operation
-import org.eclipse.uml2.uml.Property
+import org.eclipse.uml2.uml.Package
 import org.eclipse.uml2.uml.UMLFactory
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
 import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Disabled
 
-import static org.junit.jupiter.api.Assertions.assertNull
-import static org.junit.jupiter.api.Assertions.assertEquals
-
 class DataTypeTest extends AbstractComp2ClassTest {
 
-	/*******
-	 * Tests:*
-	 ********/
 	@Test
 	def void testCreateClassForDataType() {
-		val compDataType = createDataType(DATATYPE_NAME, 1)
-		propagate
+		userInteraction.onNextMultipleChoiceSingleSelection.respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createDataType() => [
+				name = DATATYPE_NAME
+			]
+		]
 
-		assertClassAndPackage(compDataType, DATATYPE_NAME, CLASS_DATATYPES_PACKAGE_NAME, false)
+		rootElement.claimPackagedElementWithName(DataType, DATATYPE_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME).
+			claimPackagedElementWithName(Class, DATATYPE_NAME)
 	}
 
 	@Test
 	def void testAddPropertyToDataType() {
-		val compDataType = createDataType(DATATYPE_NAME, 1)
-		propagate
+		userInteraction.onNextMultipleChoiceSingleSelection.respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createDataType() => [
+				name = DATATYPE_NAME
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[compDataType]).flatten
-		val umlClass = (correspondingElements.get(0) as Class)
-		val compProperty = UMLFactory.eINSTANCE.createProperty()
-		compProperty.name = PROPERTY_NAME
-		compDataType.ownedAttributes += compProperty
-		propagate
+		rootElement.claimPackagedElementWithName(DataType, DATATYPE_NAME).propagate [
+			ownedAttributes += UMLFactory.eINSTANCE.createProperty() => [
+				name = PROPERTY_NAME
+			]
+		]
 
-		assertEquals(1, umlClass.ownedAttributes.size)
-		val classProperty = umlClass.ownedAttributes.get(0)
-		assertTypeAndName(classProperty, Property, PROPERTY_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME).
+			claimPackagedElementWithName(Class, DATATYPE_NAME). //
+			claimOwnedAttributeWithName(PROPERTY_NAME)
 	}
 
-	@Disabled
 	@Test
 	def void testRenameDataTypeProperty() {
-		val compDataType = createDataType(DATATYPE_NAME, 1)
-		propagate
+		userInteraction.onNextMultipleChoiceSingleSelection.respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createDataType() => [
+				name = DATATYPE_NAME
+				ownedAttributes += UMLFactory.eINSTANCE.createProperty() => [
+					name = PROPERTY_NAME
+				]
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[compDataType]).flatten
-		val umlClass = (correspondingElements.get(0) as Class)
-		val compProperty = UMLFactory.eINSTANCE.createProperty()
-		compProperty.name = "Old"
-		compDataType.ownedAttributes += compProperty
-		propagate
+		val newPropertyName = PROPERTY_NAME + "New"
+		rootElement.claimPackagedElementWithName(DataType, DATATYPE_NAME).propagate [
+			claimOwnedAttributeWithName(PROPERTY_NAME) => [
+				name = newPropertyName
+			]
+		]
 
-		// Change name:
-		compProperty.name = "New"
-		propagate
-
-		// Check if rename happened in Class Property:
-		val classProperty = umlClass.ownedAttributes.get(0)
-		assertEquals("New", classProperty.name)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME).
+			claimPackagedElementWithName(Class, DATATYPE_NAME). //
+			claimOwnedAttributeWithName(newPropertyName)
 	}
 
 	@Test
 	def void testAddOperationToDataType() {
-		val compDataType = createDataType(DATATYPE_NAME, 1)
-		propagate
+		userInteraction.onNextMultipleChoiceSingleSelection.respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createDataType() => [
+				name = DATATYPE_NAME
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[compDataType]).flatten
-		val umlClass = (correspondingElements.get(0) as Class)
-		val compOperation = UMLFactory.eINSTANCE.createOperation()
-		compOperation.name = OPERATION_NAME
-		compDataType.ownedOperations += compOperation
-		propagate
+		rootElement.claimPackagedElementWithName(DataType, DATATYPE_NAME).propagate [
+			ownedOperations += UMLFactory.eINSTANCE.createOperation() => [
+				name = OPERATION_NAME
+			]
+		]
 
-		assertEquals(1, umlClass.ownedOperations.size)
-		val classOperation = umlClass.ownedOperations.get(0)
-		assertTypeAndName(classOperation, Operation, OPERATION_NAME)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME).
+			claimPackagedElementWithName(Class, DATATYPE_NAME). //
+			claimOwnedOperationWithName(OPERATION_NAME)
 	}
 
 	@Disabled
 	@Test
 	def void testRenameDataTypeOperation() {
-		val compDataType = createDataType(DATATYPE_NAME, 1)
-		propagate
+		userInteraction.onNextMultipleChoiceSingleSelection.respondWith("No")
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createDataType() => [
+				name = DATATYPE_NAME
+				ownedOperations += UMLFactory.eINSTANCE.createOperation() => [
+					name = OPERATION_NAME
+				]
+			]
+		]
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[compDataType]).flatten
-		val umlClass = (correspondingElements.get(0) as Class)
-		val compOperation = UMLFactory.eINSTANCE.createOperation()
-		compOperation.name = "Old"
-		compDataType.ownedOperations += compOperation
-		propagate
+		val newOperationName = OPERATION_NAME + "New"
+		rootElement.claimPackagedElementWithName(DataType, DATATYPE_NAME).propagate [
+			claimOwnedOperationWithName(PROPERTY_NAME) => [
+				name = newOperationName
+			]
+		]
 
-		// Change name:
-		compOperation.name = "New"
-		propagate
-
-		// Check if rename happened in Class Operation:
-		val classOperation = umlClass.ownedOperations.get(0)
-		assertEquals("New", classOperation.name)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME).
+			claimPackagedElementWithName(Class, DATATYPE_NAME). //
+			claimOwnedOperationWithName(newOperationName)
 	}
 
-	/*****************
-	 * Creation Helper:*
-	 ******************/
-	private def DataType createDataType(String name, int createClass) {
-		val dataType = UMLFactory.eINSTANCE.createDataType()
-		this.userInteraction.addNextSingleSelection(createClass) // Decide to create corresponding Class
-		dataType.name = name
-		rootElement.packagedElements += dataType
-		return dataType
-	}
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/InterfaceTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/InterfaceTest.xtend
@@ -24,7 +24,7 @@ class InterfaceTest extends AbstractComp2ClassTest {
 			val interface = UMLFactory.eINSTANCE.createInterface() => [
 				name = INTERFACE_NAME
 			]
-			packagedElements += interface 
+			packagedElements += interface
 			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
 				name = COMP_NAME
 				interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
@@ -33,13 +33,13 @@ class InterfaceTest extends AbstractComp2ClassTest {
 				]
 			]
 		]
-		
-		val componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)		
+
+		val componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
 		val componentClass = componentPackage.claimPackagedElementWithName(Class, COMP_NAME)
-		// TODO I think it's not reasonable to place the class interface in the package of the component realization class that uses the interface first.
-		// Probably, there should not even be two interfaces, one for the component and one for the class
-		val classInterface = componentPackage.claimPackagedElementWithName(Interface, INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
-		val classInterfaceRealization = componentClass.claimInterfaceRealization(INTERFACE_REALIZATION_NAME + CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
+		val classInterface = componentPackage.claimPackagedElementWithName(Interface,
+			INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
+		val classInterfaceRealization = componentClass.claimInterfaceRealization(INTERFACE_REALIZATION_NAME +
+			CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
 		componentClass.checkInterfaceRealization(classInterfaceRealization, classInterface)
 	}
 
@@ -49,7 +49,7 @@ class InterfaceTest extends AbstractComp2ClassTest {
 			val interface = UMLFactory.eINSTANCE.createInterface() => [
 				name = INTERFACE_NAME
 			]
-			packagedElements += interface 
+			packagedElements += interface
 			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
 				name = COMP_NAME
 				interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
@@ -58,19 +58,21 @@ class InterfaceTest extends AbstractComp2ClassTest {
 				]
 			]
 		]
-		 		
+
 		rootElement.claimPackagedElementWithName(Component, COMP_NAME).propagate [
 			val componentInterface = rootElement.claimPackagedElementWithName(Interface, INTERFACE_NAME)
 			claimInterfaceRealization(INTERFACE_REALIZATION_NAME, componentInterface) => [
 				destroy()
-			]	
+			]
 		]
-		
+
 		val componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
 		val componentClass = componentPackage.claimPackagedElementWithName(Class, COMP_NAME)
-		val classInterface = componentPackage.claimPackagedElementWithName(Interface, INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
-		componentClass.claimNoInterfaceRealization(INTERFACE_REALIZATION_NAME + CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
-		assertThat(componentClass.interfaceRealizations.size, is(0))	
+		val classInterface = componentPackage.claimPackagedElementWithName(Interface,
+			INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
+		componentClass.claimNoInterfaceRealization(INTERFACE_REALIZATION_NAME + CLASS_IFR_AND_USAGE_SUFFIX,
+			classInterface)
+		assertThat(componentClass.interfaceRealizations.size, is(0))
 	}
 
 	@Test
@@ -79,7 +81,7 @@ class InterfaceTest extends AbstractComp2ClassTest {
 			val interface = UMLFactory.eINSTANCE.createInterface() => [
 				name = INTERFACE_NAME
 			]
-			packagedElements += interface 
+			packagedElements += interface
 			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
 				name = COMP_NAME
 				interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
@@ -88,7 +90,7 @@ class InterfaceTest extends AbstractComp2ClassTest {
 				]
 			]
 		]
-		
+
 		rootElement.propagate [
 			val interface = model.claimPackagedElementWithName(Interface, INTERFACE_NAME)
 			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
@@ -96,17 +98,19 @@ class InterfaceTest extends AbstractComp2ClassTest {
 				val component = it
 				packagedElements += UMLFactory.eINSTANCE.createUsage() => [
 					name = USAGE_NAME
-					clients += component 
+					clients += component
 					suppliers += interface
 				]
 			]
 		]
-		
+
 		val componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
-		val classInterface = componentPackage.claimPackagedElementWithName(Interface, INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
-		val component2Package = rootElement.claimPackagedElementWithName(Package, COMP_NAME2 + PACKAGE_SUFFIX)		
+		val classInterface = componentPackage.claimPackagedElementWithName(Interface,
+			INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
+		val component2Package = rootElement.claimPackagedElementWithName(Package, COMP_NAME2 + PACKAGE_SUFFIX)
 		val component2Class = component2Package.claimPackagedElementWithName(Class, COMP_NAME2)
-		val class2InterfaceRealization = component2Class.claimInterfaceRealization(USAGE_NAME + CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
+		val class2InterfaceRealization = component2Class.claimInterfaceRealization(USAGE_NAME +
+			CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
 		component2Class.checkInterfaceRealization(class2InterfaceRealization, classInterface)
 	}
 
@@ -116,7 +120,7 @@ class InterfaceTest extends AbstractComp2ClassTest {
 			val interface = UMLFactory.eINSTANCE.createInterface() => [
 				name = INTERFACE_NAME
 			]
-			packagedElements += interface 
+			packagedElements += interface
 			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
 				name = COMP_NAME
 				interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
@@ -129,22 +133,23 @@ class InterfaceTest extends AbstractComp2ClassTest {
 				val component = it
 				packagedElements += UMLFactory.eINSTANCE.createUsage() => [
 					name = USAGE_NAME
-					clients += component 
+					clients += component
 					suppliers += interface
 				]
 			]
 		]
-		
+
 		rootElement.claimPackagedElementWithName(Component, COMP_NAME2).propagate [
 			claimPackagedElementWithName(Usage, USAGE_NAME) => [
 				destroy()
 			]
 		]
-		
+
 		// Assert that everything still exists except for the interface realization
 		val componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
-		val classInterface = componentPackage.claimPackagedElementWithName(Interface, INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
-		val component2Package = rootElement.claimPackagedElementWithName(Package, COMP_NAME2 + PACKAGE_SUFFIX)		
+		val classInterface = componentPackage.claimPackagedElementWithName(Interface,
+			INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
+		val component2Package = rootElement.claimPackagedElementWithName(Package, COMP_NAME2 + PACKAGE_SUFFIX)
 		val component2Class = component2Package.claimPackagedElementWithName(Class, COMP_NAME2)
 		component2Class.claimNoInterfaceRealization(USAGE_NAME + CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
 		assertThat(component2Class.interfaceRealizations.size, is(0))
@@ -156,7 +161,7 @@ class InterfaceTest extends AbstractComp2ClassTest {
 			val interface = UMLFactory.eINSTANCE.createInterface() => [
 				name = INTERFACE_NAME
 			]
-			packagedElements += interface 
+			packagedElements += interface
 			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
 				name = COMP_NAME
 				interfaceRealizations += UMLFactory.eINSTANCE.createInterfaceRealization() => [
@@ -165,7 +170,7 @@ class InterfaceTest extends AbstractComp2ClassTest {
 				]
 			]
 		]
-		
+
 		rootElement.propagate [
 			val interface = claimPackagedElementWithName(Interface, INTERFACE_NAME)
 			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
@@ -173,7 +178,7 @@ class InterfaceTest extends AbstractComp2ClassTest {
 				val component = it
 				packagedElements += UMLFactory.eINSTANCE.createUsage() => [
 					name = USAGE_NAME
-					clients += component 
+					clients += component
 					suppliers += interface
 				]
 			]
@@ -182,25 +187,29 @@ class InterfaceTest extends AbstractComp2ClassTest {
 				val component = it
 				packagedElements += UMLFactory.eINSTANCE.createUsage() => [
 					name = USAGE_NAME2
-					clients += component 
+					clients += component
 					suppliers += interface
 				]
 			]
 		]
 
 		val componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
-		val classInterface = componentPackage.claimPackagedElementWithName(Interface, INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
-		val component2Package = rootElement.claimPackagedElementWithName(Package, COMP_NAME2 + PACKAGE_SUFFIX)		
+		val classInterface = componentPackage.claimPackagedElementWithName(Interface,
+			INTERFACE_NAME + CLASS_INTERFACE_SUFFIX)
+		val component2Package = rootElement.claimPackagedElementWithName(Package, COMP_NAME2 + PACKAGE_SUFFIX)
 		val component2Class = component2Package.claimPackagedElementWithName(Class, COMP_NAME2)
-		val class2InterfaceRealization = component2Class.claimInterfaceRealization(USAGE_NAME + CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
+		val class2InterfaceRealization = component2Class.claimInterfaceRealization(USAGE_NAME +
+			CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
 		component2Class.checkInterfaceRealization(class2InterfaceRealization, classInterface)
-		val component3Package = rootElement.claimPackagedElementWithName(Package, COMP_NAME3 + PACKAGE_SUFFIX)		
+		val component3Package = rootElement.claimPackagedElementWithName(Package, COMP_NAME3 + PACKAGE_SUFFIX)
 		val component3Class = component3Package.claimPackagedElementWithName(Class, COMP_NAME3)
-		val class3InterfaceRealization = component3Class.claimInterfaceRealization(USAGE_NAME2 + CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
+		val class3InterfaceRealization = component3Class.claimInterfaceRealization(USAGE_NAME2 +
+			CLASS_IFR_AND_USAGE_SUFFIX, classInterface)
 		component3Class.checkInterfaceRealization(class3InterfaceRealization, classInterface)
 	}
-	
-	def static checkInterfaceRealization(Class realizingClass, InterfaceRealization interfaceRealization, Interface expectedInterface) {
+
+	def static checkInterfaceRealization(Class realizingClass, InterfaceRealization interfaceRealization,
+		Interface expectedInterface) {
 		assertThat(interfaceRealization.clients.size, is(1))
 		assertThat(interfaceRealization.clients, hasItem(realizingClass))
 		assertThat(interfaceRealization.suppliers.size, is(1))

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ModelTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/ModelTest.xtend
@@ -1,37 +1,20 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.comp2class
 
-import org.eclipse.uml2.uml.Model
 import org.eclipse.uml2.uml.Package
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
 import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.testutils.matchers.ModelMatchers.isResource
-import java.nio.file.Path
 
 class ModelTest extends AbstractComp2ClassTest {
 
-	/*******
-	 * Tests:*
-	 ********/
 	@Test
-	// This test covers usage of one as well as two Models
 	def void testModelCreation() {
-		// Check Model:
-		val modelUri = getUri(Path.of(FOLDER_NAME).resolve(MODEL_NAME + "." + MODEL_FILE_EXTENSION))
-		assertThat(modelUri, isResource)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[rootElement]).flatten
-		val classModel = correspondingElements.filter(Model).get(0)
-		assertTypeAndName(classModel, Model, MODEL_NAME)
-
-		// Check DataType Package
-		val packagedElements = classModel.packagedElements
-		assertEquals(1, packagedElements.size)
-		val dataTypePackage = packagedElements.get(0)
-		assertTypeAndName(dataTypePackage, Package, CLASS_DATATYPES_PACKAGE_NAME)
+		assertThat(getUri(MODEL_NAME.projectModelPath), isResource)
+		rootElement.claimPackagedElementWithName(Package, CLASS_DATATYPES_PACKAGE_NAME)
 	}
 
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/VisibilityTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/VisibilityTest.xtend
@@ -1,37 +1,41 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.comp2class
 
-import org.eclipse.emf.ecore.EObject
-import org.eclipse.uml2.uml.NamedElement
 import org.eclipse.uml2.uml.VisibilityKind
 
-import static tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static extension tools.vitruv.applications.umlclassumlcomponents.tests.util.SharedTestUtil.*
+import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertEquals
+import org.eclipse.uml2.uml.UMLFactory
+import org.eclipse.uml2.uml.Package
+import org.eclipse.uml2.uml.Class
+import org.eclipse.uml2.uml.Component
 
 class VisibilityTest extends AbstractComp2ClassTest {
 
-	/*******
-	 * Tests:*
-	 ********/
-	private def void assertVisibility(NamedElement element) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[element]).flatten
-		for (EObject corrElement : correspondingElements) {
-			assertTrue((corrElement as NamedElement).visibility == element.visibility)
-		}
-
-	}
-
 	@Test
 	def void testVisibilityChange() {
-		val umlComp = createComponent(COMP_NAME)
-		umlComp.visibility = VisibilityKind.PRIVATE_LITERAL
-		propagate
-		assertVisibility(umlComp)
-
-		umlComp.visibility = VisibilityKind.PUBLIC_LITERAL
-		propagate
-		assertVisibility(umlComp)
+		rootElement.propagate [
+			packagedElements += UMLFactory.eINSTANCE.createComponent() => [
+				name = COMP_NAME
+				visibility = VisibilityKind.PRIVATE_LITERAL
+			]
+		]
+		
+		var componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
+		assertEquals(VisibilityKind.PRIVATE_LITERAL, componentPackage.visibility)
+		assertEquals(VisibilityKind.PRIVATE_LITERAL, componentPackage.claimPackagedElementWithName(Class, COMP_NAME).visibility)
+		
+		rootElement.claimPackagedElementWithName(Component, COMP_NAME).propagate [
+			visibility = VisibilityKind.PUBLIC_LITERAL
+		]
+		
+		componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
+		assertEquals(VisibilityKind.PUBLIC_LITERAL, componentPackage.visibility)
+		assertEquals(VisibilityKind.PUBLIC_LITERAL, componentPackage.claimPackagedElementWithName(Class, COMP_NAME).visibility)
+		
 	}
 
 }
+

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/VisibilityTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/comp2class/VisibilityTest.xtend
@@ -22,20 +22,20 @@ class VisibilityTest extends AbstractComp2ClassTest {
 				visibility = VisibilityKind.PRIVATE_LITERAL
 			]
 		]
-		
+
 		var componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
 		assertEquals(VisibilityKind.PRIVATE_LITERAL, componentPackage.visibility)
-		assertEquals(VisibilityKind.PRIVATE_LITERAL, componentPackage.claimPackagedElementWithName(Class, COMP_NAME).visibility)
-		
+		assertEquals(VisibilityKind.PRIVATE_LITERAL,
+			componentPackage.claimPackagedElementWithName(Class, COMP_NAME).visibility)
+
 		rootElement.claimPackagedElementWithName(Component, COMP_NAME).propagate [
 			visibility = VisibilityKind.PUBLIC_LITERAL
 		]
-		
+
 		componentPackage = rootElement.claimPackagedElementWithName(Package, COMP_NAME + PACKAGE_SUFFIX)
 		assertEquals(VisibilityKind.PUBLIC_LITERAL, componentPackage.visibility)
-		assertEquals(VisibilityKind.PUBLIC_LITERAL, componentPackage.claimPackagedElementWithName(Class, COMP_NAME).visibility)
-		
+		assertEquals(VisibilityKind.PUBLIC_LITERAL,
+			componentPackage.claimPackagedElementWithName(Class, COMP_NAME).visibility)
 	}
 
 }
-

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/AbstractUmlClassCompTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/AbstractUmlClassCompTest.xtend
@@ -1,0 +1,40 @@
+package tools.vitruv.applications.umlclassumlcomponents.tests.util
+
+import tools.vitruv.testutils.VitruvApplicationTest
+import org.eclipse.uml2.uml.UMLFactory
+
+import static tools.vitruv.applications.umlclassumlcomponents.util.SharedUtil.*
+import org.junit.jupiter.api.BeforeEach
+import java.nio.file.Path
+
+import org.eclipse.uml2.uml.Model
+
+abstract class AbstractUmlClassCompTest extends VitruvApplicationTest {
+	protected def Model getRootElement() {
+		return Model.from(MODEL_NAME.projectModelPath)
+	}
+
+	@BeforeEach
+	def setup() {
+		if (isInitializeTestModel()) {
+			initializeTestModel()
+		}
+	}
+
+	protected def boolean isInitializeTestModel() {
+		return true
+	}
+
+	private def void initializeTestModel() {
+		resourceAt(MODEL_NAME.projectModelPath).propagate [
+			contents += UMLFactory.eINSTANCE.createModel() => [
+				name = MODEL_NAME
+			]
+		]
+	}
+
+	protected def Path getProjectModelPath(String modelName) {
+		Path.of(FOLDER_NAME).resolve(modelName + "." + MODEL_FILE_EXTENSION)
+	}
+
+}

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/SharedTestUtil.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/SharedTestUtil.xtend
@@ -3,8 +3,7 @@ package tools.vitruv.applications.umlclassumlcomponents.tests.util
 import org.eclipse.emf.ecore.EObject
 
 import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertNotNull
-import static org.junit.jupiter.api.Assertions.assertNull
+import static org.junit.jupiter.api.Assertions.assertEquals
 import edu.kit.ipd.sdq.activextendannotations.Utility
 import org.eclipse.uml2.uml.Package
 import org.eclipse.uml2.uml.PackageableElement
@@ -39,80 +38,72 @@ class SharedTestUtil {
 	public static val PROPERTY_NAME = "TestProperty"
 	public static val OPERATION_NAME = "TestOperation"
 
-	def static void claimNoPackagedElementWithName(Package in, Class<? extends PackageableElement> containedElementType,
-		String containedElementName) {
-		val foundElement = in.getPackagedElementWithName(containedElementType, containedElementName)
-		assertNull(foundElement,
-			containedElementType.name + " with name '" + containedElementName + "' found in package " + in)
-	}
-
 	def static <T extends PackageableElement> T claimPackagedElementWithName(Package in, Class<T> containedElementType,
 		String containedElementName) {
-		val foundElement = in.getPackagedElementWithName(containedElementType, containedElementName)
-		assertNotNull(foundElement,
-			"No " + containedElementType.name + " with name '" + containedElementName + "' found in package " + in)
-		return foundElement
+		return in.claimPackagedElementWithName(in.packagedElements, containedElementType, containedElementName)
 	}
 
-	def static <T extends PackageableElement> T getPackagedElementWithName(Package in, Class<T> containedElementType,
+	def static void claimNoPackagedElementWithName(Package in, Class<? extends PackageableElement> containedElementType,
 		String containedElementName) {
-		val foundElements = in.packagedElements.filter(containedElementType).filter[name == containedElementName]
-		assertTrue(foundElements.size <= 1,
-			"There were " + foundElements.size + " " + containedElementType.name + "s with name '" +
-				containedElementName + "' in package " + in)
-		return foundElements.findFirst[true]
-	}
-
-	def static void claimNoPackagedElementWithName(Component in,
-		Class<? extends PackageableElement> containedElementType, String containedElementName) {
-		val foundElement = in.getPackagedElementWithName(containedElementType, containedElementName)
-		assertNull(foundElement,
-			containedElementType.name + " with name '" + containedElementName + "' found in component " + in)
+		in.claimNoPackagedElementWithName(in.packagedElements, containedElementType, containedElementName)
 	}
 
 	def static <T extends PackageableElement> T claimPackagedElementWithName(Component in,
 		Class<T> containedElementType, String containedElementName) {
-		val foundElement = in.getPackagedElementWithName(containedElementType, containedElementName)
-		assertNotNull(foundElement,
-			"No " + containedElementType.name + " with name '" + containedElementName + "' found in component " + in)
-		return foundElement
+		return in.claimPackagedElementWithName(in.packagedElements, containedElementType, containedElementName)
 	}
 
-	def static <T extends PackageableElement> T getPackagedElementWithName(Component in, Class<T> containedElementType,
-		String containedElementName) {
-		val foundElements = in.packagedElements.filter(containedElementType).filter[name == containedElementName]
-		assertTrue(foundElements.size <= 1,
+	def static void claimNoPackagedElementWithName(Component in,
+		Class<? extends PackageableElement> containedElementType, String containedElementName) {
+		in.claimNoPackagedElementWithName(in.packagedElements, containedElementType, containedElementName)
+	}
+
+	private def static <T extends PackageableElement> T claimPackagedElementWithName(EObject container,
+		Iterable<PackageableElement> packagedElements, Class<T> containedElementType, String containedElementName) {
+		val foundElements = packagedElements.filterCandidates(containedElementType, containedElementName)
+		assertEquals(1, foundElements.size,
 			"There were " + foundElements.size + " " + containedElementType.name + "s with name '" +
-				containedElementName + "' in component " + in)
-		return foundElements.findFirst[true]
+				containedElementName + "' in " + container)
+		return foundElements.get(0)
 	}
 
-	def static void claimNoInterfaceRealization(BehavioredClassifier in, String interfaceRelalizationName,
-		Interface realizedInterface) {
-		val foundElement = in.getInterfaceRealization(interfaceRelalizationName, realizedInterface)
-		assertNull(foundElement,
-			"Interface realization with name '" + interfaceRelalizationName + "' for interface " + realizedInterface +
-				" found in classifier " + in)
+	private def static void claimNoPackagedElementWithName(EObject container,
+		Iterable<PackageableElement> packagedElements, Class<? extends PackageableElement> containedElementType,
+		String containedElementName) {
+		val foundElements = packagedElements.filterCandidates(containedElementType, containedElementName)
+		assertTrue(foundElements.empty,
+			"There were " + foundElements.size + " " + containedElementType.name + "s with name '" +
+				containedElementName + "' in " + container)
+	}
+
+	private def static <T extends PackageableElement> Iterable<T> filterCandidates(
+		Iterable<PackageableElement> packagedElements, Class<T> containedElementType, String containedElementName) {
+		return packagedElements.filter(containedElementType).filter[name == containedElementName]
 	}
 
 	def static InterfaceRealization claimInterfaceRealization(BehavioredClassifier in, String interfaceRelalizationName,
 		Interface realizedInterface) {
-		val foundElement = getInterfaceRealization(in, interfaceRelalizationName, realizedInterface)
-		assertNotNull(foundElement,
-			"No interface realization with name '" + interfaceRelalizationName + "' for interface " +
-				realizedInterface + " found in classifier " + in)
-		return foundElement
-	}
-
-	def static InterfaceRealization getInterfaceRealization(BehavioredClassifier in, String interfaceRelalizationName,
-		Interface realizedInterface) {
-		val foundElements = in.interfaceRealizations.filter[name == interfaceRelalizationName].filter [
-			suppliers.size == 1 && suppliers.contains(realizedInterface)
-		]
-		assertTrue(foundElements.size <= 1,
+		val foundElements = in.interfaceRealizations.filterCandidates(interfaceRelalizationName, realizedInterface)
+		assertEquals(1, foundElements.size,
 			"There were " + foundElements.size + " interface realizations with name '" + interfaceRelalizationName +
 				"' for interface " + realizedInterface + " in classifier " + in)
-		return foundElements.findFirst[true]
+		return foundElements.get(0)
+	}
+
+	def static void claimNoInterfaceRealization(BehavioredClassifier in, String interfaceRelalizationName,
+		Interface realizedInterface) {
+		val foundElements = in.interfaceRealizations.filterCandidates(interfaceRelalizationName, realizedInterface)
+		assertTrue(foundElements.empty,
+			"Interface realization with name '" + interfaceRelalizationName + "' for interface " + realizedInterface +
+				" found in classifier " + in)
+	}
+
+	private def static Iterable<InterfaceRealization> filterCandidates(
+		Iterable<InterfaceRealization> interfaceRealizations, String interfaceRelalizationName,
+		Interface realizedInterface) {
+		return interfaceRealizations.filter[name == interfaceRelalizationName].filter [
+			suppliers.size == 1 && suppliers.contains(realizedInterface)
+		]
 	}
 
 	def static Property claimOwnedAttributeWithName(StructuredClassifier in, String containedAttributeName) {
@@ -126,8 +117,7 @@ class SharedTestUtil {
 	private def static claimSingleProperty(EObject container, Iterable<Property> properties, String expectedName) {
 		val foundElements = properties.filter[name == expectedName]
 		assertTrue(foundElements.size <= 1,
-			"There were " + foundElements.size + " properties with name '" + expectedName + "' in classifier " +
-				container)
+			"There were " + foundElements.size + " properties with name '" + expectedName + "' in " + container)
 		assertTrue(foundElements.size > 0, "No property with name '" + expectedName + "' found in " + container)
 		return foundElements.get(0)
 	}
@@ -143,8 +133,7 @@ class SharedTestUtil {
 	private def static claimSingleOperation(EObject container, Iterable<Operation> properties, String expectedName) {
 		val foundElements = properties.filter[name == expectedName]
 		assertTrue(foundElements.size <= 1,
-			"There were " + foundElements.size + " operations with name '" + expectedName + "' in classifier " +
-				container)
+			"There were " + foundElements.size + " operations with name '" + expectedName + "' in " + container)
 		assertTrue(foundElements.size > 0, "No operation with name '" + expectedName + "' found in " + container)
 		return foundElements.get(0)
 	}

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/SharedTestUtil.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/SharedTestUtil.xtend
@@ -1,10 +1,8 @@
 package tools.vitruv.applications.umlclassumlcomponents.tests.util
 
 import org.eclipse.emf.ecore.EObject
-import org.eclipse.uml2.uml.NamedElement
 
 import static org.junit.jupiter.api.Assertions.assertTrue
-import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertNull
 import edu.kit.ipd.sdq.activextendannotations.Utility
@@ -21,9 +19,6 @@ import org.eclipse.uml2.uml.Operation
 
 @Utility
 class SharedTestUtil {
-	/***************
-	 * Constants:*
-	 ****************/
 	// Class
 	public static val CLASS_NAME = "TestUmlClass"
 	public static val CLASS_NAME2 = "TestUmlClass2"
@@ -43,15 +38,6 @@ class SharedTestUtil {
 	public static val DATATYPE_NAME = "TestDataType"
 	public static val PROPERTY_NAME = "TestProperty"
 	public static val OPERATION_NAME = "TestOperation"
-
-	/***************
-	 * Assert Helper:*
-	 ****************/
-	static def void assertTypeAndName(EObject umlObject, Class<? extends NamedElement> umlType, String name) {
-		assertTrue(umlObject.class.isInstance(umlType) || umlObject.class.genericInterfaces.contains(umlType))
-		// Second condition encloses 'impl'-Classes		
-		assertEquals(name, (umlObject as NamedElement).name)
-	}
 
 	def static void claimNoPackagedElementWithName(Package in, Class<? extends PackageableElement> containedElementType,
 		String containedElementName) {
@@ -75,6 +61,13 @@ class SharedTestUtil {
 			"There were " + foundElements.size + " " + containedElementType.name + "s with name '" +
 				containedElementName + "' in package " + in)
 		return foundElements.findFirst[true]
+	}
+
+	def static void claimNoPackagedElementWithName(Component in,
+		Class<? extends PackageableElement> containedElementType, String containedElementName) {
+		val foundElement = in.getPackagedElementWithName(containedElementType, containedElementName)
+		assertNull(foundElement,
+			containedElementType.name + " with name '" + containedElementName + "' found in component " + in)
 	}
 
 	def static <T extends PackageableElement> T claimPackagedElementWithName(Component in,
@@ -133,12 +126,12 @@ class SharedTestUtil {
 	private def static claimSingleProperty(EObject container, Iterable<Property> properties, String expectedName) {
 		val foundElements = properties.filter[name == expectedName]
 		assertTrue(foundElements.size <= 1,
-			"There were " + foundElements.size + " properties with name '" + expectedName +
-				"' in classifier " + container)
+			"There were " + foundElements.size + " properties with name '" + expectedName + "' in classifier " +
+				container)
 		assertTrue(foundElements.size > 0, "No property with name '" + expectedName + "' found in " + container)
 		return foundElements.get(0)
 	}
-	
+
 	def static Operation claimOwnedOperationWithName(org.eclipse.uml2.uml.Class in, String containedOperationName) {
 		return in.claimSingleOperation(in.ownedOperations, containedOperationName)
 	}
@@ -150,8 +143,8 @@ class SharedTestUtil {
 	private def static claimSingleOperation(EObject container, Iterable<Operation> properties, String expectedName) {
 		val foundElements = properties.filter[name == expectedName]
 		assertTrue(foundElements.size <= 1,
-			"There were " + foundElements.size + " operations with name '" + expectedName +
-				"' in classifier " + container)
+			"There were " + foundElements.size + " operations with name '" + expectedName + "' in classifier " +
+				container)
 		assertTrue(foundElements.size > 0, "No operation with name '" + expectedName + "' found in " + container)
 		return foundElements.get(0)
 	}

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/SharedTestUtil.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/SharedTestUtil.xtend
@@ -5,7 +5,19 @@ import org.eclipse.uml2.uml.NamedElement
 
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertNull
 import edu.kit.ipd.sdq.activextendannotations.Utility
+import org.eclipse.uml2.uml.Package
+import org.eclipse.uml2.uml.PackageableElement
+import org.eclipse.uml2.uml.Component
+import org.eclipse.uml2.uml.InterfaceRealization
+import org.eclipse.uml2.uml.BehavioredClassifier
+import org.eclipse.uml2.uml.Interface
+import org.eclipse.uml2.uml.StructuredClassifier
+import org.eclipse.uml2.uml.Property
+import org.eclipse.uml2.uml.DataType
+import org.eclipse.uml2.uml.Operation
 
 @Utility
 class SharedTestUtil {
@@ -40,4 +52,108 @@ class SharedTestUtil {
 		// Second condition encloses 'impl'-Classes		
 		assertEquals(name, (umlObject as NamedElement).name)
 	}
+
+	def static void claimNoPackagedElementWithName(Package in, Class<? extends PackageableElement> containedElementType,
+		String containedElementName) {
+		val foundElement = in.getPackagedElementWithName(containedElementType, containedElementName)
+		assertNull(foundElement,
+			containedElementType.name + " with name '" + containedElementName + "' found in package " + in)
+	}
+
+	def static <T extends PackageableElement> T claimPackagedElementWithName(Package in, Class<T> containedElementType,
+		String containedElementName) {
+		val foundElement = in.getPackagedElementWithName(containedElementType, containedElementName)
+		assertNotNull(foundElement,
+			"No " + containedElementType.name + " with name '" + containedElementName + "' found in package " + in)
+		return foundElement
+	}
+
+	def static <T extends PackageableElement> T getPackagedElementWithName(Package in, Class<T> containedElementType,
+		String containedElementName) {
+		val foundElements = in.packagedElements.filter(containedElementType).filter[name == containedElementName]
+		assertTrue(foundElements.size <= 1,
+			"There were " + foundElements.size + " " + containedElementType.name + "s with name '" +
+				containedElementName + "' in package " + in)
+		return foundElements.findFirst[true]
+	}
+
+	def static <T extends PackageableElement> T claimPackagedElementWithName(Component in,
+		Class<T> containedElementType, String containedElementName) {
+		val foundElement = in.getPackagedElementWithName(containedElementType, containedElementName)
+		assertNotNull(foundElement,
+			"No " + containedElementType.name + " with name '" + containedElementName + "' found in component " + in)
+		return foundElement
+	}
+
+	def static <T extends PackageableElement> T getPackagedElementWithName(Component in, Class<T> containedElementType,
+		String containedElementName) {
+		val foundElements = in.packagedElements.filter(containedElementType).filter[name == containedElementName]
+		assertTrue(foundElements.size <= 1,
+			"There were " + foundElements.size + " " + containedElementType.name + "s with name '" +
+				containedElementName + "' in component " + in)
+		return foundElements.findFirst[true]
+	}
+
+	def static void claimNoInterfaceRealization(BehavioredClassifier in, String interfaceRelalizationName,
+		Interface realizedInterface) {
+		val foundElement = in.getInterfaceRealization(interfaceRelalizationName, realizedInterface)
+		assertNull(foundElement,
+			"Interface realization with name '" + interfaceRelalizationName + "' for interface " + realizedInterface +
+				" found in classifier " + in)
+	}
+
+	def static InterfaceRealization claimInterfaceRealization(BehavioredClassifier in, String interfaceRelalizationName,
+		Interface realizedInterface) {
+		val foundElement = getInterfaceRealization(in, interfaceRelalizationName, realizedInterface)
+		assertNotNull(foundElement,
+			"No interface realization with name '" + interfaceRelalizationName + "' for interface " +
+				realizedInterface + " found in classifier " + in)
+		return foundElement
+	}
+
+	def static InterfaceRealization getInterfaceRealization(BehavioredClassifier in, String interfaceRelalizationName,
+		Interface realizedInterface) {
+		val foundElements = in.interfaceRealizations.filter[name == interfaceRelalizationName].filter [
+			suppliers.size == 1 && suppliers.contains(realizedInterface)
+		]
+		assertTrue(foundElements.size <= 1,
+			"There were " + foundElements.size + " interface realizations with name '" + interfaceRelalizationName +
+				"' for interface " + realizedInterface + " in classifier " + in)
+		return foundElements.findFirst[true]
+	}
+
+	def static Property claimOwnedAttributeWithName(StructuredClassifier in, String containedAttributeName) {
+		return in.claimSingleProperty(in.ownedAttributes, containedAttributeName)
+	}
+
+	def static Property claimOwnedAttributeWithName(DataType in, String containedAttributeName) {
+		return in.claimSingleProperty(in.ownedAttributes, containedAttributeName)
+	}
+
+	private def static claimSingleProperty(EObject container, Iterable<Property> properties, String expectedName) {
+		val foundElements = properties.filter[name == expectedName]
+		assertTrue(foundElements.size <= 1,
+			"There were " + foundElements.size + " properties with name '" + expectedName +
+				"' in classifier " + container)
+		assertTrue(foundElements.size > 0, "No property with name '" + expectedName + "' found in " + container)
+		return foundElements.get(0)
+	}
+	
+	def static Operation claimOwnedOperationWithName(org.eclipse.uml2.uml.Class in, String containedOperationName) {
+		return in.claimSingleOperation(in.ownedOperations, containedOperationName)
+	}
+
+	def static Operation claimOwnedOperationWithName(DataType in, String containedOperationName) {
+		return in.claimSingleOperation(in.ownedOperations, containedOperationName)
+	}
+
+	private def static claimSingleOperation(EObject container, Iterable<Operation> properties, String expectedName) {
+		val foundElements = properties.filter[name == expectedName]
+		assertTrue(foundElements.size <= 1,
+			"There were " + foundElements.size + " operations with name '" + expectedName +
+				"' in classifier " + container)
+		assertTrue(foundElements.size > 0, "No operation with name '" + expectedName + "' found in " + container)
+		return foundElements.get(0)
+	}
+
 }


### PR DESCRIPTION
This PR fixes some issues in the UML class-components application (although they are still in a rather immature state):
* Create and retrieve correspondences only via Reactions language constructs. By now, manual correspondences were created and not necessarily resolved correctly
* Propagate renaming of packages to components
* React to the renaming of data types

The focus of this PR, however, is the rewrite of tests between UML classes and components. Some of them were hard to fix to be compatible with https://github.com/vitruv-tools/Vitruv/pull/438, such that this PR completely replaces the existing tests using the `VitruvApplicationTest` rather than the `LegacyVitruvApplicationTest`. This especially ensure that:
* The `CorrespondenceModel` is not accessed in the test anymore
* No elements internal to the `VirtualModel` are considered in the tests
* Conceptually, views are re-created after each change propagation
While these changes adapt to the transactional specification of tests in the `VitruvApplicationTest` and are prepared for a proper coming view API, this PR is not meant to improve the test design. The tests are, from my point of view, still incomplete and several of them do not provide sufficient validation. But fixing this only makes sense together with a significant improvement of the transformations on their own.

Finally, the adaptations to transactional testing and state comparison rather than correspondence checks lead to tests comparable to equivalence tests, which only check the actual and the expected model for equivalence. However, the proposed tests are less expressive, because they only validate parts of the models rather than the complete models. Thus, the proposed tests can be seen as a poor-mans version of proper equivalence tests.
