### PR TITLE
Reuse Existing Type References in UML-Java

### DIFF
--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
@@ -1,5 +1,4 @@
 import org.eclipse.uml2.uml.LiteralUnlimitedNatural
-
 import static tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import org.eclipse.emf.ecore.util.EcoreUtil
@@ -30,11 +29,9 @@ routine propagateParameterTypeChange(java::OrdinaryParameter jParam, uml::Parame
 }
 
 // ******** general variants to reduce code duplication. If possible please use the facade routines above
-
-routine propagateTypeChangeToTypedMultiplicityElement(
-		uml::TypedElement uTyped, uml::MultiplicityElement uMultiplicity, // same element -- uml::Property or uml::Parameter
+routine propagateTypeChangeToTypedMultiplicityElement(uml::TypedElement uTyped, uml::MultiplicityElement uMultiplicity, // same element -- uml::Property or uml::Parameter
 		java::TypedElement jElement // java::Field, java::Parameter, or java::Method
-	) {
+) {
 	match {
 		check {
 			if(uTyped !== uMultiplicity) {
@@ -50,19 +47,17 @@ routine propagateTypeChangeToTypedMultiplicityElement(
 			val existingUmlType = uTyped.type
 			val jType = jElement.typeReference
 			val isCollectionReference = isCollectionTypeReference(jType)
-	    	val newType = if (isCollectionReference){
-	    		uMultiplicity.lower = 0
-	    		uMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
-	    		val innerTypeRef = getInnerTypeRefOfCollectionReference(jType)
-	    		val innerType = if(innerTypeRef !== null) getUmlTypeFromReference(innerTypeRef, correspondenceModel) else null
-	    		innerType
-	    	}
-	    	else {
-	    		getUmlTypeFromReference(jType, correspondenceModel)
-	    	}
-	    	if (!EcoreUtil.equals(existingUmlType, newType)) {
-	    		uTyped.type = newType
-	    	}
+			val newType = if (isCollectionReference) {
+				uMultiplicity.lower = 0
+				uMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
+				val innerTypeRef = getInnerTypeRefOfCollectionReference(jType)
+				if(innerTypeRef !== null) getUmlTypeFromReference(innerTypeRef, correspondenceModel) else null
+			} else {
+				getUmlTypeFromReference(jType, correspondenceModel)
+			}
+			if (!EcoreUtil.equals(existingUmlType, newType)) {
+				uTyped.type = newType
+			}
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
@@ -2,6 +2,7 @@ import org.eclipse.uml2.uml.LiteralUnlimitedNatural
 
 import static tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
+import org.eclipse.emf.ecore.util.EcoreUtil
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -46,17 +47,21 @@ routine propagateTypeChangeToTypedMultiplicityElement(
 	}
 	action {
 		execute {
+			val existingUmlType = uTyped.type
 			val jType = jElement.typeReference
 			val isCollectionReference = isCollectionTypeReference(jType)
-	    	if (isCollectionReference){
+	    	val newType = if (isCollectionReference){
 	    		uMultiplicity.lower = 0
 	    		uMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
 	    		val innerTypeRef = getInnerTypeRefOfCollectionReference(jType)
 	    		val innerType = if(innerTypeRef !== null) getUmlTypeFromReference(innerTypeRef, correspondenceModel) else null
-	    		uTyped.type = innerType
+	    		innerType
 	    	}
 	    	else {
-	    		uTyped.type = getUmlTypeFromReference(jType, correspondenceModel)
+	    		getUmlTypeFromReference(jType, correspondenceModel)
+	    	}
+	    	if (!EcoreUtil.equals(existingUmlType, newType)) {
+	    		uTyped.type = newType
 	    	}
 		}
 	}

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
@@ -6,6 +6,7 @@ import org.eclipse.uml2.uml.ParameterDirectionKind
 
 import static tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
+import org.eclipse.emf.ecore.util.EcoreUtil
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -79,9 +80,9 @@ routine propagateTypedMultiplicityElementTypeChanged(
 	}
 	action {
 		execute {
+			val existingJavaTypeReference = jElement.typeReference
 	    	var typeReference = createTypeReference(uElement.type, jType, defaultReference, userInteractor)
-	    	
-			if(uMultiplicity.lower == 0 && uMultiplicity.upper == LiteralUnlimitedNatural.UNLIMITED) {
+	    	if(uMultiplicity.lower == 0 && uMultiplicity.upper == LiteralUnlimitedNatural.UNLIMITED) {
 				if (typeReference === defaultReference){
 					// could not create a specific typeReference for the uElement.type
 					// default to java.lang.Object as an inner type
@@ -99,8 +100,10 @@ routine propagateTypedMultiplicityElementTypeChanged(
 	    		}
 			}
 			
-			jElement.typeReference = typeReference
-			addJavaImport(jElement.containingCompilationUnit, typeReference)
+			if (!EcoreUtil.equals(existingJavaTypeReference, typeReference)) {
+				jElement.typeReference = typeReference
+				addJavaImport(jElement.containingCompilationUnit, typeReference)				
+			}
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
@@ -3,7 +3,6 @@ import org.emftext.language.java.classifiers.ConcreteClassifier
 import org.emftext.language.java.types.TypesFactory
 import tools.vitruv.domains.java.util.JavaModificationUtil
 import org.eclipse.uml2.uml.ParameterDirectionKind
-
 import static tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import org.eclipse.emf.ecore.util.EcoreUtil
@@ -15,11 +14,9 @@ reactions: umlToJavaTypePropagation
 in reaction to changes in UML
 execute actions in Java
 
-routine propagatePropertyTypeChanged(
-		uml::Property uProperty,
-		java::Field jElement,
+routine propagatePropertyTypeChanged(uml::Property uProperty, java::Field jElement,
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-	) {
+) {
 	action {
 		call {
 			propagateTypedMultiplicityElementTypeChanged_defaultObject(uProperty, uProperty, jElement, jType)
@@ -27,11 +24,9 @@ routine propagatePropertyTypeChanged(
 	}
 }
 
-routine propagateReturnParameterTypeChanged(
-		uml::Parameter uReturnParameter,
-		java::Method jMethod,
+routine propagateReturnParameterTypeChanged(uml::Parameter uReturnParameter, java::Method jMethod,
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-	) {
+) {
 	action {
 		call {
 			if (uReturnParameter.direction !== ParameterDirectionKind.RETURN_LITERAL) {
@@ -42,11 +37,9 @@ routine propagateReturnParameterTypeChanged(
 	}
 }
 
-routine propagateOrdinaryParameterTypeChanged(
-		uml::Parameter uParameter,
-		java::OrdinaryParameter jParameter,
+routine propagateOrdinaryParameterTypeChanged(uml::Parameter uParameter, java::OrdinaryParameter jParameter,
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-	) {
+) {
 	action {
 		call {
 			if (uParameter.direction === ParameterDirectionKind.RETURN_LITERAL) {
@@ -59,15 +52,11 @@ routine propagateOrdinaryParameterTypeChanged(
 	}
 }
 
-
 // ******** general variants to reduce code duplication. If possible please use the facade routines above
-
-routine propagateTypedMultiplicityElementTypeChanged(
-		uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
+routine propagateTypedMultiplicityElementTypeChanged(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
 		java::TypedElement jElement, // java::Field, java::Parameter, or java::Method
 		java::ConcreteClassifier jType, // new type retrieved from correspondences or null
-		java::TypeReference defaultReference
-	) {
+		java::TypeReference defaultReference) {
 	match {
 		check {
 			if(uElement !== uMultiplicity) {
@@ -81,25 +70,23 @@ routine propagateTypedMultiplicityElementTypeChanged(
 	action {
 		execute {
 			val existingJavaTypeReference = jElement.typeReference
-	    	var typeReference = createTypeReference(uElement.type, jType, defaultReference, userInteractor)
-	    	if(uMultiplicity.lower == 0 && uMultiplicity.upper == LiteralUnlimitedNatural.UNLIMITED) {
+			var typeReference = createTypeReference(uElement.type, jType, defaultReference, userInteractor)
+			if(uMultiplicity.lower == 0 && uMultiplicity.upper == LiteralUnlimitedNatural.UNLIMITED) {
 				if (typeReference === defaultReference){
 					// could not create a specific typeReference for the uElement.type
 					// default to java.lang.Object as an inner type
 					typeReference = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass)
 				}
-	    		if(isCollectionTypeReference(jElement.typeReference)){
-	    			// reuse previously selected CollectionType
-	    			val collectionClassifier = getNormalizedClassifierFromTypeReference(jElement.typeReference) as ConcreteClassifier
-	    			typeReference = createCollectionTypeReference(collectionClassifier, typeReference)
-	    		}
-	    		else {
-	    			// no previously selected CollectionType
-		        	val Class<?> collectionType = userSelectCollectionType(userInteractor)
+				if (isCollectionTypeReference(jElement.typeReference)) {
+					// reuse previously selected CollectionType
+					val collectionClassifier = getNormalizedClassifierFromTypeReference(jElement.typeReference) as ConcreteClassifier
+					typeReference = createCollectionTypeReference(collectionClassifier, typeReference)
+				} else {
+					// no previously selected CollectionType
+					val Class<?> collectionType = userSelectCollectionType(userInteractor)
 					typeReference = createCollectionTypeReference(collectionType, typeReference)
-	    		}
+				}
 			}
-			
 			if (!EcoreUtil.equals(existingJavaTypeReference, typeReference)) {
 				jElement.typeReference = typeReference
 				addJavaImport(jElement.containingCompilationUnit, typeReference)				
@@ -107,25 +94,23 @@ routine propagateTypedMultiplicityElementTypeChanged(
 		}
 	}
 }
-	
-routine propagateTypedMultiplicityElementTypeChanged_defaultObject(
-		uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
+
+routine propagateTypedMultiplicityElementTypeChanged_defaultObject(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
 		java::TypedElement jElement, // java::Field, java::Parameter, or java::Method
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-	) {
+) {
 	action {
 		call {
-			val objectNsRef = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass)// default to java.lang.Object
+			val objectNsRef = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass) // default to java.lang.Object
 			propagateTypedMultiplicityElementTypeChanged(uElement, uMultiplicity, jElement, jType, objectNsRef)
 		}
 	}
 }
 
-routine propagateTypedMultiplicityElementTypeChanged_defaultVoid(
-		uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
+routine propagateTypedMultiplicityElementTypeChanged_defaultVoid(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
 		java::TypedElement jElement, // java::Field, java::Parameter, or java::Method
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-	) {
+) {
 	action {
 		call {
 			val voidRef = TypesFactory.eINSTANCE.createVoid


### PR DESCRIPTION
Currently, the UML-Java transformations create a new type reference on every change, even if the type reference stays the same. This especially violates hippocraticness of the bidirectional transformation between UML and Java, because adding a type reference in Java and propagating it to UML will result in overwriting the Java type reference again by the inverse direction transformation.
This PR fixes that and reuses the existing type reference.