### PR TITLE
Adapt to Changed Correspondence Model Access in Vitruv Tests

### DIFF
--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.editortests/src/tools/vitruv/applications/pcmjava/ejbtransformations/editortests/java2pcm/EjbJava2PcmTransformationTest.xtend
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.editortests/src/tools/vitruv/applications/pcmjava/ejbtransformations/editortests/java2pcm/EjbJava2PcmTransformationTest.xtend
@@ -9,7 +9,6 @@ import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils
 import org.palladiosimulator.pcm.repository.Repository
 import java.io.IOException
 import org.eclipse.core.runtime.CoreException
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 import static tools.vitruv.applications.pcmjava.ejbtransformations.java2pcm.EjbAnnotationHelper.*
 
@@ -55,8 +54,7 @@ abstract class EjbJava2PcmTransformationTest extends Java2PcmTransformationTest 
 		this.mainPackage = this.createPackageWithPackageInfo(#[Pcm2JavaTestUtils.REPOSITORY_NAME])
 		this.createPackageWithPackageInfo(#[Pcm2JavaTestUtils.REPOSITORY_NAME, "contracts"])
 		this.createPackageWithPackageInfo(#[Pcm2JavaTestUtils.REPOSITORY_NAME, "datatypes"])
-		val Repository repo = claimOne(
-			CorrespondenceModelUtil.getCorrespondingEObjectsByType(correspondenceModel, this.mainPackage, Repository))
+		val Repository repo = claimOne(getCorrespondingEObjects(this.mainPackage, Repository))
 		return repo
 	}
 }

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.editortests/src/tools/vitruv/applications/pcmjava/ejbtransformations/editortests/java2pcm/EjbPackageMappingTest.xtend
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations.editortests/src/tools/vitruv/applications/pcmjava/ejbtransformations/editortests/java2pcm/EjbPackageMappingTest.xtend
@@ -2,7 +2,6 @@ package tools.vitruv.applications.pcmjava.ejbtransformations.editortests.java2pc
 
 import org.palladiosimulator.pcm.repository.Repository
 
-import static extension tools.vitruv.framework.correspondence.CorrespondenceModelUtil.*
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*
 import org.junit.jupiter.api.Test
 import static org.junit.jupiter.api.Assertions.assertEquals
@@ -15,8 +14,7 @@ class EjbPackageMappingTest extends EjbJava2PcmTransformationTest {
 		super.addRepoContractsAndDatatypesPackage()
 
 		// check: main package needs to correspond to a repository
-		val correspondingRepo = this.correspondenceModel.getCorrespondingEObjectsByType(this.mainPackage, Repository).
-			claimOne
+		val correspondingRepo = getCorrespondingEObjects(this.mainPackage, Repository).claimOne
 		assertEquals(correspondingRepo.entityName, this.mainPackage.name,
 			"Corresponding Repository has not the same name as the main package")
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/META-INF/MANIFEST.MF
@@ -8,7 +8,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.jdt.core,
  org.eclipse.text,
  tools.vitruv.testutils,
- tools.vitruv.extensions.dslsruntime.reactions,
  tools.vitruv.applications.pcmjava.util,
  tools.vitruv.applications.pcmjava.tests.util,
  tools.vitruv.applications.pcmjava.pojotransformations,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/FieldMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/FieldMappingTransformationTest.java
@@ -3,7 +3,6 @@ package tools.vitruv.applications.pcmjava.pojotransformations.editortests.java2p
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
-import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.ecore.EObject;
@@ -21,7 +20,6 @@ import org.palladiosimulator.pcm.repository.OperationRequiredRole;
 
 import tools.vitruv.applications.pcmjava.tests.util.java2pcm.CompilationUnitManipulatorHelper;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -128,8 +126,7 @@ public class FieldMappingTransformationTest extends Java2PcmPackageMappingTransf
 	}
 
 	private void assertOperationRequiredRole(final OperationRequiredRole operationRequiredRole) throws Throwable {
-		Set<EObject> correspondingEObjects = CorrespondenceModelUtil.getCorrespondingEObjects(
-				FieldMappingTransformationTest.this.getCorrespondenceModel(), operationRequiredRole);
+		Iterable<EObject> correspondingEObjects = getCorrespondingEObjects(operationRequiredRole, EObject.class);
 
 		boolean fieldFound = false;
 		for (final EObject correspondingEObject : correspondingEObjects) {
@@ -159,8 +156,7 @@ public class FieldMappingTransformationTest extends Java2PcmPackageMappingTransf
 		final InsertEdit insertEdit = new InsertEdit(offset, newFieldName + ";");
 		editCompilationUnit(icu, deleteEdit, insertEdit);
 		final Field newJaMoPPField = this.getJaMoPPFieldFromClass(icu, newFieldName);
-		return claimOne(CorrespondenceModelUtil.getCorrespondingEObjectsByType(this.getCorrespondenceModel(),
-				newJaMoPPField, InnerDeclaration.class));
+		return claimOne(getCorrespondingEObjects(newJaMoPPField, InnerDeclaration.class));
 	}
 
 	private InnerDeclaration changeFieldTypeInClass(final String className, final String fieldName,
@@ -177,8 +173,7 @@ public class FieldMappingTransformationTest extends Java2PcmPackageMappingTransf
 		final InsertEdit insertEdit = new InsertEdit(offset, newFieldTypeName);
 		editCompilationUnit(icu, deleteEdit, insertEdit);
 		final Field newJaMoPPField = this.getJaMoPPFieldFromClass(icu, fieldName);
-		return claimOne(CorrespondenceModelUtil.getCorrespondingEObjectsByType(this.getCorrespondenceModel(),
-				newJaMoPPField, InnerDeclaration.class));
+		return claimOne(getCorrespondingEObjects(newJaMoPPField, InnerDeclaration.class));
 	}
 
 	private void assertInnerDeclaration(final InnerDeclaration innerDeclaration, final String fieldType,

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/JaMoPPParameterMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/JaMoPPParameterMappingTransformationTest.java
@@ -1,7 +1,5 @@
 package tools.vitruv.applications.pcmjava.pojotransformations.editortests.java2pcm;
 
-import java.util.Set;
-
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMethod;
@@ -18,7 +16,6 @@ import org.palladiosimulator.pcm.repository.PrimitiveDataType;
 
 import tools.vitruv.applications.pcmjava.tests.util.java2pcm.CompilationUnitManipulatorHelper;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -82,8 +79,7 @@ public class JaMoPPParameterMappingTransformationTest extends Java2PcmPackageMap
 		editCompilationUnit(icu, replaceEdit);
 		final org.emftext.language.java.parameters.Parameter newJaMoPPParameter = super.findJaMoPPParameterInICU(icu,
 				interfaceName, methodName, newParameterName);
-		return claimOne(CorrespondenceModelUtil.getCorrespondingEObjectsByType(this.getCorrespondenceModel(),
-				newJaMoPPParameter, Parameter.class));
+		return claimOne(getCorrespondingEObjects(newJaMoPPParameter, Parameter.class));
 	}
 
 	private Parameter changeParameterType(final String interfaceName, final String methodName, final String paramName,
@@ -98,8 +94,7 @@ public class JaMoPPParameterMappingTransformationTest extends Java2PcmPackageMap
 		editCompilationUnit(icu, replaceEdit);
 		final org.emftext.language.java.parameters.Parameter newJaMoPPParameter = super.findJaMoPPParameterInICU(icu,
 				interfaceName, methodName, paramName);
-		Set<Parameter> correspondingEObjectsByType = CorrespondenceModelUtil
-				.getCorrespondingEObjectsByType(this.getCorrespondenceModel(), newJaMoPPParameter, Parameter.class);
+		Iterable<Parameter> correspondingEObjectsByType = getCorrespondingEObjects(newJaMoPPParameter, Parameter.class);
 		return claimOne(correspondingEObjectsByType);
 	}
 

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/MethodMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/MethodMappingTransformationTest.java
@@ -11,7 +11,6 @@ import org.palladiosimulator.pcm.repository.OperationSignature;
 
 import tools.vitruv.applications.pcmjava.tests.util.java2pcm.CompilationUnitManipulatorHelper;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -75,8 +74,7 @@ public class MethodMappingTransformationTest extends Java2PcmPackageMappingTrans
 				"OperationSignature " + opSig + " is not in OperationInterface " + opInterface);
 		this.assertPCMNamedElement(opSig, expectedName);
 
-		Method jaMoPPMethod = claimOne(CorrespondenceModelUtil.getCorrespondingEObjectsByType(
-					MethodMappingTransformationTest.this.getCorrespondenceModel(), opSig, Method.class));
+		Method jaMoPPMethod = claimOne(getCorrespondingEObjects(opSig, Method.class));
 		MethodMappingTransformationTest.this.assertDataTypeName(jaMoPPMethod.getTypeReference(),
 				opSig.getReturnType__OperationSignature());
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/PackageMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.editortests/src/tools/vitruv/applications/pcmjava/pojotransformations/editortests/java2pcm/PackageMappingTransformationTest.java
@@ -1,8 +1,5 @@
 package tools.vitruv.applications.pcmjava.pojotransformations.editortests.java2pcm;
 
-import java.util.Set;
-
-import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.containers.Package;
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.pcm.repository.BasicComponent;
@@ -11,9 +8,7 @@ import org.palladiosimulator.pcm.repository.Repository;
 import org.palladiosimulator.pcm.system.System;
 
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*;
-import static java.util.stream.Collectors.toSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,11 +83,7 @@ public class PackageMappingTransformationTest extends Java2PcmPackageMappingTran
 
 		final Package renamedPackage = super.renamePackage(this.secondPackage, packageName);
 
-		final Set<EObject> correspondingEObjects = CorrespondenceModelUtil
-				.getCorrespondingEObjects(this.getCorrespondenceModel(), renamedPackage).stream()
-				.filter(it -> it != null && it instanceof BasicComponent).collect(toSet()); // filter out null from non-EObject correspondence
-		final EObject correspondingEObject = claimOne(correspondingEObjects);
-		final BasicComponent bc = (BasicComponent) correspondingEObject;
+		final BasicComponent bc = claimOne(getCorrespondingEObjects(renamedPackage, BasicComponent.class));
 		// repository of basic component has to be the repository
 		assertEquals(repo.getId(), bc.getRepository__RepositoryComponent().getId(),
 				"Repository of basic compoennt is not the repository: " + repo);

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/META-INF/MANIFEST.MF
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/META-INF/MANIFEST.MF
@@ -7,11 +7,12 @@ Bundle-Version: 0.3.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.emf.transaction,
  tools.vitruv.testutils,
- tools.vitruv.extensions.dslsruntime.reactions,
  tools.vitruv.applications.pcmjava.util,
  tools.vitruv.applications.pcmjava.tests.util,
  tools.vitruv.applications.pcmjava.pojotransformations,
- org.junit.jupiter.api
+ org.junit.jupiter.api,
+ org.hamcrest.core,
+ com.google.guava
 Export-Package: tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java,
  tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository,
  tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.system

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/DataTypeCorrespondenceHelperTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/DataTypeCorrespondenceHelperTest.java
@@ -1,23 +1,15 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 import org.emftext.language.java.classifiers.Classifier;
-import org.emftext.language.java.types.Int;
-import org.emftext.language.java.types.NamespaceClassifierReference;
-import org.emftext.language.java.types.TypeReference;
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.pcm.repository.CollectionDataType;
 import org.palladiosimulator.pcm.repository.CompositeDataType;
-import org.palladiosimulator.pcm.repository.PrimitiveDataType;
-import org.palladiosimulator.pcm.repository.PrimitiveTypeEnum;
 import org.palladiosimulator.pcm.repository.Repository;
-import org.palladiosimulator.pcm.repository.RepositoryFactory;
 
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.applications.pcmjava.util.pcm2java.DataTypeCorrespondenceHelper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne;
 
 public class DataTypeCorrespondenceHelperTest extends Pcm2JavaTransformationTest {
 
@@ -28,26 +20,8 @@ public class DataTypeCorrespondenceHelperTest extends Pcm2JavaTransformationTest
 		// Create and sync CompositeDataType
 		final CompositeDataType cdt = this.createAndSyncCompositeDataType(repo);
 
-		final TypeReference type = DataTypeCorrespondenceHelper.claimUniqueCorrespondingJaMoPPDataTypeReference(cdt,
-				super.getCorrespondenceModel());
-		final NamespaceClassifierReference ncr = (NamespaceClassifierReference) type;
-		final Classifier classifier = (Classifier) ncr.getTarget();
-		assertEquals(cdt.getEntityName(), classifier.getName(),
+		assertEquals(cdt.getEntityName(), claimOne(getCorrespondingEObjects(cdt, Classifier.class)).getName(),
 				"Name of composite data type does not equals name of classifier");
-	}
-
-	@Test
-	public void testCorrespondenceForPrimitiveDataType() throws Throwable {
-		// final Repository repo =
-		// this.createAndSyncRepository(this.resourceSet,
-		// PCM2JaMoPPUtils.REPOSITORY_NAME);
-		final PrimitiveDataType pdtInt = RepositoryFactory.eINSTANCE.createPrimitiveDataType();
-		pdtInt.setType(PrimitiveTypeEnum.INT);
-		final TypeReference type = DataTypeCorrespondenceHelper.claimUniqueCorrespondingJaMoPPDataTypeReference(pdtInt,
-				super.getCorrespondenceModel());
-		if (!(type instanceof Int)) {
-			fail("found type is not instance of Int");
-		}
 	}
 
 	@Test
@@ -59,11 +33,8 @@ public class DataTypeCorrespondenceHelperTest extends Pcm2JavaTransformationTest
 		final CollectionDataType collectionDataType = this.addCollectionDatatypeAndSync(repo,
 				Pcm2JavaTestUtils.COLLECTION_DATA_TYPE_NAME, null);
 
-		final TypeReference type = DataTypeCorrespondenceHelper
-				.claimUniqueCorrespondingJaMoPPDataTypeReference(collectionDataType, super.getCorrespondenceModel());
-		final NamespaceClassifierReference ncr = (NamespaceClassifierReference) type;
-		final Classifier classifier = (Classifier) ncr.getTarget();
-		assertEquals(collectionDataType.getEntityName(), classifier.getName(),
+		assertEquals(collectionDataType.getEntityName(),
+				claimOne(getCorrespondingEObjects(collectionDataType, Classifier.class)).getName(),
 				"Name of composite data type does not equals name of classifier");
 	}
 

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -52,6 +52,8 @@ import org.palladiosimulator.pcm.seff.ResourceDemandingSEFF;
 import org.palladiosimulator.pcm.seff.SeffFactory;
 import org.palladiosimulator.pcm.system.System;
 
+import com.google.common.collect.Iterables;
+
 import tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.Pcm2JavaChangePropagationSpecification;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
 import tools.vitruv.applications.pcmjava.util.pcm2java.DataTypeCorrespondenceHelper;
@@ -59,7 +61,6 @@ import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil;
 import tools.vitruv.applications.util.temporary.pcm.PcmParameterUtil;
 import tools.vitruv.domains.pcm.PcmNamespace;
 import tools.vitruv.framework.propagation.ChangePropagationSpecification;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 import tools.vitruv.testutils.LegacyVitruvApplicationTest;
 import tools.vitruv.testutils.TestProject;
 
@@ -117,14 +118,12 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	protected <T> Set<NamedElement> assertCorrespondnecesAndCompareNames(final EObject pcmNamedElement,
 			final int expectedSize, final java.lang.Class<? extends EObject>[] expectedClasses,
 			final String[] expectedNames) throws Throwable {
-		final Set<EObject> correspondences = (Set<EObject>) claimNotEmpty(
-				CorrespondenceModelUtil.getCorrespondingEObjects(this.getCorrespondenceModel(), pcmNamedElement));
-		assertEquals(expectedSize, correspondences.size(), "correspondences.size should be " + expectedSize);
+		final Iterable<EObject> correspondences = claimNotEmpty(getCorrespondingEObjects(pcmNamedElement, EObject.class));
+		assertEquals(expectedSize, Iterables.size(correspondences), "correspondences.size should be " + expectedSize);
 		final Set<NamedElement> jaMoPPElements = new HashSet<NamedElement>();
 		for (int i = 0; i < expectedClasses.length; i++) {
 			final java.lang.Class<? extends EObject> expectedClass = expectedClasses[i];
-			final EObject correspondingEObject = claimOne(CorrespondenceModelUtil
-					.getCorrespondingEObjectsByType(this.getCorrespondenceModel(), pcmNamedElement, expectedClass));
+			final EObject correspondingEObject = claimOne(getCorrespondingEObjects(pcmNamedElement, expectedClass));
 			if (!expectedClass.isInstance(correspondingEObject)) {
 				fail("Corresponding EObject " + correspondingEObject + " is not an instance of " + expectedClass);
 			}
@@ -143,22 +142,14 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 		return jaMoPPElements;
 	}
 
-	protected void assertEmptyCorrespondence(final EObject eObject) throws Throwable {
-		try {
-			final Set<EObject> correspondences = (Set<EObject>) claimNotEmpty(
-					CorrespondenceModelUtil.getCorrespondingEObjects(this.getCorrespondenceModel(), eObject));
-			fail("correspondences.size should be " + 0 + " but is " + correspondences.size());
-		} catch (final RuntimeException re) {
-			// expected Runtime expception:
-		}
-
+	protected void assertEmptyCorrespondence(final EObject eObject) {
+		assertEquals(0, Iterables.size(getCorrespondingEObjects(eObject, EObject.class)));
 	}
 
 	protected void assertEqualsTypeReference(final TypeReference expected, final TypeReference actual) {
 		assertTrue(expected.getClass().equals(actual.getClass()), "type reference are not from the same type");
 		// Note: not necessary to check Primitive type: if the classes are from
-		// the same type (e.g.
-		// Int) the TypeReferences are equal
+		// the same type (e.g. Int) the TypeReferences are equal
 		if (expected instanceof ClassifierReference) {
 			final ClassifierReference expectedClassifierRef = (ClassifierReference) expected;
 			final ClassifierReference actualClassifierRef = (ClassifierReference) actual;
@@ -405,8 +396,7 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	 * @throws Throwable
 	 */
 	protected void assertOperationProvidedRole(final OperationProvidedRole operationProvidedRole) throws Throwable {
-		final Set<EObject> correspondingEObjects = CorrespondenceModelUtil
-				.getCorrespondingEObjects(this.getCorrespondenceModel(), operationProvidedRole);
+		final Iterable<EObject> correspondingEObjects = getCorrespondingEObjects(operationProvidedRole, EObject.class);
 		int namespaceClassifierReferenceFound = 0;
 		int importFound = 0;
 		for (final EObject eObject : correspondingEObjects) {
@@ -433,8 +423,7 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	 * @throws Throwable
 	 */
 	protected void assertOperationRequiredRole(final OperationRequiredRole operationRequiredRole) throws Throwable {
-		final Set<EObject> correspondingEObjects = CorrespondenceModelUtil
-				.getCorrespondingEObjects(this.getCorrespondenceModel(), operationRequiredRole);
+		final Iterable<EObject> correspondingEObjects = getCorrespondingEObjects(operationRequiredRole, EObject.class);
 		int importFounds = 0;
 		int constructorParameterFound = 0;
 		int fieldsFound = 0;
@@ -485,8 +474,7 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	 * @throws Throwable
 	 */
 	protected void assertAssemblyContext(final AssemblyContext assemblyContext) throws Throwable {
-		final Set<EObject> correspondingEObjects = CorrespondenceModelUtil
-				.getCorrespondingEObjects(this.getCorrespondenceModel(), assemblyContext);
+		final Iterable<EObject> correspondingEObjects = getCorrespondingEObjects(assemblyContext, EObject.class);
 		boolean fieldFound = false;
 		boolean importFound = false;
 		boolean newConstructorCallFound = false;
@@ -579,8 +567,7 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	 * @throws Throwable
 	 */
 	protected void assertInnerDeclaration(final InnerDeclaration innerDec) throws Throwable {
-		final Set<EObject> correspondingObjects = CorrespondenceModelUtil
-				.getCorrespondingEObjects(this.getCorrespondenceModel(), innerDec);
+		final Iterable<EObject> correspondingObjects = getCorrespondingEObjects(innerDec, EObject.class);
 		int fieldsFound = 0;
 		int methodsFound = 0;
 		String fieldName = null;

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationProvidedRoleMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationProvidedRoleMappingTransformationTest.java
@@ -11,7 +11,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory;
 
 import tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.Pcm2JavaTransformationTest;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -98,8 +97,7 @@ public class OperationProvidedRoleMappingTransformationTest extends Pcm2JavaTran
 		propagate();
 
 		this.assertOperationProvidedRole(operationProvidedRole);
-		final CompilationUnit jaMoPPCu = claimOne(CorrespondenceModelUtil
-				.getCorrespondingEObjectsByType(this.getCorrespondenceModel(), basicComponent, CompilationUnit.class));
+		final CompilationUnit jaMoPPCu = claimOne(getCorrespondingEObjects(basicComponent, CompilationUnit.class));
 		assertEquals(1, jaMoPPCu.getImports().size(), "Unexpected size of imports");
 		final Class jaMoPPClass = (Class) jaMoPPCu.getClassifiers().get(0);
 		assertEquals(1, jaMoPPClass.getImplements().size(), "Unexpected size of implemented interfaces");

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationSignatureMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationSignatureMappingTransformationTest.java
@@ -1,7 +1,9 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository;
 
+import org.emftext.language.java.classifiers.Classifier;
 import org.emftext.language.java.members.InterfaceMethod;
-import org.emftext.language.java.types.TypeReference;
+import org.emftext.language.java.types.Type;
+import org.emftext.language.java.types.Void;
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.pcm.repository.OperationInterface;
 import org.palladiosimulator.pcm.repository.OperationSignature;
@@ -13,6 +15,13 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory;
 import tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.Pcm2JavaTransformationTest;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
 import tools.vitruv.applications.pcmjava.util.pcm2java.DataTypeCorrespondenceHelper;
+
+import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne;
+
+import org.eclipse.emf.ecore.util.EcoreUtil;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class OperationSignatureMappingTransformationTest extends Pcm2JavaTransformationTest {
 
@@ -68,10 +77,17 @@ public class OperationSignatureMappingTransformationTest extends Pcm2JavaTransfo
 	private InterfaceMethod assertOperationSignatureCorrespondence(final OperationSignature opSig) throws Throwable {
 		final InterfaceMethod intMethod = (InterfaceMethod) this.assertSingleCorrespondence(opSig,
 				InterfaceMethod.class, opSig.getEntityName());
-		final TypeReference tr = DataTypeCorrespondenceHelper.claimUniqueCorrespondingJaMoPPDataTypeReference(
-				opSig.getReturnType__OperationSignature(), this.getCorrespondenceModel());
-		this.assertEqualsTypeReference(intMethod.getTypeReference(), tr);
-
+		if (opSig.getReturnType__OperationSignature() == null) {
+			assertThat(intMethod.getTypeReference(), instanceOf(Void.class));
+		} else {
+			Type type;
+			if (opSig.getReturnType__OperationSignature() instanceof PrimitiveDataType) {
+				type = DataTypeCorrespondenceHelper.claimJaMoPPTypeForPrimitiveDataType((PrimitiveDataType)opSig.getReturnType__OperationSignature());
+			} else {
+				type = claimOne(getCorrespondingEObjects(opSig.getReturnType__OperationSignature(), Classifier.class));
+			}
+			EcoreUtil.equals(intMethod.getTypeReference().getTarget(), type);
+		}
 		return intMethod;
 	}
 

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/PcmParameterMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/PcmParameterMappingTransformationTest.java
@@ -1,7 +1,5 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository;
 
-import java.util.Set;
-
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emftext.language.java.members.InterfaceMethod;
 import org.emftext.language.java.parameters.OrdinaryParameter;
@@ -14,10 +12,11 @@ import org.palladiosimulator.pcm.repository.PrimitiveDataType;
 import org.palladiosimulator.pcm.repository.PrimitiveTypeEnum;
 import org.palladiosimulator.pcm.repository.Repository;
 
+import com.google.common.collect.Iterables;
+
 import tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.Pcm2JavaTransformationTest;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
 import tools.vitruv.applications.util.temporary.pcm.PcmParameterUtil;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -125,15 +124,13 @@ public class PcmParameterMappingTransformationTest extends Pcm2JavaTransformatio
 
 	private void assertCorrectSignatureMappingWithParameters(final OperationSignature signature,
 			int expectedParameterCount) throws Throwable {
-		Set<InterfaceMethod> ims = CorrespondenceModelUtil.getCorrespondingEObjectsByType(getCorrespondenceModel(),
-				signature, InterfaceMethod.class);
-		assertEquals(1, ims.size());
+		Iterable<InterfaceMethod> ims = getCorrespondingEObjects(signature, InterfaceMethod.class);
+		assertEquals(1, Iterables.size(ims));
 		InterfaceMethod im = ims.iterator().next();
 		assertEquals(expectedParameterCount, im.getParameters().size());
 		for (Parameter curParam : signature.getParameters__OperationSignature()) {
-			Set<OrdinaryParameter> javaParams = CorrespondenceModelUtil
-					.getCorrespondingEObjectsByType(getCorrespondenceModel(), curParam, OrdinaryParameter.class);
-			assertEquals(1, javaParams.size());
+			Iterable<OrdinaryParameter> javaParams = getCorrespondingEObjects(curParam, OrdinaryParameter.class);
+			assertEquals(1, Iterables.size(javaParams));
 			OrdinaryParameter javaParam = javaParams.iterator().next();
 			assertEquals(im.getParameters().get(signature.getParameters__OperationSignature().indexOf(curParam)),
 					javaParam);

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/RepositoryMappingTransformaitonTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/RepositoryMappingTransformaitonTest.java
@@ -1,9 +1,5 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
-import java.util.Set;
-
 import org.emftext.language.java.classifiers.Class;
 import org.emftext.language.java.containers.CompilationUnit;
 import org.emftext.language.java.containers.Package;
@@ -13,7 +9,6 @@ import org.palladiosimulator.pcm.repository.Repository;
 
 import tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.Pcm2JavaTransformationTest;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,12 +64,7 @@ public class RepositoryMappingTransformaitonTest extends Pcm2JavaTransformationT
 	}
 
 	private void assertRepositoryCorrespondences(final Repository repo) throws Throwable {
-		if (null == this.getCorrespondenceModel()) {
-			fail("correspondence instance is still null - no transformation was executed.");
-			return;
-		}
-		final Set<Package> jaMoPPPackages = CorrespondenceModelUtil
-				.getCorrespondingEObjectsByType(this.getCorrespondenceModel(), repo, Package.class);
+		final Iterable<Package> jaMoPPPackages = getCorrespondingEObjects(repo, Package.class);
 		boolean foundRepositoryPackage = false;
 		boolean foundDatatypesPackage = false;
 		boolean foundContractsPackage = false;

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/ResourceDemandingInternalBehaviorMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/ResourceDemandingInternalBehaviorMappingTransformationTest.java
@@ -12,7 +12,6 @@ import org.palladiosimulator.pcm.seff.SeffFactory;
 
 import tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.Pcm2JavaTransformationTest;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 import static edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,8 +38,7 @@ public class ResourceDemandingInternalBehaviorMappingTransformationTest extends 
 	private void assertResourceDemandingInternalBehaviourCorrespondenceToMethod(
 			final ResourceDemandingInternalBehaviour resourceDemandingInternalBehaviour,
 			final String expectedMethodName) throws Throwable {
-		final ClassMethod classMethod = claimOne(CorrespondenceModelUtil.getCorrespondingEObjectsByType(
-				this.getCorrespondenceModel(), resourceDemandingInternalBehaviour, ClassMethod.class));
+		final ClassMethod classMethod = claimOne(getCorrespondingEObjects(resourceDemandingInternalBehaviour, ClassMethod.class));
 		assertEquals(classMethod.getName(), expectedMethodName,
 				"The class method should have the same name as the user selected");
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/SEFFMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/SEFFMappingTransformationTest.java
@@ -1,7 +1,5 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository;
 
-import java.util.Set;
-
 import org.eclipse.emf.ecore.EObject;
 import org.emftext.language.java.members.ClassMethod;
 import org.junit.jupiter.api.Test;
@@ -11,9 +9,10 @@ import org.palladiosimulator.pcm.repository.OperationSignature;
 import org.palladiosimulator.pcm.repository.Repository;
 import org.palladiosimulator.pcm.seff.ResourceDemandingSEFF;
 
+import com.google.common.collect.Iterables;
+
 import tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.Pcm2JavaTransformationTest;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,9 +51,8 @@ public class SEFFMappingTransformationTest extends Pcm2JavaTransformationTest {
 
 	private void assertSEFFCorrespondenceToMethod(final ResourceDemandingSEFF rdSEFF, final String expectedName)
 			throws Throwable {
-		final Set<EObject> correspondingEObjects = CorrespondenceModelUtil
-				.getCorrespondingEObjects(this.getCorrespondenceModel(), rdSEFF);
-		assertEquals(1, correspondingEObjects.size(),
+		final Iterable<EObject> correspondingEObjects = getCorrespondingEObjects(rdSEFF, EObject.class);
+		assertEquals(1, Iterables.size(correspondingEObjects),
 				"Expected exactly one corresponding EObject for rdSEFF " + rdSEFF);
 		final EObject correspondingEObject = correspondingEObjects.iterator().next();
 		assertTrue(correspondingEObject instanceof ClassMethod,

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/PcmUmlClassTestHelper.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/PcmUmlClassTestHelper.xtend
@@ -23,10 +23,10 @@ import org.palladiosimulator.pcm.repository.PrimitiveTypeEnum
 import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
-import tools.vitruv.extensions.dslsruntime.reactions.helper.ReactionsCorrespondenceHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import tools.vitruv.applications.util.temporary.uml.UmlTypeUtil
 import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil
+import tools.vitruv.testutils.LegacyCorrespondenceRetriever
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class PcmUmlClassTestHelper {
 	public static val REPOSITORY_NAME = "TestRepository"
@@ -52,11 +52,11 @@ class PcmUmlClassTestHelper {
 	public val PrimitiveType UML_STRING
 	public val PrimitiveType UML_UNLIMITED_NATURAL
 
-	val CorrespondenceModel correspondenceModel
+	val LegacyCorrespondenceRetriever correspondenceRetriever
 	val Function<URI, Resource> resourceRetriever
 
-	new(CorrespondenceModel testCorrespondenceModel, Function<URI, Resource> resourceRetriever) {
-		this.correspondenceModel = testCorrespondenceModel
+	new(LegacyCorrespondenceRetriever correspondenceRetriever, Function<URI, Resource> resourceRetriever) {
+		this.correspondenceRetriever = correspondenceRetriever
 		this.resourceRetriever = resourceRetriever
 
 		val pcmPrimitiveTypes = PcmDataTypeUtil.getPcmPrimitiveTypes(resourceRetriever)
@@ -91,17 +91,10 @@ class PcmUmlClassTestHelper {
 		return resourceRetriever.apply(originalURI.trimFragment).getEObject(originalURI.fragment) as T
 	}
 
-//	def public <T extends EObject> Set<T> getCorrSet(EObject source, Class<T> typeFilter) {
-//		return correspondenceModel.getCorrespondingEObjectsByType(source, typeFilter) as Set<T>
-//	}
 	def <T extends EObject> T getCorr(EObject source, java.lang.Class<T> typeFilter, String tag) {
-		return ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(correspondenceModel, source, tag,
-			typeFilter).head
+		return correspondenceRetriever.getCorrespondingEObjects(source, typeFilter, tag).claimOne()
 	}
-
-//	def public <T extends EObject> Set<T> getModifiableCorrSet(EObject source, Class<T> typeFilter) {
-//		return getCorrSet(source, typeFilter).map[getModifiableInstance(it)].filter[it !== null].toSet
-//	}
+	
 	def <T extends EObject> T getModifiableCorr(EObject source, java.lang.Class<T> typeFilter, String tag) {
 		val correspondence = getCorr(source, typeFilter, tag)
 		if(correspondence === null) return null

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/DatatypesTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/DatatypesTest.xtend
@@ -8,8 +8,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
 import static tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals.*
 import tools.vitruv.applications.pcmumlclass.mapping.tests.PcmUmlClassTest
-import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -23,20 +21,19 @@ class DatatypesTest extends PcmUmlClassTest {
 	static val TEST_COMPOSITE_DATATYPE = "TestCompositeType"
 	static val TEST_COMPOSITE_DATATYPE_PARENT = "TestCompositeTypeParent"
 
-	def static checkCompositeDataTypeConcept(
-		CorrespondenceModel cm,
+	def checkCompositeDataTypeConcept(
 		CompositeDataType pcmCompositeType,
 		Class umlClass
 	) {
-		assertTrue(corresponds(cm, pcmCompositeType, umlClass))
+		assertTrue(corresponds(pcmCompositeType, umlClass))
 		assertTrue(pcmCompositeType.entityName == umlClass.name)
 		// Repository should correspond to the datatypes package
 		assertTrue(
-			corresponds(cm, pcmCompositeType.repository__DataType, umlClass.package,
+			corresponds(pcmCompositeType.repository__DataType, umlClass.package,
 				TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
 		// check that parent compositedatatypes and parent classes correspond
 		val umlParentCorrespondences = pcmCompositeType.parentType_CompositeDataType.map [ pcmParent |
-			CorrespondenceModelUtil.getCorrespondingEObjectsByType(cm, pcmParent, Class).head
+			getCorrespondingEObjects(pcmParent, Class).head
 		].toList
 		assertFalse(umlParentCorrespondences.contains(null))
 		assertFalse(
@@ -49,14 +46,14 @@ class DatatypesTest extends PcmUmlClassTest {
 	def protected checkCompositeDataTypeConcept(CompositeDataType pcmCompositeType) {
 		val umlClass = helper.getCorr(pcmCompositeType, Class, TagLiterals.COMPOSITE_DATATYPE__CLASS)
 		assertNotNull(umlClass)
-		checkCompositeDataTypeConcept(correspondenceModel, pcmCompositeType, umlClass)
+		checkCompositeDataTypeConcept(pcmCompositeType, umlClass)
 	}
 
 	def protected checkCompositeDataTypeConcept(Class umlClass) {
 		val pcmCompositeType = helper.getCorr(umlClass, CompositeDataType,
 			TagLiterals.COMPOSITE_DATATYPE__CLASS)
 		assertNotNull(pcmCompositeType)
-		checkCompositeDataTypeConcept(correspondenceModel, pcmCompositeType, umlClass)
+		checkCompositeDataTypeConcept(pcmCompositeType, umlClass)
 	}
 
 	/**

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/InterfaceTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/InterfaceTest.xtend
@@ -8,8 +8,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
 import static tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals.*
 import tools.vitruv.applications.pcmumlclass.mapping.tests.PcmUmlClassTest
-import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -20,22 +18,21 @@ import java.nio.file.Path
 class InterfaceTest extends PcmUmlClassTest {
 	static val TEST_INTERFACE_NAME = "TestInterface"
 
-	def static checkInterfaceConcept(
-		CorrespondenceModel cm,
+	def checkInterfaceConcept(
 		OperationInterface pcmInterface,
 		Interface umlInterface
 	) {
 		assertNotNull(pcmInterface)
 		assertNotNull(umlInterface)
-		assertTrue(corresponds(cm, pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE))
+		assertTrue(corresponds(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE))
 		assertTrue(pcmInterface.entityName == umlInterface.name)
 		// should be contained in corresponding repository and contracts package respectively
 		assertTrue(
-			corresponds(cm, pcmInterface.repository__Interface, umlInterface.package,
+			corresponds(pcmInterface.repository__Interface, umlInterface.package,
 				TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
 		// parent interfaces should correspond
 		val umlParentCorrespondences = pcmInterface.parentInterfaces__Interface.map [ pcmParent |
-			CorrespondenceModelUtil.getCorrespondingEObjectsByType(cm, pcmParent, Interface).head
+			getCorrespondingEObjects(pcmParent, Interface).head
 		].toList
 		assertFalse(umlParentCorrespondences.contains(null))
 		assertFalse(
@@ -47,13 +44,13 @@ class InterfaceTest extends PcmUmlClassTest {
 
 	def protected checkInterfaceConcept(OperationInterface pcmInterface) {
 		val umlInterface = helper.getCorr(pcmInterface, Interface, TagLiterals.INTERFACE_TO_INTERFACE)
-		checkInterfaceConcept(correspondenceModel, pcmInterface, umlInterface)
+		checkInterfaceConcept(pcmInterface, umlInterface)
 	}
 
 	def protected checkInterfaceConcept(Interface umlInterface) {
 		val pcmInterface = helper.getCorr(umlInterface, OperationInterface,
 			TagLiterals.INTERFACE_TO_INTERFACE)
-		checkInterfaceConcept(correspondenceModel, pcmInterface, umlInterface)
+		checkInterfaceConcept(pcmInterface, umlInterface)
 	}
 
 	def private Repository createRepositoryConcept() {

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/ParameterTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/ParameterTest.xtend
@@ -13,7 +13,6 @@ import tools.vitruv.applications.pcmumlclass.mapping.PcmUmlClassHelper
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
 import static tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals.*
 import tools.vitruv.applications.pcmumlclass.mapping.tests.PcmUmlClassTest
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertNotNull
@@ -31,31 +30,30 @@ class ParameterTest extends PcmUmlClassTest {
 		return umlDirection == PcmUmlClassHelper.getMatchingParameterDirection(pcmModifier)
 	}
 
-	def static checkParameterConcept(
-		CorrespondenceModel cm,
+	def checkParameterConcept(
 		Parameter pcmParam,
 		org.eclipse.uml2.uml.Parameter umlParam
 	) {
 		assertNotNull(pcmParam)
 		assertNotNull(umlParam)
-		assertTrue(corresponds(cm, pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER))
+		assertTrue(corresponds(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER))
 		assertTrue(pcmParam.parameterName == umlParam.name)
 		assertTrue(checkParameterModifiers(pcmParam.modifier__Parameter, umlParam.direction))
-		assertTrue(isCorrect_DataType_Parameter_Correspondence(cm, pcmParam.dataType__Parameter, umlParam))
+		assertTrue(isCorrect_DataType_Parameter_Correspondence(pcmParam.dataType__Parameter, umlParam))
 		assertTrue(
-			corresponds(cm, pcmParam.operationSignature__Parameter, umlParam.operation,
+			corresponds(pcmParam.operationSignature__Parameter, umlParam.operation,
 				TagLiterals.SIGNATURE__OPERATION))
 	}
 
 	def protected checkParameterConcept(Parameter pcmParam) {
 		val mUmlParam = helper.getCorr(pcmParam, org.eclipse.uml2.uml.Parameter,
 			TagLiterals.PARAMETER__REGULAR_PARAMETER)
-		checkParameterConcept(correspondenceModel, pcmParam, mUmlParam)
+		checkParameterConcept(pcmParam, mUmlParam)
 	}
 
 	def protected checkParameterConcept(org.eclipse.uml2.uml.Parameter umlParam) {
 		val mPcmParam = helper.getCorr(umlParam, Parameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
-		checkParameterConcept(correspondenceModel, mPcmParam, umlParam)
+		checkParameterConcept(mPcmParam, umlParam)
 	}
 
 	def private Repository createRepositoryWithSignature() {

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/ProvidedRoleTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/ProvidedRoleTest.xtend
@@ -7,7 +7,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
 import static tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals.*
 import tools.vitruv.applications.pcmumlclass.mapping.tests.PcmUmlClassTest
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -18,35 +17,34 @@ class ProvidedRoleTest extends PcmUmlClassTest {
 
 	static val PROVIDED_ROLE_NAME = "testProvidedRole"
 
-	def static void checkProvidedRoleConcept(
-		CorrespondenceModel cm,
+	def void checkProvidedRoleConcept(
 		OperationProvidedRole pcmProvided,
 		InterfaceRealization umlRealization
 	) {
 		assertNotNull(pcmProvided)
 		assertNotNull(umlRealization)
-		assertTrue(corresponds(cm, pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION))
+		assertTrue(corresponds(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION))
 		assertTrue(pcmProvided.entityName == umlRealization.name)
 		// the respective type references have to correspond
 		assertTrue(
-			corresponds(cm, pcmProvided.providedInterface__OperationProvidedRole, umlRealization.contract,
+			corresponds(pcmProvided.providedInterface__OperationProvidedRole, umlRealization.contract,
 				TagLiterals.INTERFACE_TO_INTERFACE))
 		// the owning component and component implementation have to correspond
 		assertTrue(
-			corresponds(cm, pcmProvided.providingEntity_ProvidedRole, umlRealization.implementingClassifier,
+			corresponds(pcmProvided.providingEntity_ProvidedRole, umlRealization.implementingClassifier,
 				TagLiterals.IPRE__IMPLEMENTATION))
 	}
 
 	def protected checkProvidedRoleConcept(OperationProvidedRole pcmProvided) {
 		val umlRealization = helper.getCorr(pcmProvided, InterfaceRealization,
 			TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
-		checkProvidedRoleConcept(correspondenceModel, pcmProvided, umlRealization)
+		checkProvidedRoleConcept(pcmProvided, umlRealization)
 	}
 
 	def protected checkProvidedRoleConcept(InterfaceRealization umlRealization) {
 		val pcmProvided = helper.getCorr(umlRealization, OperationProvidedRole,
 			TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
-		checkProvidedRoleConcept(correspondenceModel, pcmProvided, umlRealization)
+		checkProvidedRoleConcept(pcmProvided, umlRealization)
 	}
 
 	def private Repository createRepository_Component_Interface() {

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/RepositoryComponentTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/RepositoryComponentTest.xtend
@@ -12,7 +12,6 @@ import tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
 import static tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals.*
 import tools.vitruv.applications.pcmumlclass.mapping.tests.PcmUmlClassTest
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -24,8 +23,7 @@ class RepositoryComponentTest extends PcmUmlClassTest {
 
 	val COMPONENT_NAME = "TestComponent"
 
-	def static void checkRepositoryComponentConcept(
-		CorrespondenceModel cm,
+	def void checkRepositoryComponentConcept(
 		RepositoryComponent pcmComponent,
 		Package umlComponentPkg,
 		Class umlComponentImpl,
@@ -35,9 +33,9 @@ class RepositoryComponentTest extends PcmUmlClassTest {
 		assertNotNull(umlComponentPkg)
 		assertNotNull(umlComponentImpl)
 		assertNotNull(umlComponentConstructor)
-		assertTrue(corresponds(cm, pcmComponent, umlComponentPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE))
-		assertTrue(corresponds(cm, pcmComponent, umlComponentImpl, TagLiterals.IPRE__IMPLEMENTATION))
-		assertTrue(corresponds(cm, pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR))
+		assertTrue(corresponds(pcmComponent, umlComponentPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE))
+		assertTrue(corresponds(pcmComponent, umlComponentImpl, TagLiterals.IPRE__IMPLEMENTATION))
+		assertTrue(corresponds(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR))
 		assertEquals(umlComponentPkg.name, pcmComponent.entityName.toFirstLower)
 		assertEquals(umlComponentPkg.name.toFirstUpper, pcmComponent.entityName)
 		assertEquals(pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX, umlComponentImpl.name)
@@ -49,7 +47,7 @@ class RepositoryComponentTest extends PcmUmlClassTest {
 		assertEquals(umlComponentPkg, umlComponentImpl.package)
 		// component repository should correspond to the parent package of the component package
 		assertTrue(
-			corresponds(cm, pcmComponent.repository__RepositoryComponent, umlComponentPkg.nestingPackage,
+			corresponds(pcmComponent.repository__RepositoryComponent, umlComponentPkg.nestingPackage,
 				TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
 	}
 
@@ -57,7 +55,7 @@ class RepositoryComponentTest extends PcmUmlClassTest {
 		val umlComponentPkg = helper.getCorr(pcmComponent, Package, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 		val umlComponentImpl = helper.getCorr(pcmComponent, Class, TagLiterals.IPRE__IMPLEMENTATION)
 		val umlComponentConstructor = helper.getCorr(pcmComponent, Operation, TagLiterals.IPRE__CONSTRUCTOR)
-		checkRepositoryComponentConcept(correspondenceModel, pcmComponent, umlComponentPkg, umlComponentImpl,
+		checkRepositoryComponentConcept(pcmComponent, umlComponentPkg, umlComponentImpl,
 			umlComponentConstructor)
 	}
 

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/RepositoryTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/RepositoryTest.xtend
@@ -8,7 +8,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
 import static tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals.*
 import tools.vitruv.applications.pcmumlclass.mapping.tests.PcmUmlClassTest
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import org.apache.log4j.Logger
 
@@ -21,17 +20,16 @@ import java.nio.file.Path
 class RepositoryTest extends PcmUmlClassTest {
 	static val logger = Logger.getLogger(RepositoryTest)
 
-	def protected static checkRepositoryConcept(
-		CorrespondenceModel cm,
+	def protected checkRepositoryConcept(
 		Repository pcmRepo,
 		Package umlRepositoryPkg,
 		Package umlContractsPkg,
 		Package umlDatatypesPkg
 	) {
 		// correspondence constraints
-		assertTrue(corresponds(cm, pcmRepo, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
-		assertTrue(corresponds(cm, pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
-		assertTrue(corresponds(cm, pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
 		// containment constraints
 		assertTrue(EcoreUtil.equals(umlContractsPkg.nestingPackage, umlRepositoryPkg))
 		assertTrue(EcoreUtil.equals(umlDatatypesPkg.nestingPackage, umlRepositoryPkg))
@@ -58,7 +56,7 @@ class RepositoryTest extends PcmUmlClassTest {
 		assertTrue(umlRepositoryPkg !== null)
 		assertTrue(umlContractsPkg !== null)
 		assertTrue(umlDatatypesPkg !== null)
-		checkRepositoryConcept(correspondenceModel, pcmRepository, umlRepositoryPkg, umlContractsPkg, umlDatatypesPkg)
+		checkRepositoryConcept(pcmRepository, umlRepositoryPkg, umlContractsPkg, umlDatatypesPkg)
 	}
 
 	@Test

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/RequiredRoleTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/RequiredRoleTest.xtend
@@ -10,7 +10,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
 import static tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals.*
 import tools.vitruv.applications.pcmumlclass.mapping.tests.PcmUmlClassTest
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import org.eclipse.uml2.uml.Operation
 import org.apache.log4j.Logger
@@ -28,25 +27,24 @@ class RequiredRoleTest extends PcmUmlClassTest {
 
 	val REQUIRED_ROLE_NAME = "testRequiredRole"
 
-	def static void checkRequiredRoleConcept(
-		CorrespondenceModel cm,
+	def void checkRequiredRoleConcept(
 		OperationRequiredRole pcmRequired,
 		Property umlRequiredInstance,
 		Parameter umlRequiredParameter
 	) {
 		assertNotNull(umlRequiredInstance)
 		assertNotNull(umlRequiredParameter)
-		assertTrue(corresponds(cm, pcmRequired, umlRequiredInstance, TagLiterals.REQUIRED_ROLE__PROPERTY))
-		assertTrue(corresponds(cm, pcmRequired, umlRequiredParameter, TagLiterals.REQUIRED_ROLE__PARAMETER))
+		assertTrue(corresponds(pcmRequired, umlRequiredInstance, TagLiterals.REQUIRED_ROLE__PROPERTY))
+		assertTrue(corresponds(pcmRequired, umlRequiredParameter, TagLiterals.REQUIRED_ROLE__PARAMETER))
 		// the respective type references have to correspond
-		assertTrue(corresponds(cm, pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredInstance.type))
-		assertTrue(corresponds(cm, pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredParameter.type))
+		assertTrue(corresponds(pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredInstance.type))
+		assertTrue(corresponds(pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredParameter.type))
 		// the owning component and component implementation have to correspond
 		assertTrue(
-			corresponds(cm, pcmRequired.requiringEntity_RequiredRole, umlRequiredInstance.class_,
+			corresponds(pcmRequired.requiringEntity_RequiredRole, umlRequiredInstance.class_,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(
-			corresponds(cm, pcmRequired.requiringEntity_RequiredRole, umlRequiredParameter.operation?.class_,
+			corresponds(pcmRequired.requiringEntity_RequiredRole, umlRequiredParameter.operation?.class_,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertEquals(pcmRequired.entityName, umlRequiredInstance.name)
 		assertEquals(pcmRequired.entityName, umlRequiredParameter.name)
@@ -56,7 +54,7 @@ class RequiredRoleTest extends PcmUmlClassTest {
 		assertNotNull(pcmRequired)
 		val umlRequiredInstance = helper.getCorr(pcmRequired, Property, TagLiterals.REQUIRED_ROLE__PROPERTY)
 		val umlRequiredParameter = helper.getCorr(pcmRequired, Parameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
-		checkRequiredRoleConcept(correspondenceModel, pcmRequired, umlRequiredInstance, umlRequiredParameter)
+		checkRequiredRoleConcept(pcmRequired, umlRequiredInstance, umlRequiredParameter)
 	}
 
 	def protected checkRequiredRoleConcept(Property umlRequiredInstance, Parameter umlRequiredParameter) {

--- a/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/SignatureTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.mapping.tests/src/tools/vitruv/applications/pcmumlclass/mapping/tests/cases/SignatureTest.xtend
@@ -13,7 +13,6 @@ import tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.mapping.TagLiterals
 import static tools.vitruv.applications.pcmumlclass.mapping.DefaultLiterals.*
 import tools.vitruv.applications.pcmumlclass.mapping.tests.PcmUmlClassTest
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import org.apache.log4j.Logger
 
@@ -31,8 +30,7 @@ class SignatureTest extends PcmUmlClassTest {
 
 	static val TEST_SIGNATURE_NAME = "testSignature"
 
-	def static void checkSignatureConcept(
-		CorrespondenceModel cm,
+	def void checkSignatureConcept(
 		OperationSignature pcmSignature,
 		Operation umlOperation
 	) {
@@ -42,31 +40,31 @@ class SignatureTest extends PcmUmlClassTest {
 		assertNotNull(pcmSignature)
 		assertNotNull(umlOperation)
 		assertNotNull(returnParam)
-		assertTrue(corresponds(cm, pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION))
-		assertTrue(corresponds(cm, pcmSignature, returnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER))
+		assertTrue(corresponds(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION))
+		assertTrue(corresponds(pcmSignature, returnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER))
 		assertEquals(umlOperation.name, pcmSignature.entityName)
 		// the name needs to be set, so that its TUID is distinct and the object is not confused with new instances
 		assertEquals(DefaultLiterals.RETURN_PARAM_NAME, returnParam.name)
 		// return types of both model elements should correspond to each other if they are set
 		logger.debug('''pcm «pcmSignature.returnType__OperationSignature»  uml «returnParam»''')
 		assertTrue(
-			isCorrect_DataType_Parameter_Correspondence(cm, pcmSignature.returnType__OperationSignature, returnParam))
+			isCorrect_DataType_Parameter_Correspondence(pcmSignature.returnType__OperationSignature, returnParam))
 		// should both be contained in corresponding interfaces
 		assertTrue(
-			corresponds(cm, pcmSignature.interface__OperationSignature, umlOperation.interface,
+			corresponds(pcmSignature.interface__OperationSignature, umlOperation.interface,
 				TagLiterals.INTERFACE_TO_INTERFACE))
 	}
 
 	def protected checkSignatureConcept(OperationSignature pcmSignature) {
 		val umlOperation = helper.getCorr(pcmSignature, Operation, TagLiterals.SIGNATURE__OPERATION)
 		assertNotNull(umlOperation)
-		checkSignatureConcept(correspondenceModel, pcmSignature, umlOperation)
+		checkSignatureConcept(pcmSignature, umlOperation)
 	}
 
 	def protected checkSignatureConcept(Operation umlOperation) {
 		val pcmSignature = helper.getCorr(umlOperation, OperationSignature, TagLiterals.SIGNATURE__OPERATION)
 		assertNotNull(pcmSignature)
-		checkSignatureConcept(correspondenceModel, pcmSignature, umlOperation)
+		checkSignatureConcept(pcmSignature, umlOperation)
 	}
 
 	def private Repository createRepositoryWithInterface() {

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/META-INF/MANIFEST.MF
@@ -10,7 +10,7 @@ Require-Bundle: tools.vitruv.testutils,
  org.eclipse.emf.compare,
  org.hamcrest.core,
  tools.vitruv.applications.pcmumlclass,
- tools.vitruv.extensions.dslsruntime.reactions,
- tools.vitruv.applications.util.temporary
+ tools.vitruv.applications.util.temporary,
+ org.eclipse.xtend.lib
 Export-Package: tools.vitruv.applications.pcmumlclass.tests
 Bundle-Vendor: vitruv.tools

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/AssemblyContextConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/AssemblyContextConceptTest.xtend
@@ -5,7 +5,6 @@ import org.palladiosimulator.pcm.core.composition.AssemblyContext
 import org.palladiosimulator.pcm.core.composition.CompositionFactory
 import org.palladiosimulator.pcm.repository.Repository
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -21,20 +20,19 @@ class AssemblyContextConceptTest extends PcmUmlClassApplicationTest {
 
 	static val PROPERTY_NAME = "testAssemblyContextField"
 
-	def static void checkAssemblyContextConcept(
-		CorrespondenceModel cm,
+	def void checkAssemblyContextConcept(
 		AssemblyContext pcmAssemblyContext,
 		Property umlAssemblyContextProperty
 	) {
 		assertNotNull(pcmAssemblyContext)
 		assertNotNull(umlAssemblyContextProperty)
 		assertTrue(
-			corresponds(cm, pcmAssemblyContext, umlAssemblyContextProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY))
+			corresponds(pcmAssemblyContext, umlAssemblyContextProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY))
 		assertTrue(
-			corresponds(cm, pcmAssemblyContext.parentStructure__AssemblyContext, umlAssemblyContextProperty.owner,
+			corresponds(pcmAssemblyContext.parentStructure__AssemblyContext, umlAssemblyContextProperty.owner,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(
-			corresponds(cm, pcmAssemblyContext.encapsulatedComponent__AssemblyContext, umlAssemblyContextProperty.type,
+			corresponds( pcmAssemblyContext.encapsulatedComponent__AssemblyContext, umlAssemblyContextProperty.type,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(pcmAssemblyContext.entityName == umlAssemblyContextProperty.name)
 	}
@@ -42,13 +40,13 @@ class AssemblyContextConceptTest extends PcmUmlClassApplicationTest {
 	def protected checkAssemblyContextConcept(AssemblyContext pcmAssemblyContext) {
 		val umlAssemblyContextProperty = helper.getModifiableCorr(pcmAssemblyContext, Property,
 			TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
-		checkAssemblyContextConcept(correspondenceModel, pcmAssemblyContext, umlAssemblyContextProperty)
+		checkAssemblyContextConcept(pcmAssemblyContext, umlAssemblyContextProperty)
 	}
 
 	def protected checkAssemblyContextConcept(Property umlAssemblyContextProperty) {
 		val pcmAssemblyContext = helper.getModifiableCorr(umlAssemblyContextProperty, AssemblyContext,
 			TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
-		checkAssemblyContextConcept(correspondenceModel, pcmAssemblyContext, umlAssemblyContextProperty)
+		checkAssemblyContextConcept(pcmAssemblyContext, umlAssemblyContextProperty)
 	}
 
 	/**

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/AttributeConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/AttributeConceptTest.xtend
@@ -9,7 +9,6 @@ import org.palladiosimulator.pcm.repository.InnerDeclaration
 import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Disabled
 import static org.junit.jupiter.api.Assertions.assertNotNull
@@ -26,32 +25,31 @@ class AttributeConceptTest extends PcmUmlClassApplicationTest {
 
 	static val TEST_ATTRIBUTE = "testAttribute"
 
-	def static void checkAttributeConcept(
-		CorrespondenceModel cm,
+	def void checkAttributeConcept(
 		InnerDeclaration pcmAttribute,
 		Property umlAttribute
 	) {
 		assertNotNull(pcmAttribute)
 		assertNotNull(umlAttribute)
-		assertTrue(corresponds(cm, pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY))
+		assertTrue(corresponds(pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY))
 		assertTrue(pcmAttribute.entityName == umlAttribute.name)
 		// parent CompositeType should correspond to parent uml::Class
 		assertTrue(
-			corresponds(cm, pcmAttribute.compositeDataType_InnerDeclaration, umlAttribute.class_,
+			corresponds(pcmAttribute.compositeDataType_InnerDeclaration, umlAttribute.class_,
 				TagLiterals.COMPOSITE_DATATYPE__CLASS))
 		// types should correspond
-		assertTrue(isCorrect_DataType_Property_Correspondence(cm, pcmAttribute.datatype_InnerDeclaration, umlAttribute))
+		assertTrue(isCorrect_DataType_Property_Correspondence(pcmAttribute.datatype_InnerDeclaration, umlAttribute))
 	}
 
 	def protected checkAttributeConcept(InnerDeclaration pcmAttribute) {
 		val umlAttribute = helper.getModifiableCorr(pcmAttribute, Property, TagLiterals.INNER_DECLARATION__PROPERTY)
-		checkAttributeConcept(correspondenceModel, pcmAttribute, umlAttribute)
+		checkAttributeConcept(pcmAttribute, umlAttribute)
 	}
 
 	def protected checkAttributeConcept(Property umlAttribute) {
 		val pcmAttribute = helper.getModifiableCorr(umlAttribute, InnerDeclaration,
 			TagLiterals.INNER_DECLARATION__PROPERTY)
-		checkAttributeConcept(correspondenceModel, pcmAttribute, umlAttribute)
+		checkAttributeConcept(pcmAttribute, umlAttribute)
 	}
 
 	def private Repository createRepository() {

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/CompositeDataTypeConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/CompositeDataTypeConceptTest.xtend
@@ -6,8 +6,6 @@ import org.palladiosimulator.pcm.repository.CompositeDataType
 import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 import org.junit.jupiter.api.Test
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -29,20 +27,19 @@ class CompositeDataTypeConceptTest extends PcmUmlClassApplicationTest {
 	static val TEST_COMPOSITE_DATATYPE = "TestCompositeType"
 	static val TEST_COMPOSITE_DATATYPE_PARENT = "TestCompositeTypeParent"
 
-	def static checkCompositeDataTypeConcept(
-		CorrespondenceModel cm,
+	def checkCompositeDataTypeConcept(
 		CompositeDataType pcmCompositeType,
 		Class umlClass
 	) {
-		assertTrue(corresponds(cm, pcmCompositeType, umlClass))
+		assertTrue(corresponds(pcmCompositeType, umlClass))
 		assertTrue(pcmCompositeType.entityName == umlClass.name)
 		// Repository should correspond to the datatypes package
 		assertTrue(
-			corresponds(cm, pcmCompositeType.repository__DataType, umlClass.package,
+			corresponds(pcmCompositeType.repository__DataType, umlClass.package,
 				TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
 		// check that parent compositedatatypes and parent classes correspond
 		val umlParentCorrespondences = pcmCompositeType.parentType_CompositeDataType.map [ pcmParent |
-			CorrespondenceModelUtil.getCorrespondingEObjectsByType(cm, pcmParent, Class).head
+			getCorrespondingEObjects(pcmParent, Class).head
 		].toList
 		assertFalse(umlParentCorrespondences.contains(null))
 		assertFalse(
@@ -54,13 +51,13 @@ class CompositeDataTypeConceptTest extends PcmUmlClassApplicationTest {
 
 	def protected checkCompositeDataTypeConcept(CompositeDataType pcmCompositeType) {
 		val umlClass = helper.getModifiableCorr(pcmCompositeType, Class, TagLiterals.COMPOSITE_DATATYPE__CLASS)
-		checkCompositeDataTypeConcept(correspondenceModel, pcmCompositeType, umlClass)
+		checkCompositeDataTypeConcept(pcmCompositeType, umlClass)
 	}
 
 	def protected checkCompositeDataTypeConcept(Class umlClass) {
 		val pcmCompositeType = helper.getModifiableCorr(umlClass, CompositeDataType,
 			TagLiterals.COMPOSITE_DATATYPE__CLASS)
-		checkCompositeDataTypeConcept(correspondenceModel, pcmCompositeType, umlClass)
+		checkCompositeDataTypeConcept(pcmCompositeType, umlClass)
 	}
 
 	/**

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/InterfaceConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/InterfaceConceptTest.xtend
@@ -6,8 +6,6 @@ import org.palladiosimulator.pcm.repository.OperationInterface
 import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
@@ -25,22 +23,21 @@ class InterfaceConceptTest extends PcmUmlClassApplicationTest {
 
 	static val TEST_INTERFACE_NAME = "TestInterface"
 
-	def static checkInterfaceConcept(
-		CorrespondenceModel cm,
+	def checkInterfaceConcept(
 		OperationInterface pcmInterface,
 		Interface umlInterface
 	) {
 		assertNotNull(pcmInterface)
 		assertNotNull(umlInterface)
-		assertTrue(corresponds(cm, pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE))
+		assertTrue(corresponds(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE))
 		assertTrue(pcmInterface.entityName == umlInterface.name)
 		// should be contained in corresponding repository and contracts package respectively
 		assertTrue(
-			corresponds(cm, pcmInterface.repository__Interface, umlInterface.package,
+			corresponds(pcmInterface.repository__Interface, umlInterface.package,
 				TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
 		// parent interfaces should correspond
 		val umlParentCorrespondences = pcmInterface.parentInterfaces__Interface.map [ pcmParent |
-			CorrespondenceModelUtil.getCorrespondingEObjectsByType(cm, pcmParent, Interface).head
+			getCorrespondingEObjects(pcmParent, Interface).head
 		].toList
 		assertFalse(umlParentCorrespondences.contains(null))
 		assertFalse(
@@ -52,13 +49,13 @@ class InterfaceConceptTest extends PcmUmlClassApplicationTest {
 
 	def protected checkInterfaceConcept(OperationInterface pcmInterface) {
 		val umlInterface = helper.getModifiableCorr(pcmInterface, Interface, TagLiterals.INTERFACE_TO_INTERFACE)
-		checkInterfaceConcept(correspondenceModel, pcmInterface, umlInterface)
+		checkInterfaceConcept(pcmInterface, umlInterface)
 	}
 
 	def protected checkInterfaceConcept(Interface umlInterface) {
 		val pcmInterface = helper.getModifiableCorr(umlInterface, OperationInterface,
 			TagLiterals.INTERFACE_TO_INTERFACE)
-		checkInterfaceConcept(correspondenceModel, pcmInterface, umlInterface)
+		checkInterfaceConcept(pcmInterface, umlInterface)
 	}
 
 	def private Repository createRepositoryConcept() {

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/ParameterConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/ParameterConceptTest.xtend
@@ -11,7 +11,6 @@ import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertNull
@@ -34,31 +33,30 @@ class ParameterConceptTest extends PcmUmlClassApplicationTest {
 		return umlDirection == PcmUmlClassHelper.getMatchingParameterDirection(pcmModifier)
 	}
 
-	def static checkParameterConcept(
-		CorrespondenceModel cm,
+	def checkParameterConcept(
 		Parameter pcmParam,
 		org.eclipse.uml2.uml.Parameter umlParam
 	) {
 		assertNotNull(pcmParam)
 		assertNotNull(umlParam)
-		assertTrue(corresponds(cm, pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER))
+		assertTrue(corresponds(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER))
 		assertTrue(pcmParam.parameterName == umlParam.name)
 		assertTrue(checkParameterModifiers(pcmParam.modifier__Parameter, umlParam.direction))
-		assertTrue(isCorrect_DataType_Parameter_Correspondence(cm, pcmParam.dataType__Parameter, umlParam))
+		assertTrue(isCorrect_DataType_Parameter_Correspondence(pcmParam.dataType__Parameter, umlParam))
 		assertTrue(
-			corresponds(cm, pcmParam.operationSignature__Parameter, umlParam.operation,
+			corresponds(pcmParam.operationSignature__Parameter, umlParam.operation,
 				TagLiterals.SIGNATURE__OPERATION))
 	}
 
 	def protected checkParameterConcept(Parameter pcmParam) {
 		val mUmlParam = helper.getModifiableCorr(pcmParam, org.eclipse.uml2.uml.Parameter,
 			TagLiterals.PARAMETER__REGULAR_PARAMETER)
-		checkParameterConcept(correspondenceModel, pcmParam, mUmlParam)
+		checkParameterConcept(pcmParam, mUmlParam)
 	}
 
 	def protected checkParameterConcept(org.eclipse.uml2.uml.Parameter umlParam) {
 		val mPcmParam = helper.getModifiableCorr(umlParam, Parameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
-		checkParameterConcept(correspondenceModel, mPcmParam, umlParam)
+		checkParameterConcept(mPcmParam, umlParam)
 	}
 
 	def private Repository createRepositoryWithSignature() {

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlClassApplicationTestHelper.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlClassApplicationTestHelper.xtend
@@ -1,6 +1,5 @@
 package tools.vitruv.applications.pcmumlclass.tests
 
-import java.util.Set
 import java.util.function.Function
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.EObject
@@ -25,15 +24,14 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.util.temporary.uml.UmlTypeUtil
-import tools.vitruv.extensions.dslsruntime.reactions.helper.ReactionsCorrespondenceHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
-import static extension tools.vitruv.framework.correspondence.CorrespondenceModelUtil.*
 import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil
+import tools.vitruv.testutils.LegacyCorrespondenceRetriever
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 final class PcmUmlClassApplicationTestHelper {
-	new(CorrespondenceModel testCorrespondenceModel, Function<URI, Resource> resourceRetriever) {
-		this.correspondenceModel = testCorrespondenceModel
+	new(LegacyCorrespondenceRetriever correspondenceRetriever, Function<URI, Resource> resourceRetriever) {
+		this.correspondenceRetriever = correspondenceRetriever
 		this.resourceRetriever = resourceRetriever
 
 		val pcmPrimitiveTypes = PcmDataTypeUtil.getPcmPrimitiveTypes(resourceRetriever)
@@ -52,7 +50,7 @@ final class PcmUmlClassApplicationTestHelper {
 		UML_UNLIMITED_NATURAL = umlPrimitiveTypes.findFirst[it.name == "UnlimitedNatural"]
 	}
 
-	val CorrespondenceModel correspondenceModel
+	val LegacyCorrespondenceRetriever correspondenceRetriever
 	val Function<URI, Resource> resourceRetriever
 
 	/**
@@ -71,17 +69,8 @@ final class PcmUmlClassApplicationTestHelper {
 		return resourceRetriever.apply(originalURI.trimFragment).getEObject(originalURI.fragment) as T
 	}
 
-	def <T extends EObject> Set<T> getCorrSet(EObject source, Class<T> typeFilter) {
-		return correspondenceModel.getCorrespondingEObjectsByType(source, typeFilter)
-	}
-
 	def <T extends EObject> T getCorr(EObject source, Class<T> typeFilter, String tag) {
-		return ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(correspondenceModel, source, tag,
-			typeFilter).head
-	}
-
-	def <T extends EObject> Set<T> getModifiableCorrSet(EObject source, Class<T> typeFilter) {
-		return getCorrSet(source, typeFilter).map[getModifiableInstance(it)].filter[it !== null].toSet
+		return correspondenceRetriever.getCorrespondingEObjects(source, typeFilter, tag).claimOne()
 	}
 
 	def <T extends EObject> T getModifiableCorr(EObject source, Class<T> typeFilter, String tag) {

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/ProvidedRoleTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/ProvidedRoleTest.xtend
@@ -5,7 +5,6 @@ import org.palladiosimulator.pcm.repository.OperationProvidedRole
 import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
@@ -22,35 +21,34 @@ class ProvidedRoleTest extends PcmUmlClassApplicationTest {
 
 	static val PROVIDED_ROLE_NAME = "testProvidedRole"
 
-	def static void checkProvidedRoleConcept(
-		CorrespondenceModel cm,
+	def void checkProvidedRoleConcept(
 		OperationProvidedRole pcmProvided,
 		InterfaceRealization umlRealization
 	) {
 		assertNotNull(pcmProvided)
 		assertNotNull(umlRealization)
-		assertTrue(corresponds(cm, pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION))
+		assertTrue(corresponds(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION))
 		assertTrue(pcmProvided.entityName == umlRealization.name)
 		// the respective type references have to correspond
 		assertTrue(
-			corresponds(cm, pcmProvided.providedInterface__OperationProvidedRole, umlRealization.contract,
+			corresponds(pcmProvided.providedInterface__OperationProvidedRole, umlRealization.contract,
 				TagLiterals.INTERFACE_TO_INTERFACE))
 		// the owning component and component implementation have to correspond
 		assertTrue(
-			corresponds(cm, pcmProvided.providingEntity_ProvidedRole, umlRealization.implementingClassifier,
+			corresponds(pcmProvided.providingEntity_ProvidedRole, umlRealization.implementingClassifier,
 				TagLiterals.IPRE__IMPLEMENTATION))
 	}
 
 	def protected checkProvidedRoleConcept(OperationProvidedRole pcmProvided) {
 		val umlRealization = helper.getModifiableCorr(pcmProvided, InterfaceRealization,
 			TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
-		checkProvidedRoleConcept(correspondenceModel, pcmProvided, umlRealization)
+		checkProvidedRoleConcept(pcmProvided, umlRealization)
 	}
 
 	def protected checkProvidedRoleConcept(InterfaceRealization umlRealization) {
 		val pcmProvided = helper.getModifiableCorr(umlRealization, OperationProvidedRole,
 			TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
-		checkProvidedRoleConcept(correspondenceModel, pcmProvided, umlRealization)
+		checkProvidedRoleConcept(pcmProvided, umlRealization)
 	}
 
 	def private Repository createRepository_Component_Interface() {

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RepositoryComponentConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RepositoryComponentConceptTest.xtend
@@ -10,7 +10,6 @@ import org.palladiosimulator.pcm.repository.RepositoryComponent
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
@@ -31,8 +30,7 @@ class RepositoryComponentConceptTest extends PcmUmlClassApplicationTest {
 
 	val COMPONENT_NAME = "testComponent"
 
-	def static void checkRepositoryComponentConcept(
-		CorrespondenceModel cm,
+	def void checkRepositoryComponentConcept(
 		RepositoryComponent pcmComponent,
 		Package umlComponentPkg,
 		Class umlComponentImpl,
@@ -42,9 +40,9 @@ class RepositoryComponentConceptTest extends PcmUmlClassApplicationTest {
 		assertNotNull(umlComponentPkg)
 		assertNotNull(umlComponentImpl)
 		assertNotNull(umlComponentConstructor)
-		assertTrue(corresponds(cm, pcmComponent, umlComponentPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE))
-		assertTrue(corresponds(cm, pcmComponent, umlComponentImpl, TagLiterals.IPRE__IMPLEMENTATION))
-		assertTrue(corresponds(cm, pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR))
+		assertTrue(corresponds(pcmComponent, umlComponentPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE))
+		assertTrue(corresponds(pcmComponent, umlComponentImpl, TagLiterals.IPRE__IMPLEMENTATION))
+		assertTrue(corresponds(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR))
 		assertTrue(pcmComponent.entityName.toFirstLower == umlComponentPkg.name)
 		assertTrue(pcmComponent.entityName == umlComponentPkg.name.toFirstUpper)
 		assertTrue(pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX == umlComponentImpl.name)
@@ -55,7 +53,7 @@ class RepositoryComponentConceptTest extends PcmUmlClassApplicationTest {
 		assertTrue(umlComponentImpl.package === umlComponentPkg)
 		// component repository should correspond to the parent package of the component package
 		assertTrue(
-			corresponds(cm, pcmComponent.repository__RepositoryComponent, umlComponentPkg.nestingPackage,
+			corresponds(pcmComponent.repository__RepositoryComponent, umlComponentPkg.nestingPackage,
 				TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
 	}
 
@@ -63,7 +61,7 @@ class RepositoryComponentConceptTest extends PcmUmlClassApplicationTest {
 		val umlComponentPkg = helper.getModifiableCorr(pcmComponent, Package, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 		val umlComponentImpl = helper.getModifiableCorr(pcmComponent, Class, TagLiterals.IPRE__IMPLEMENTATION)
 		val umlComponentConstructor = helper.getModifiableCorr(pcmComponent, Operation, TagLiterals.IPRE__CONSTRUCTOR)
-		checkRepositoryComponentConcept(correspondenceModel, pcmComponent, umlComponentPkg, umlComponentImpl,
+		checkRepositoryComponentConcept(pcmComponent, umlComponentPkg, umlComponentImpl,
 			umlComponentConstructor)
 	}
 

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RepositoryConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RepositoryConceptTest.xtend
@@ -7,7 +7,6 @@ import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertTrue
@@ -22,17 +21,16 @@ import java.nio.file.Path
  */
 class RepositoryConceptTest extends PcmUmlClassApplicationTest {
 
-	def protected static checkRepositoryConcept(
-		CorrespondenceModel cm,
+	def protected checkRepositoryConcept(
 		Repository pcmRepo,
 		Package umlRepositoryPkg,
 		Package umlContractsPkg,
 		Package umlDatatypesPkg
 	) {
 		// correspondence constraints
-		assertTrue(corresponds(cm, pcmRepo, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
-		assertTrue(corresponds(cm, pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
-		assertTrue(corresponds(cm, pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
 		// containment constraints
 		assertTrue(EcoreUtil.equals(umlContractsPkg.nestingPackage, umlRepositoryPkg))
 		assertTrue(EcoreUtil.equals(umlDatatypesPkg.nestingPackage, umlRepositoryPkg))
@@ -62,7 +60,7 @@ class RepositoryConceptTest extends PcmUmlClassApplicationTest {
 		assertTrue(umlRepositoryPkg !== null)
 		assertTrue(umlContractsPkg !== null)
 		assertTrue(umlDatatypesPkg !== null)
-		checkRepositoryConcept(correspondenceModel, pcmRepository, umlRepositoryPkg, umlContractsPkg, umlDatatypesPkg)
+		checkRepositoryConcept(pcmRepository, umlRepositoryPkg, umlContractsPkg, umlDatatypesPkg)
 	}
 
 	@Test

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RequiredRoleConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/RequiredRoleConceptTest.xtend
@@ -6,7 +6,6 @@ import org.palladiosimulator.pcm.repository.OperationRequiredRole
 import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
@@ -26,8 +25,7 @@ class RequiredRoleConceptTest extends PcmUmlClassApplicationTest {
 
 	val REQUIRED_ROLE_NAME = "testRequiredRole"
 
-	def static void checkRequiredRoleConcept(
-		CorrespondenceModel cm,
+	def void checkRequiredRoleConcept(
 		OperationRequiredRole pcmRequired,
 		Property umlRequiredInstance,
 		Parameter umlRequiredParameter
@@ -35,17 +33,17 @@ class RequiredRoleConceptTest extends PcmUmlClassApplicationTest {
 		assertNotNull(pcmRequired)
 		assertNotNull(umlRequiredInstance)
 		assertNotNull(umlRequiredParameter)
-		assertTrue(corresponds(cm, pcmRequired, umlRequiredInstance, TagLiterals.REQUIRED_ROLE__PROPERTY))
-		assertTrue(corresponds(cm, pcmRequired, umlRequiredParameter, TagLiterals.REQUIRED_ROLE__PARAMETER))
+		assertTrue(corresponds(pcmRequired, umlRequiredInstance, TagLiterals.REQUIRED_ROLE__PROPERTY))
+		assertTrue(corresponds(pcmRequired, umlRequiredParameter, TagLiterals.REQUIRED_ROLE__PARAMETER))
 		// the respective type references have to correspond
-		assertTrue(corresponds(cm, pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredInstance.type))
-		assertTrue(corresponds(cm, pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredParameter.type))
+		assertTrue(corresponds(pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredInstance.type))
+		assertTrue(corresponds(pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredParameter.type))
 		// the owning component and component implementation have to correspond
 		assertTrue(
-			corresponds(cm, pcmRequired.requiringEntity_RequiredRole, umlRequiredInstance.class_,
+			corresponds(pcmRequired.requiringEntity_RequiredRole, umlRequiredInstance.class_,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(
-			corresponds(cm, pcmRequired.requiringEntity_RequiredRole, umlRequiredParameter.operation?.class_,
+			corresponds(pcmRequired.requiringEntity_RequiredRole, umlRequiredParameter.operation?.class_,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(pcmRequired.entityName == umlRequiredInstance.name)
 		assertTrue(pcmRequired.entityName == umlRequiredParameter.name)
@@ -55,7 +53,7 @@ class RequiredRoleConceptTest extends PcmUmlClassApplicationTest {
 		val umlRequiredInstance = helper.getModifiableCorr(pcmRequired, Property, TagLiterals.REQUIRED_ROLE__PROPERTY)
 		val umlRequiredParameter = helper.getModifiableCorr(pcmRequired, Parameter,
 			TagLiterals.REQUIRED_ROLE__PARAMETER)
-		checkRequiredRoleConcept(correspondenceModel, pcmRequired, umlRequiredInstance, umlRequiredParameter)
+		checkRequiredRoleConcept(pcmRequired, umlRequiredInstance, umlRequiredParameter)
 	}
 
 	def protected checkRequiredRoleConcept(Property umlRequiredInstance) {

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/SignatureConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/SignatureConceptTest.xtend
@@ -11,7 +11,6 @@ import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertNull
@@ -31,8 +30,7 @@ class SignatureConceptTest extends PcmUmlClassApplicationTest {
 
 	static val TEST_SIGNATURE_NAME = "testSignature"
 
-	def static void checkSignatureConcept(
-		CorrespondenceModel cm,
+	def void checkSignatureConcept(
 		OperationSignature pcmSignature,
 		Operation umlOperation
 	) {
@@ -42,28 +40,28 @@ class SignatureConceptTest extends PcmUmlClassApplicationTest {
 		assertNotNull(pcmSignature)
 		assertNotNull(umlOperation)
 		assertNotNull(returnParam)
-		assertTrue(corresponds(cm, pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION))
-		assertTrue(corresponds(cm, pcmSignature, returnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER))
+		assertTrue(corresponds(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION))
+		assertTrue(corresponds(pcmSignature, returnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER))
 		assertTrue(pcmSignature.entityName == umlOperation.name)
 		// the name needs to be set, so that its TUID is distinct and the object is not confused with new instances
 		assertTrue(returnParam.name == DefaultLiterals.RETURN_PARAM_NAME)
 		// return types of both model elements should correspond to each other if they are set
 		assertTrue(
-			isCorrect_DataType_Parameter_Correspondence(cm, pcmSignature.returnType__OperationSignature, returnParam))
+			isCorrect_DataType_Parameter_Correspondence(pcmSignature.returnType__OperationSignature, returnParam))
 		// should both be contained in corresponding interfaces
 		assertTrue(
-			corresponds(cm, pcmSignature.interface__OperationSignature, umlOperation.interface,
+			corresponds(pcmSignature.interface__OperationSignature, umlOperation.interface,
 				TagLiterals.INTERFACE_TO_INTERFACE))
 	}
 
 	def protected checkSignatureConcept(OperationSignature pcmSignature) {
 		val umlOperation = helper.getModifiableCorr(pcmSignature, Operation, TagLiterals.SIGNATURE__OPERATION)
-		checkSignatureConcept(correspondenceModel, pcmSignature, umlOperation)
+		checkSignatureConcept(pcmSignature, umlOperation)
 	}
 
 	def protected checkSignatureConcept(Operation umlOperation) {
 		val pcmSignature = helper.getModifiableCorr(umlOperation, OperationSignature, TagLiterals.SIGNATURE__OPERATION)
-		checkSignatureConcept(correspondenceModel, pcmSignature, umlOperation)
+		checkSignatureConcept(pcmSignature, umlOperation)
 	}
 
 	def private Repository createRepositoryWithInterface() {

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/SystemConceptTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/SystemConceptTest.xtend
@@ -9,7 +9,6 @@ import org.palladiosimulator.pcm.system.System
 import org.palladiosimulator.pcm.system.SystemFactory
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
@@ -35,8 +34,7 @@ class SystemConceptTest extends PcmUmlClassApplicationTest {
 	val MODEL_NAME = "testRootModel"
 	val SYSTEM_NAME = "TestSystem"
 
-	def protected static checkSystemConcept(
-		CorrespondenceModel cm,
+	def protected checkSystemConcept(
 		System pcmSystem,
 		Package umlSystemPkg,
 		Class umlSystemImpl,
@@ -46,8 +44,8 @@ class SystemConceptTest extends PcmUmlClassApplicationTest {
 		assertNotNull(umlSystemPkg)
 		assertNotNull(umlSystemImpl)
 		assertNotNull(umlSystemConstructor)
-		assertTrue(corresponds(cm, pcmSystem, umlSystemPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE))
-		assertTrue(corresponds(cm, pcmSystem, umlSystemImpl, TagLiterals.IPRE__IMPLEMENTATION))
+		assertTrue(corresponds(pcmSystem, umlSystemPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE))
+		assertTrue(corresponds(pcmSystem, umlSystemImpl, TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(pcmSystem.entityName.toFirstLower == umlSystemPkg.name)
 		assertTrue(pcmSystem.entityName == umlSystemPkg.name.toFirstUpper)
 		assertTrue(pcmSystem.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX == umlSystemImpl.name)
@@ -68,7 +66,7 @@ class SystemConceptTest extends PcmUmlClassApplicationTest {
 		val umlSystemPkg = helper.getModifiableCorr(pcmSystem, Package, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
 		val umlSystemImpl = helper.getModifiableCorr(pcmSystem, Class, TagLiterals.IPRE__IMPLEMENTATION)
 		val umlSystemConstructor = helper.getModifiableCorr(pcmSystem, Operation, TagLiterals.IPRE__CONSTRUCTOR)
-		checkSystemConcept(correspondenceModel, pcmSystem, umlSystemPkg, umlSystemImpl, umlSystemConstructor)
+		checkSystemConcept(pcmSystem, umlSystemPkg, umlSystemImpl, umlSystemConstructor)
 	}
 
 	@Test

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/AbstractPcmUmlTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/AbstractPcmUmlTest.xtend
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach
 import java.nio.file.Path
 import tools.vitruv.testutils.LegacyVitruvApplicationTest
 import tools.vitruv.applications.pcmumlcomponents.PcmToUmlComponentsChangePropagationSpecification
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 abstract class AbstractPcmUmlTest extends LegacyVitruvApplicationTest {
 	protected static val MODEL_FILE_EXTENSION = "repository"
@@ -52,8 +53,7 @@ abstract class AbstractPcmUmlTest extends LegacyVitruvApplicationTest {
 	}
 
 	protected def Model getUmlModel() {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[rootElement]).flatten
-		return (correspondingElements.get(0) as Model)
+		return getCorrespondingEObjects(rootElement, Model).claimOne()
 	}
 
 	@BeforeEach
@@ -87,7 +87,7 @@ abstract class AbstractPcmUmlTest extends LegacyVitruvApplicationTest {
 	}
 
 	protected def Iterable<EObject> correspondingElements(EObject element) {
-		return correspondenceModel.getCorrespondingEObjects(#[element]).flatten
+		return getCorrespondingEObjects(element, EObject)
 	}
 
 }

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/ComponentsTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/ComponentsTest.xtend
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class ComponentsTest extends AbstractPcmUmlTest {
 	static val COMPONENT_NAME = "TestComponent"
@@ -38,13 +39,11 @@ class ComponentsTest extends AbstractPcmUmlTest {
 	}
 
 	protected def Interface getCorrespondingUmlInterface(OperationInterface pcmInterface) {
-		val correspondingInterfaceElements = correspondenceModel.getCorrespondingEObjects(#[pcmInterface]).flatten
-		correspondingInterfaceElements.get(0) as Interface
+		return getCorrespondingEObjects(pcmInterface, Interface).claimOne
 	}
 
 	protected def Component getCorrespondingUmlComponent(RepositoryComponent pcmComponent) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmComponent]).flatten
-		correspondingElements.get(0) as Component
+		return getCorrespondingEObjects(pcmComponent, Component).claimOne
 	}
 
 	@Test
@@ -53,7 +52,7 @@ class ComponentsTest extends AbstractPcmUmlTest {
 		pcmComponent.entityName = COMPONENT_NAME
 		rootElement.components__Repository += pcmComponent
 		propagate
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmComponent]).flatten
+		val correspondingElements = pcmComponent.correspondingElements
 		assertEquals(1, correspondingElements.size)
 		val umlComponent = correspondingElements.get(0)
 		assertTrue(umlComponent instanceof Component)
@@ -71,7 +70,7 @@ class ComponentsTest extends AbstractPcmUmlTest {
 		pcmComponent.requiredRoles_InterfaceRequiringEntity += requiredRole
 		propagate
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[requiredRole]).flatten
+		val correspondingElements = requiredRole.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof Usage)
 		val umlUsage = (correspondingElements.get(0) as Usage)
@@ -101,7 +100,7 @@ class ComponentsTest extends AbstractPcmUmlTest {
 		requiredRole.requiredInterface__OperationRequiredRole = pcmInterface2
 		propagate
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[requiredRole]).flatten
+		val correspondingElements = requiredRole.correspondingElements
 		val umlUsage = (correspondingElements.get(0) as Usage)
 		val umlInterface = getCorrespondingUmlInterface(pcmInterface2)
 		assertEquals(umlInterface, umlUsage.suppliers.get(0))
@@ -135,7 +134,7 @@ class ComponentsTest extends AbstractPcmUmlTest {
 		pcmComponent.providedRoles_InterfaceProvidingEntity += providedRole
 		propagate
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[providedRole]).flatten
+		val correspondingElements = providedRole.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof InterfaceRealization)
 		val umlInterfaceRealization = (correspondingElements.get(0) as InterfaceRealization)

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/DataTypesTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/DataTypesTest.xtend
@@ -34,7 +34,7 @@ class DataTypesTest extends AbstractPcmUmlTest {
 	@Test
 	def void testPrimitiveDataTypeCreate() {
 		val pcmDataType = createPrimitiveDataType()
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmDataType]).flatten
+		val correspondingElements = pcmDataType.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		val umlModel = getUmlModel()
 		val umlType = umlModel.getOwnedType(PcmToUmlUtil.getUmlPrimitiveTypeName(pcmDataType.type))
@@ -71,7 +71,7 @@ class DataTypesTest extends AbstractPcmUmlTest {
 	@Test
 	def void testCompositeDataTypeCreate() {
 		val pcmDataType = createCompositeDataType(DATATYPE_NAME)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmDataType]).flatten
+		val correspondingElements = pcmDataType.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		val umlModel = getUmlModel()
 		val umlType = umlModel.getOwnedType(pcmDataType.entityName)
@@ -82,7 +82,7 @@ class DataTypesTest extends AbstractPcmUmlTest {
 	def void testCompositeDataTypeDeclarationAdd() {
 		val attributeName = ATTRIBUTE_NAME
 		val pcmDataType = initCompositeDataTypeDeclaration(DATATYPE_NAME, attributeName)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmDataType]).flatten
+		val correspondingElements = pcmDataType.correspondingElements
 		val umlType = (correspondingElements.get(0) as DataType)
 		assertEquals(1, umlType.ownedAttributes.length)
 		assertEquals(attributeName, umlType.ownedAttributes.get(0).name)
@@ -94,7 +94,7 @@ class DataTypesTest extends AbstractPcmUmlTest {
 	def void testCompositeDataTypeDeclarationEdit() {
 		val attributeName = ATTRIBUTE_NAME
 		val pcmDataType = initCompositeDataTypeDeclaration(DATATYPE_NAME, ATTRIBUTE_NAME + "2")
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmDataType]).flatten
+		val correspondingElements = pcmDataType.correspondingElements
 		val declaration = pcmDataType.innerDeclaration_CompositeDataType.get(0)
 		declaration.entityName = attributeName
 		pcmDataType.innerDeclaration_CompositeDataType.set(0, declaration)
@@ -116,7 +116,7 @@ class DataTypesTest extends AbstractPcmUmlTest {
 		declaration.datatype_InnerDeclaration = innerType
 		pcmDataType.innerDeclaration_CompositeDataType += declaration
 		propagate
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmDataType]).flatten
+		val correspondingElements = pcmDataType.correspondingElements
 		val umlType = (correspondingElements.get(0) as DataType)
 		assertEquals(2, umlType.ownedAttributes.length, "Type should be initialized with two properties")
 		val removedDeclaration = pcmDataType.innerDeclaration_CompositeDataType.remove(0)

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/InterfacesTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/InterfacesTest.xtend
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
 import tools.vitruv.applications.pcmumlcomponents.pcm2uml.PcmToUmlUtil
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class InterfacesTest extends AbstractPcmUmlTest {
 
@@ -51,7 +52,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 	def void testInterfaceCreation() {
 		val interfaceName = INTERFACE_NAME
 		val pcmInterface = createOperationInterface(interfaceName)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmInterface]).flatten
+		val correspondingElements = pcmInterface.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof Interface)
 		val umlInterface = (correspondingElements.get(0) as Interface)
@@ -67,9 +68,9 @@ class InterfacesTest extends AbstractPcmUmlTest {
 		propagate
 		val operationName = OPERATION_NAME
 		val pcmOperation = createOperationInterfaceOperation(pcmInterface, operationName, returnType)
-		val correspondingInterface = correspondenceModel.getCorrespondingEObjects(#[pcmInterface]).flatten
+		val correspondingInterface = pcmInterface.correspondingElements
 		assertEquals(1, (correspondingInterface.get(0) as Interface).ownedOperations.length)
-		val correspondingOperation = correspondenceModel.getCorrespondingEObjects(#[pcmOperation]).flatten
+		val correspondingOperation = pcmOperation.correspondingElements
 		assertEquals(1, correspondingOperation.length)
 		val umlOperation = (correspondingOperation.get(0) as Operation)
 		assertEquals(operationName, umlOperation.name)
@@ -85,7 +86,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 		rootElement.dataTypes__Repository += newReturnType
 		pcmOperation.returnType__OperationSignature = newReturnType
 		propagate
-		var correspondingOperation = correspondenceModel.getCorrespondingEObjects(#[pcmOperation]).flatten
+		var correspondingOperation = pcmOperation.correspondingElements
 		var umlOperation = (correspondingOperation.get(0) as Operation)
 		assertEquals(PcmToUmlUtil.getUmlPrimitiveTypeName(newReturnType.type), umlOperation.type.name)
 
@@ -96,7 +97,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 
 		pcmOperation.returnType__OperationSignature = null
 		propagate
-		correspondingOperation = correspondenceModel.getCorrespondingEObjects(#[pcmOperation]).flatten
+		correspondingOperation = pcmOperation.correspondingElements
 		umlOperation = (correspondingOperation.get(0) as Operation)
 		assertEquals(null, umlOperation.type)
 	}
@@ -106,7 +107,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 		val pcmInterface = createOperationInterface(INTERFACE_NAME)
 		val pcmOperation1 = createOperationInterfaceOperation(pcmInterface, OPERATION_NAME, PrimitiveTypeEnum.INT)
 		val pcmOperation2 = createOperationInterfaceOperation(pcmInterface, OPERATION_NAME_2, PrimitiveTypeEnum.DOUBLE)
-		val correspondingInterface = correspondenceModel.getCorrespondingEObjects(#[pcmInterface]).flatten
+		val correspondingInterface = pcmInterface.correspondingElements
 		val umlInterface = (correspondingInterface.get(0) as Interface)
 		assertEquals(2, umlInterface.ownedOperations.length)
 		pcmInterface.signatures__OperationInterface -= pcmOperation1
@@ -118,9 +119,9 @@ class InterfacesTest extends AbstractPcmUmlTest {
 	@Test
 	def void testInterfaceRemove() {
 		val pcmInterface = createOperationInterface(INTERFACE_NAME)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmInterface]).flatten
+		val correspondingElements = pcmInterface.correspondingElements
 		assertEquals(1, correspondingElements.length)
-		val umlModel = (correspondenceModel.getCorrespondingEObjects(#[rootElement]).flatten.get(0) as Model)
+		val umlModel = getCorrespondingEObjects(rootElement, Model).claimOne
 		val elementCount = umlModel.packagedElements.length
 		rootElement.interfaces__Repository -= pcmInterface
 		propagate
@@ -144,7 +145,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 		createOperationParameter(pcmOperation, parameterName, pcmOperation.returnType__OperationSignature)
 		val parameterType = pcmOperation.returnType__OperationSignature
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmOperation]).flatten
+		val correspondingElements = pcmOperation.correspondingElements
 		val umlOperation = (correspondingElements.get(0) as Operation)
 		assertEquals(2, umlOperation.ownedParameters.length)
 		// first parameter should be the return value
@@ -162,8 +163,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 		val pcmParameter = createOperationParameter(pcmOperation, PARAMETER_NAME,
 			pcmOperation.returnType__OperationSignature)
 
-		var correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmParameter]).flatten
-		var umlParameter = (correspondingElements.get(0) as org.eclipse.uml2.uml.Parameter)
+		var umlParameter = getCorrespondingEObjects(pcmParameter, org.eclipse.uml2.uml.Parameter).claimOne
 
 		val newType = RepositoryFactory.eINSTANCE.createPrimitiveDataType()
 		newType.type = PrimitiveTypeEnum.DOUBLE
@@ -171,8 +171,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 		pcmParameter.dataType__Parameter = newType
 		propagate
 
-		correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmParameter]).flatten
-		umlParameter = (correspondingElements.get(0) as org.eclipse.uml2.uml.Parameter)
+		umlParameter = getCorrespondingEObjects(pcmParameter, org.eclipse.uml2.uml.Parameter).claimOne
 
 		assertEquals(PcmToUmlUtil.getUmlPrimitiveTypeName(newType.type), umlParameter.type.name)
 
@@ -184,8 +183,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 		pcmParameter.modifier__Parameter = ParameterModifier.OUT
 		propagate
 
-		correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmParameter]).flatten
-		umlParameter = (correspondingElements.get(0) as org.eclipse.uml2.uml.Parameter)
+		umlParameter = getCorrespondingEObjects(pcmParameter, org.eclipse.uml2.uml.Parameter).claimOne
 
 		assertEquals(PcmToUmlUtil.getUmlParameterDirection(pcmParameter.modifier__Parameter), umlParameter.direction)
 	}
@@ -199,8 +197,7 @@ class InterfacesTest extends AbstractPcmUmlTest {
 		val remainingParameterName = PARAMETER_NAME_2
 		createOperationParameter(pcmOperation, remainingParameterName, pcmOperation.returnType__OperationSignature)
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[pcmOperation]).flatten
-		val umlOperation = (correspondingElements.get(0) as Operation)
+		val umlOperation = getCorrespondingEObjects(pcmOperation, Operation).claimOne
 		assertEquals(3, umlOperation.ownedParameters.length)
 
 		val parameterCount = umlOperation.ownedParameters.length

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/UmlModelTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/UmlModelTest.xtend
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.testutils.matchers.ModelMatchers.isResource
 import java.nio.file.Path
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class UmlModelTest extends AbstractPcmUmlTest {
 
@@ -16,7 +17,7 @@ class UmlModelTest extends AbstractPcmUmlTest {
 	def void testModelCreation() {
 		val modelUri = getUri(Path.of("model").resolve(MODEL_NAME + ".uml"))
 		assertThat(modelUri, isResource)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[rootElement]).flatten
+		val correspondingElements = rootElement.correspondingElements
 		assertEquals(1, correspondingElements.size)
 		val umlModel = correspondingElements.get(0)
 		assertTrue(umlModel instanceof Model)
@@ -28,7 +29,7 @@ class UmlModelTest extends AbstractPcmUmlTest {
 		val newName = 'foo'
 		rootElement.entityName = newName
 		propagate
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[rootElement]).flatten
-		assertEquals(newName, (correspondingElements.get(0) as Model).name)
+		val model = getCorrespondingEObjects(rootElement, Model).claimOne
+		assertEquals(newName, model.name)
 	}
 }

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/AbstractUmlPcmTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/AbstractUmlPcmTest.xtend
@@ -83,7 +83,7 @@ abstract class AbstractUmlPcmTest extends LegacyVitruvApplicationTest {
 	}
 
 	protected def Iterable<EObject> correspondingElements(EObject element) {
-		return correspondenceModel.getCorrespondingEObjects(#[element]).flatten
+		return getCorrespondingEObjects(element, EObject)
 	}
 
 	protected def <T> EList<T> toEList(List<T> elements) {

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/ComponentsTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/ComponentsTest.xtend
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class ComponentsTest extends AbstractUmlPcmTest {
 
@@ -42,24 +43,21 @@ class ComponentsTest extends AbstractUmlPcmTest {
 	}
 
 	protected def CompositeComponent getCorrespondingCompositeComponent(Component umlComponent) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlComponent]).flatten
-		return (correspondingElements.get(0) as CompositeComponent)
+		getCorrespondingEObjects(umlComponent, CompositeComponent).claimOne
 	}
 
 	protected def BasicComponent getCorrespondingBasicComponent(Component umlComponent) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlComponent]).flatten
-		return (correspondingElements.get(0) as BasicComponent)
+		getCorrespondingEObjects(umlComponent, BasicComponent).claimOne
 	}
 
 	protected def OperationInterface getCorrespondingInterface(Interface umlInterface) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlInterface]).flatten
-		return (correspondingElements.get(0) as OperationInterface)
+		getCorrespondingEObjects(umlInterface, OperationInterface).claimOne
 	}
 
 	@Test
 	def void testCreateBasicComponent() {
 		val umlComponent = createUmlComponent(COMPONENT_NAME)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlComponent]).flatten
+		val correspondingElements = umlComponent.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof BasicComponent)
 		val pcmComponent = getCorrespondingBasicComponent(umlComponent)
@@ -186,7 +184,7 @@ class ComponentsTest extends AbstractUmlPcmTest {
 	@Test
 	def void testCreateCompositeComponent() {
 		val umlComponent = createUmlComponent(COMPONENT_NAME, true)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlComponent]).flatten
+		val correspondingElements = umlComponent.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof CompositeComponent)
 		val pcmComponent = getCorrespondingCompositeComponent(umlComponent)

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/DataTypesTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/DataTypesTest.xtend
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
 import tools.vitruv.applications.pcmumlcomponents.uml2pcm.UmlToPcmUtil
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class DataTypesTest extends AbstractUmlPcmTest {
 
@@ -23,7 +24,7 @@ class DataTypesTest extends AbstractUmlPcmTest {
 		primitiveType.name = UML_TYPE_BOOL
 		rootElement.packagedElements += primitiveType
 		propagate
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[primitiveType]).flatten
+		val correspondingElements = primitiveType.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		val pcmType = correspondingElements.get(0)
 		assertTrue(pcmType instanceof PrimitiveDataType)
@@ -40,7 +41,7 @@ class DataTypesTest extends AbstractUmlPcmTest {
 		userInteraction.addNextSingleSelection(1)
 		propagate
 		assertEquals(nrOwnedTypesBefore + 1, rootElement.ownedTypes.length)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[dataType]).flatten
+		val correspondingElements = dataType.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		val pcmType = correspondingElements.get(0)
 		assertTrue(pcmType instanceof CompositeDataType)
@@ -61,8 +62,7 @@ class DataTypesTest extends AbstractUmlPcmTest {
 		property.type = propertyType
 		dataType.ownedAttributes += property
 		propagate
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[dataType]).flatten
-		val pcmType = (correspondingElements.get(0) as CompositeDataType)
+		val pcmType = getCorrespondingEObjects(dataType, CompositeDataType).claimOne
 		assertEquals(1, pcmType.innerDeclaration_CompositeDataType.length)
 		assertEquals(propertyName, pcmType.innerDeclaration_CompositeDataType.get(0).entityName)
 		assertEquals(UmlToPcmUtil.getPcmPrimitiveType(propertyType.name),
@@ -91,8 +91,7 @@ class DataTypesTest extends AbstractUmlPcmTest {
 	}
 
 	protected def org.palladiosimulator.pcm.repository.DataType getCorrespondingDataType(DataType umlType) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlType]).flatten
-		return correspondingElements.get(0) as org.palladiosimulator.pcm.repository.DataType
+		return getCorrespondingEObjects(umlType, org.palladiosimulator.pcm.repository.DataType).claimOne
 	}
 
 	@Test

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/ImportedDataTypesTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/ImportedDataTypesTest.xtend
@@ -1,7 +1,6 @@
 package tools.vitruv.applications.pcmumlcomponents.tests.uml2pcm
 
 import org.eclipse.emf.common.util.BasicEList
-import org.eclipse.uml2.uml.DataType
 import org.eclipse.uml2.uml.PrimitiveType
 import org.eclipse.uml2.uml.Type
 import org.eclipse.uml2.uml.UMLFactory
@@ -11,32 +10,14 @@ import org.palladiosimulator.pcm.repository.PrimitiveDataType
 import org.palladiosimulator.pcm.repository.PrimitiveTypeEnum
 import org.junit.jupiter.api.Test
 
-import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
-import tools.vitruv.applications.pcmumlcomponents.uml2pcm.UmlToPcmTypesUtil
 import tools.vitruv.applications.pcmumlcomponents.uml2pcm.UmlToPcmUtil
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class ImportedDataTypesTest extends AbstractUmlPcmTest {
 
 	protected val UMLTYPE_BOOL = "Boolean"
-
-	/**
-	 * Cannot modify resource set without a write transaction
-	 */
-	// @Test
-	def void importedTypesExistTest() {
-		val umlTypes = importPrimitiveTypes()
-		assertNotNull(umlTypes.getOwnedMember(UMLTYPE_BOOL))
-		val umlType = umlTypes.getOwnedMember(UMLTYPE_BOOL) as DataType
-		val pcmRepository = rootElement.claimCorrespondingRepository
-		propagate
-		val pcmType = UmlToPcmTypesUtil.retrieveCorrespondingPcmType(umlType, pcmRepository, false, null,
-			correspondenceModel)
-		assertNotNull(pcmType)
-		assertTrue(pcmType instanceof PrimitiveDataType)
-		assertEquals(PrimitiveTypeEnum.BOOL, (pcmType as PrimitiveDataType).type)
-	}
 
 	@Test
 	def void unmappedPrimitiveTypeTest() {
@@ -47,9 +28,7 @@ class ImportedDataTypesTest extends AbstractUmlPcmTest {
 		userInteraction.addNextSingleSelection(PrimitiveTypeEnum.BYTE_VALUE)
 		rootElement.packagedElements += umlType
 		propagate
-		val pcmRepository = rootElement.claimCorrespondingRepository
-		val pcmType = UmlToPcmTypesUtil.retrieveCorrespondingPcmType(umlType, pcmRepository, false, null,
-			correspondenceModel) as PrimitiveDataType
+		val pcmType = getCorrespondingEObjects(umlType, PrimitiveDataType).claimOne
 		assertEquals(PrimitiveTypeEnum.BYTE, pcmType.type)
 	}
 
@@ -75,8 +54,7 @@ class ImportedDataTypesTest extends AbstractUmlPcmTest {
 		umlInterface.createOwnedOperation(OPERATION_NAME, new BasicEList<String>(), new BasicEList<Type>(), umlType)
 		rootElement.packagedElements += umlInterface
 		propagate
-		val pcmInterface = correspondenceModel.getCorrespondingEObjects(#[umlInterface]).flatten.
-			head as OperationInterface
+		val pcmInterface = getCorrespondingEObjects(umlInterface, OperationInterface).claimOne
 		assertEquals(UmlToPcmUtil.getPcmPrimitiveType(UMLTYPE_BOOL),
 			(pcmInterface.signatures__OperationInterface.head.returnType__OperationSignature as PrimitiveDataType).type)
 	}

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/InterfacesTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/InterfacesTest.xtend
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
 import tools.vitruv.applications.pcmumlcomponents.uml2pcm.UmlToPcmUtil
+import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
 
 class InterfacesTest extends AbstractUmlPcmTest {
 
@@ -33,7 +34,7 @@ class InterfacesTest extends AbstractUmlPcmTest {
 	def void createInterfaceTest() {
 		val interfaceName = INTERFACE_NAME
 		val umlInterface = createUmlInterface(interfaceName)
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlInterface]).flatten
+		val correspondingElements = umlInterface.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof OperationInterface)
 		val pcmInterface = (correspondingElements.get(0) as OperationInterface)
@@ -60,7 +61,7 @@ class InterfacesTest extends AbstractUmlPcmTest {
 		val umlOperation = umlInterface.createOwnedOperation(OPERATION_NAME, parameterNames, parameterTypes, returnType)
 		propagate
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlOperation]).flatten
+		val correspondingElements = umlOperation.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof OperationSignature)
 		val pcmOperation = (correspondingElements.get(0) as OperationSignature)
@@ -90,8 +91,7 @@ class InterfacesTest extends AbstractUmlPcmTest {
 	def void changeInterfaceOperationTest() {
 		val umlInterface = createUmlInterface(INTERFACE_NAME)
 		val umlOperation = createInterfaceOperation(umlInterface, OPERATION_NAME, UML_TYPE_BOOL)
-		var correspondingSignatures = correspondenceModel.getCorrespondingEObjects(#[umlOperation]).flatten
-		var pcmSignature = (correspondingSignatures.get(0) as OperationSignature)
+		var pcmSignature = getCorrespondingEObjects(umlOperation, OperationSignature).claimOne
 		umlOperation.name = OPERATION_NAME + "2"
 		propagate
 		assertEquals(umlOperation.name, pcmSignature.entityName)
@@ -101,15 +101,13 @@ class InterfacesTest extends AbstractUmlPcmTest {
 		umlOperation.type = newType
 		propagate
 
-		correspondingSignatures = correspondenceModel.getCorrespondingEObjects(#[umlOperation]).flatten
-		pcmSignature = (correspondingSignatures.get(0) as OperationSignature)
+		pcmSignature = getCorrespondingEObjects(umlOperation, OperationSignature).claimOne
 		assertEquals(UmlToPcmUtil.getPcmPrimitiveType(newType.name),
 			(pcmSignature.returnType__OperationSignature as PrimitiveDataType).type)
 
 		umlOperation.type = null
 		propagate
-		correspondingSignatures = correspondenceModel.getCorrespondingEObjects(#[umlOperation]).flatten
-		pcmSignature = (correspondingSignatures.get(0) as OperationSignature)
+		pcmSignature = getCorrespondingEObjects(umlOperation, OperationSignature).claimOne
 		assertNull(pcmSignature.returnType__OperationSignature)
 	}
 
@@ -134,7 +132,7 @@ class InterfacesTest extends AbstractUmlPcmTest {
 		val pcmSignature = getCorrespondingSignature(umlOperation)
 		assertEquals(1, pcmSignature.parameters__OperationSignature.length)
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlParameter]).flatten
+		val correspondingElements = umlParameter.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof org.palladiosimulator.pcm.repository.Parameter)
 		val pcmParameter = (correspondingElements.get(0) as org.palladiosimulator.pcm.repository.Parameter)
@@ -146,13 +144,11 @@ class InterfacesTest extends AbstractUmlPcmTest {
 	}
 
 	protected def OperationSignature getCorrespondingSignature(Operation operation) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[operation]).flatten
-		return (correspondingElements.get(0) as OperationSignature)
+		return getCorrespondingEObjects(operation, OperationSignature).claimOne
 	}
 
 	protected def org.palladiosimulator.pcm.repository.Parameter getCorrespondingParameter(Parameter umlParameter) {
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlParameter]).flatten
-		return (correspondingElements.get(0) as org.palladiosimulator.pcm.repository.Parameter)
+		return getCorrespondingEObjects(umlParameter, org.palladiosimulator.pcm.repository.Parameter).claimOne
 	}
 
 	@Test
@@ -161,7 +157,7 @@ class InterfacesTest extends AbstractUmlPcmTest {
 		val umlOperation = createInterfaceOperation(umlInterface, OPERATION_NAME, UML_TYPE_BOOL)
 		val umlParameter = createParameter(umlOperation, PARAMETER_NAME, UML_TYPE_INT)
 
-		val correspondingElements = correspondenceModel.getCorrespondingEObjects(#[umlParameter]).flatten
+		val correspondingElements = umlParameter.correspondingElements
 		assertEquals(1, correspondingElements.length)
 		assertTrue(correspondingElements.get(0) instanceof org.palladiosimulator.pcm.repository.Parameter)
 		var pcmParameter = (correspondingElements.get(0) as org.palladiosimulator.pcm.repository.Parameter)

--- a/tests/tools.vitruv.applications.transitivechange.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.transitivechange.tests/META-INF/MANIFEST.MF
@@ -12,9 +12,10 @@ Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.applications.pcmumlclass,
  tools.vitruv.applications.pcmumlclass.tests,
  tools.vitruv.applications.pcmjava.pojotransformations,
- tools.vitruv.extensions.dslsruntime.reactions,
  org.hamcrest.core,
- edu.kit.ipd.sdq.activextendannotations
+ edu.kit.ipd.sdq.activextendannotations,
+ org.apache.log4j,
+ org.eclipse.xtend.lib
 Export-Package: tools.vitruv.applications.transitivechange.tests.circular.pcmumlclassjava,
  tools.vitruv.applications.transitivechange.tests.linear.pcmumlclassjava,
  tools.vitruv.applications.transitivechange.tests.linear.java2uml,

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/AssemblyContextConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/AssemblyContextConceptTest.xtend
@@ -7,7 +7,6 @@ import org.palladiosimulator.pcm.core.composition.CompositionFactory
 import org.palladiosimulator.pcm.repository.Repository
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -23,20 +22,19 @@ class AssemblyContextConceptTest extends PcmUmlJavaTransitiveChangeTest {
 
 	static val PROPERTY_NAME = "testAssemblyContextField"
 
-	def static void checkAssemblyContextConcept(
-		CorrespondenceModel cm,
+	def void checkAssemblyContextConcept(
 		AssemblyContext pcmAssemblyContext,
 		Property umlAssemblyContextProperty
 	) {
 		assertNotNull(pcmAssemblyContext)
 		assertNotNull(umlAssemblyContextProperty)
 		assertTrue(
-			corresponds(cm, pcmAssemblyContext, umlAssemblyContextProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY))
+			corresponds(pcmAssemblyContext, umlAssemblyContextProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY))
 		assertTrue(
-			corresponds(cm, pcmAssemblyContext.parentStructure__AssemblyContext, umlAssemblyContextProperty.owner,
+			corresponds(pcmAssemblyContext.parentStructure__AssemblyContext, umlAssemblyContextProperty.owner,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(
-			corresponds(cm, pcmAssemblyContext.encapsulatedComponent__AssemblyContext, umlAssemblyContextProperty.type,
+			corresponds(pcmAssemblyContext.encapsulatedComponent__AssemblyContext, umlAssemblyContextProperty.type,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(pcmAssemblyContext.entityName == umlAssemblyContextProperty.name)
 	}
@@ -44,14 +42,14 @@ class AssemblyContextConceptTest extends PcmUmlJavaTransitiveChangeTest {
 	def protected checkAssemblyContextConcept(AssemblyContext pcmAssemblyContext) {
 		val umlAssemblyContextProperty = helper.getModifiableCorr(pcmAssemblyContext, Property,
 			TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
-		checkAssemblyContextConcept(correspondenceModel, pcmAssemblyContext, umlAssemblyContextProperty)
+		checkAssemblyContextConcept(pcmAssemblyContext, umlAssemblyContextProperty)
 		checkJavaAssemblyContextConcept(umlAssemblyContextProperty, pcmAssemblyContext)
 	}
 
 	def protected checkAssemblyContextConcept(Property umlAssemblyContextProperty) {
 		val pcmAssemblyContext = helper.getModifiableCorr(umlAssemblyContextProperty, AssemblyContext,
 			TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
-		checkAssemblyContextConcept(correspondenceModel, pcmAssemblyContext, umlAssemblyContextProperty)
+		checkAssemblyContextConcept(pcmAssemblyContext, umlAssemblyContextProperty)
 		checkJavaAssemblyContextConcept(umlAssemblyContextProperty, pcmAssemblyContext)
 	}
 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/CompositeDataTypeConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/CompositeDataTypeConceptTest.xtend
@@ -9,8 +9,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.Java2PcmUserSelection
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -31,20 +29,19 @@ class CompositeDataTypeConceptTest extends PcmUmlJavaTransitiveChangeTest {
 	static val TEST_COMPOSITE_DATATYPE = "TestCompositeType"
 	static val TEST_COMPOSITE_DATATYPE_PARENT = "TestCompositeTypeParent"
 
-	def static checkCompositeDataTypeConcept(
-		CorrespondenceModel cm,
+	def checkCompositeDataTypeConcept(
 		CompositeDataType pcmCompositeType,
 		Class umlClass
 	) {
-		assertTrue(corresponds(cm, pcmCompositeType, umlClass))
+		assertTrue(corresponds(pcmCompositeType, umlClass))
 		assertTrue(pcmCompositeType.entityName == umlClass.name)
 		// Repository should correspond to the datatypes package
 		assertTrue(
-			corresponds(cm, pcmCompositeType.repository__DataType, umlClass.package,
+			corresponds(pcmCompositeType.repository__DataType, umlClass.package,
 				TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
 		// check that parent compositedatatypes and parent classes correspond
 		val umlParentCorrespondences = pcmCompositeType.parentType_CompositeDataType.map [ pcmParent |
-			CorrespondenceModelUtil.getCorrespondingEObjectsByType(cm, pcmParent, Class).head
+			getCorrespondingEObjects(pcmParent, Class).head
 		].toList
 		assertFalse(umlParentCorrespondences.contains(null))
 		assertFalse(
@@ -56,13 +53,13 @@ class CompositeDataTypeConceptTest extends PcmUmlJavaTransitiveChangeTest {
 
 	def protected checkCompositeDataTypeConcept(CompositeDataType pcmCompositeType) {
 		val umlClass = helper.getCorr(pcmCompositeType, Class, TagLiterals.COMPOSITE_DATATYPE__CLASS)
-		checkCompositeDataTypeConcept(correspondenceModel, pcmCompositeType, umlClass)
+		checkCompositeDataTypeConcept(pcmCompositeType, umlClass)
 	}
 
 	def protected checkCompositeDataTypeConcept(Class umlClass) {
 		val pcmCompositeType = helper.getCorr(umlClass, CompositeDataType,
 			TagLiterals.COMPOSITE_DATATYPE__CLASS)
-		checkCompositeDataTypeConcept(correspondenceModel, pcmCompositeType, umlClass)
+		checkCompositeDataTypeConcept(pcmCompositeType, umlClass)
 	}
 
 	def protected checkJavaCompositeDataTypeConcept(Class umlClass, CompositeDataType pcmCompositeType) {

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/InterfaceConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/InterfaceConceptTest.xtend
@@ -8,8 +8,6 @@ import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -26,22 +24,21 @@ class InterfaceConceptTest extends PcmUmlJavaTransitiveChangeTest {
 
 	static val TEST_INTERFACE_NAME = "TestInterface"
 
-	def static checkInterfaceConcept(
-		CorrespondenceModel cm,
+	def checkInterfaceConcept(
 		OperationInterface pcmInterface,
 		Interface umlInterface
 	) {
 		assertNotNull(pcmInterface)
 		assertNotNull(umlInterface)
-		assertTrue(corresponds(cm, pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE))
+		assertTrue(corresponds(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE))
 		assertTrue(pcmInterface.entityName == umlInterface.name)
 		// should be contained in corresponding repository and contracts package respectively
 		assertTrue(
-			corresponds(cm, pcmInterface.repository__Interface, umlInterface.package,
+			corresponds(pcmInterface.repository__Interface, umlInterface.package,
 				TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
 		// parent interfaces should correspond
 		val umlParentCorrespondences = pcmInterface.parentInterfaces__Interface.map [ pcmParent |
-			CorrespondenceModelUtil.getCorrespondingEObjectsByType(cm, pcmParent, Interface).head
+			getCorrespondingEObjects(pcmParent, Interface).head
 		].toList
 		assertFalse(umlParentCorrespondences.contains(null))
 		assertFalse(
@@ -55,14 +52,14 @@ class InterfaceConceptTest extends PcmUmlJavaTransitiveChangeTest {
 
 	def protected checkInterfaceConcept(OperationInterface pcmInterface) {
 		val umlInterface = helper.getCorr(pcmInterface, Interface, TagLiterals.INTERFACE_TO_INTERFACE)
-		checkInterfaceConcept(correspondenceModel, pcmInterface, umlInterface)
+		checkInterfaceConcept(pcmInterface, umlInterface)
 		checkJavaInterfaceConcept(umlInterface, pcmInterface)
 	}
 
 	def protected checkInterfaceConcept(Interface umlInterface) {
 		val pcmInterface = helper.getCorr(umlInterface, OperationInterface,
 			TagLiterals.INTERFACE_TO_INTERFACE)
-		checkInterfaceConcept(correspondenceModel, pcmInterface, umlInterface)
+		checkInterfaceConcept(pcmInterface, umlInterface)
 		checkJavaInterfaceConcept(umlInterface, pcmInterface)
 	}
 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/PcmUmlJavaTransitiveChangeTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/PcmUmlJavaTransitiveChangeTest.xtend
@@ -3,7 +3,6 @@ package tools.vitruv.applications.transitivechange.tests.circular.pcmumlclassjav
 import java.util.ArrayList
 import java.util.Collection
 import java.util.List
-import java.util.Set
 import org.apache.log4j.Logger
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.uml2.uml.Classifier
@@ -38,6 +37,7 @@ import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static extension tools.vitruv.applications.transitivechange.tests.util.TransitiveChangeSetup.*
+import org.emftext.language.java.containers.ContainersPackage
 
 /** 
  * Transitive change test class for networks of UML, Java and PCM models.
@@ -83,7 +83,7 @@ abstract class PcmUmlJavaTransitiveChangeTest extends PcmUmlClassApplicationTest
 	}
 
 	def protected checkNumberOfJavaPackages(Package umlRootPackage) {
-		val allJavaPackages = typeof(org.emftext.language.java.containers.Package).getCorrespondingObjectsOfClass
+		val allJavaPackages = getCorrespondingEObjects(ContainersPackage.Literals.PACKAGE, org.emftext.language.java.containers.Package)
 		var umlPackagesCount = umlRootPackage.countPackages
 		if(umlRootPackage instanceof Model) umlPackagesCount -= 1 // do not count the model
 		assertEquals(allJavaPackages.size, umlPackagesCount)
@@ -166,7 +166,7 @@ abstract class PcmUmlJavaTransitiveChangeTest extends PcmUmlClassApplicationTest
 		if (obj === null) {
 			throw new IllegalArgumentException("Cannot retrieve correspondence for null")
 		}
-		val correspondingObjectList = getCorrespondenceModel.getCorrespondingEObjects(#[obj]).flatten.filter(c)
+		val correspondingObjectList = getCorrespondingEObjects(obj, c)
 		if (correspondingObjectList.nullOrEmpty) {
 			logger.warn("There are no corresponding objects for " + obj + " of the type " + c.class +
 				". Returning null.")
@@ -176,17 +176,6 @@ abstract class PcmUmlJavaTransitiveChangeTest extends PcmUmlClassApplicationTest
 				". Returning the first.")
 		}
 		return correspondingObjectList.head
-	}
-
-	/** Retrieves all corresponding objects of the type defined by class c
-	 * 
-	 * {@link tools.vitruv.framework.tests.VitruviusUnmonitoredApplicationTest#getCorrespondenceModel}
-	 * @param obj the object for which the corresponding objects should be retrieved
-	 * @return the corresponding objects of obj filtered by c or null if none could be found
-	 * @throws IllegalArgumentException if obj is null
-	 */
-	def protected <E> Set<E> getCorrespondingObjectsOfClass(java.lang.Class<E> clazz) {
-		return getCorrespondenceModel.getAllEObjectsOfTypeInCorrespondences(clazz)
 	}
 
 	/**

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/ProvidedRoleTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/ProvidedRoleTest.xtend
@@ -7,7 +7,6 @@ import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -23,36 +22,35 @@ class ProvidedRoleTest extends PcmUmlJavaTransitiveChangeTest {
 
 	static val PROVIDED_ROLE_NAME = "testProvidedRole"
 
-	def static void checkProvidedRoleConcept(
-		CorrespondenceModel cm,
+	def void checkProvidedRoleConcept(
 		OperationProvidedRole pcmProvided,
 		InterfaceRealization umlRealization
 	) {
 		assertNotNull(pcmProvided)
 		assertNotNull(umlRealization)
-		assertTrue(corresponds(cm, pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION))
+		assertTrue(corresponds(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION))
 		assertTrue(pcmProvided.entityName == umlRealization.name)
 		// the respective type references have to correspond
 		assertTrue(
-			corresponds(cm, pcmProvided.providedInterface__OperationProvidedRole, umlRealization.contract,
+			corresponds(pcmProvided.providedInterface__OperationProvidedRole, umlRealization.contract,
 				TagLiterals.INTERFACE_TO_INTERFACE))
 		// the owning component and component implementation have to correspond
 		assertTrue(
-			corresponds(cm, pcmProvided.providingEntity_ProvidedRole, umlRealization.implementingClassifier,
+			corresponds(pcmProvided.providingEntity_ProvidedRole, umlRealization.implementingClassifier,
 				TagLiterals.IPRE__IMPLEMENTATION))
 	}
 
 	def protected checkProvidedRoleConcept(OperationProvidedRole pcmProvided) {
 		val umlRealization = helper.getModifiableCorr(pcmProvided, InterfaceRealization,
 			TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
-		checkProvidedRoleConcept(correspondenceModel, pcmProvided, umlRealization)
+		checkProvidedRoleConcept(pcmProvided, umlRealization)
 		checkJavaProvidedRoleConcept(umlRealization, pcmProvided)
 	}
 
 	def protected checkProvidedRoleConcept(InterfaceRealization umlRealization) {
 		val pcmProvided = helper.getModifiableCorr(umlRealization, OperationProvidedRole,
 			TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
-		checkProvidedRoleConcept(correspondenceModel, pcmProvided, umlRealization)
+		checkProvidedRoleConcept(pcmProvided, umlRealization)
 		checkJavaProvidedRoleConcept(umlRealization, pcmProvided)
 	}
 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/RepositoryComponentConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/RepositoryComponentConceptTest.xtend
@@ -12,7 +12,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -32,8 +31,7 @@ class RepositoryComponentConceptTest extends PcmUmlJavaTransitiveChangeTest {
 
 	val COMPONENT_NAME = "testComponent"
 
-	def static void checkRepositoryComponentConcept(
-		CorrespondenceModel cm,
+	def void checkRepositoryComponentConcept(
 		RepositoryComponent pcmComponent,
 		Package umlComponentPkg,
 		Class umlComponentImpl,
@@ -43,9 +41,9 @@ class RepositoryComponentConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		assertNotNull(umlComponentPkg)
 		assertNotNull(umlComponentImpl)
 		assertNotNull(umlComponentConstructor)
-		assertTrue(corresponds(cm, pcmComponent, umlComponentPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE))
-		assertTrue(corresponds(cm, pcmComponent, umlComponentImpl, TagLiterals.IPRE__IMPLEMENTATION))
-		assertTrue(corresponds(cm, pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR))
+		assertTrue(corresponds(pcmComponent, umlComponentPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE))
+		assertTrue(corresponds(pcmComponent, umlComponentImpl, TagLiterals.IPRE__IMPLEMENTATION))
+		assertTrue(corresponds(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR))
 		assertTrue(pcmComponent.entityName.toFirstLower == umlComponentPkg.name)
 		assertTrue(pcmComponent.entityName == umlComponentPkg.name.toFirstUpper)
 		assertTrue(pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX == umlComponentImpl.name)
@@ -56,7 +54,7 @@ class RepositoryComponentConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		assertTrue(umlComponentImpl.package === umlComponentPkg)
 		// component repository should correspond to the parent package of the component package
 		assertTrue(
-			corresponds(cm, pcmComponent.repository__RepositoryComponent, umlComponentPkg.nestingPackage,
+			corresponds(pcmComponent.repository__RepositoryComponent, umlComponentPkg.nestingPackage,
 				TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
 	}
 
@@ -64,7 +62,7 @@ class RepositoryComponentConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		val umlComponentPkg = helper.getModifiableCorr(pcmComponent, Package, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 		val umlComponentImpl = helper.getModifiableCorr(pcmComponent, Class, TagLiterals.IPRE__IMPLEMENTATION)
 		val umlComponentConstructor = helper.getModifiableCorr(pcmComponent, Operation, TagLiterals.IPRE__CONSTRUCTOR)
-		checkRepositoryComponentConcept(correspondenceModel, pcmComponent, umlComponentPkg, umlComponentImpl,
+		checkRepositoryComponentConcept(pcmComponent, umlComponentPkg, umlComponentImpl,
 			umlComponentConstructor)
 		// Check Java model:
 		umlComponentConstructor.checkJavaConstructor

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/RepositoryConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/RepositoryConceptTest.xtend
@@ -10,11 +10,11 @@ import tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.Java2PcmUs
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Disabled
 import java.nio.file.Path
+import org.emftext.language.java.containers.ContainersPackage
 
 /**
  * This class is based on the correlating PCM/UML test class. It is extended to include Java in the network.
@@ -25,17 +25,16 @@ import java.nio.file.Path
  */
 class RepositoryConceptTest extends PcmUmlJavaTransitiveChangeTest {
 
-	def protected static checkRepositoryConcept(
-		CorrespondenceModel cm,
+	def protected checkRepositoryConcept(
 		Repository pcmRepo,
 		Package umlRepositoryPkg,
 		Package umlContractsPkg,
 		Package umlDatatypesPkg
 	) {
 		// correspondence constraints
-		assertTrue(corresponds(cm, pcmRepo, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
-		assertTrue(corresponds(cm, pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
-		assertTrue(corresponds(cm, pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE))
+		assertTrue(corresponds(pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE))
 		// containment constraints
 		assertTrue(EcoreUtil.equals(umlContractsPkg.nestingPackage, umlRepositoryPkg))
 		assertTrue(EcoreUtil.equals(umlDatatypesPkg.nestingPackage, umlRepositoryPkg))
@@ -66,7 +65,7 @@ class RepositoryConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		assertTrue(umlRepositoryPkg !== null)
 		assertTrue(umlContractsPkg !== null)
 		assertTrue(umlDatatypesPkg !== null)
-		checkRepositoryConcept(correspondenceModel, pcmRepository, umlRepositoryPkg, umlContractsPkg, umlDatatypesPkg)
+		checkRepositoryConcept(pcmRepository, umlRepositoryPkg, umlContractsPkg, umlDatatypesPkg)
 		checkJavaRepositoryPackage(umlRepositoryPkg)
 	}
 
@@ -190,7 +189,7 @@ class RepositoryConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		assertTrue(umlModel?.packagedElements.empty)
 
 		// There should be no Java packages:
-		val allJavaPackages = typeof(org.emftext.language.java.containers.Package).getCorrespondingObjectsOfClass
+		val allJavaPackages = getCorrespondingEObjects(ContainersPackage.Literals.PACKAGE, org.emftext.language.java.containers.Package)
 		assertEquals(umlModel?.packagedElements.size, allJavaPackages.size,
 			"Too many Java packages: " + allJavaPackages)
 	}

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/SystemConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/SystemConceptTest.xtend
@@ -11,7 +11,6 @@ import org.palladiosimulator.pcm.system.SystemFactory
 import tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.Java2PcmUserSelection
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -36,8 +35,7 @@ class SystemConceptTest extends PcmUmlJavaTransitiveChangeTest {
 	val MODEL_NAME = "testRootModel"
 	val SYSTEM_NAME = "TestSystem"
 
-	def protected static checkSystemConcept(
-		CorrespondenceModel cm,
+	def protected checkSystemConcept(
 		System pcmSystem,
 		Package umlSystemPkg,
 		Class umlSystemImpl,
@@ -47,8 +45,8 @@ class SystemConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		assertNotNull(umlSystemPkg)
 		assertNotNull(umlSystemImpl)
 		assertNotNull(umlSystemConstructor)
-		assertTrue(corresponds(cm, pcmSystem, umlSystemPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE))
-		assertTrue(corresponds(cm, pcmSystem, umlSystemImpl, TagLiterals.IPRE__IMPLEMENTATION))
+		assertTrue(corresponds(pcmSystem, umlSystemPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE))
+		assertTrue(corresponds(pcmSystem, umlSystemImpl, TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(pcmSystem.entityName.toFirstLower == umlSystemPkg.name)
 		assertTrue(pcmSystem.entityName == umlSystemPkg.name.toFirstUpper)
 		assertTrue(pcmSystem.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX == umlSystemImpl.name)
@@ -69,7 +67,7 @@ class SystemConceptTest extends PcmUmlJavaTransitiveChangeTest {
 		val umlSystemPkg = helper.getModifiableCorr(pcmSystem, Package, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
 		val umlSystemImpl = helper.getModifiableCorr(pcmSystem, Class, TagLiterals.IPRE__IMPLEMENTATION)
 		val umlSystemConstructor = helper.getModifiableCorr(pcmSystem, Operation, TagLiterals.IPRE__CONSTRUCTOR)
-		checkSystemConcept(correspondenceModel, pcmSystem, umlSystemPkg, umlSystemImpl, umlSystemConstructor)
+		checkSystemConcept(pcmSystem, umlSystemPkg, umlSystemImpl, umlSystemConstructor)
 		checkJavaPackage(umlSystemPkg)
 		checkJavaType(umlSystemImpl)
 		checkJavaConstructor(umlSystemConstructor)

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlTransformationTest.xtend
@@ -12,7 +12,6 @@ import org.eclipse.uml2.uml.Property
 import java.util.List
 import org.emftext.language.java.members.EnumConstant
 import org.emftext.language.java.members.Member
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 import org.eclipse.uml2.uml.UMLPackage
 import java.util.ArrayList
 import org.junit.jupiter.api.BeforeEach
@@ -214,8 +213,7 @@ abstract class JavaToUmlTransformationTest extends AbstractUmlJavaTest {
 	}
 
 	def protected getRegisteredUmlModel() {
-		val model = CorrespondenceModelUtil.getCorrespondingEObjectsByType(correspondenceModel,
-			UMLPackage.Literals.MODEL, Model).head
+		val model = getCorrespondingEObjects(UMLPackage.Literals.MODEL, Model).head
 		return model
 	}
 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/AttributeConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/AttributeConceptTest.xtend
@@ -10,7 +10,6 @@ import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -26,33 +25,32 @@ class AttributeConceptTest extends PcmUmlJavaLinearTransitiveChangeTest {
 
 	static val TEST_ATTRIBUTE = "testAttribute"
 
-	def static void checkAttributeConcept(
-		CorrespondenceModel cm,
+	def void checkAttributeConcept(
 		InnerDeclaration pcmAttribute,
 		Property umlAttribute
 	) {
 		assertNotNull(pcmAttribute)
 		assertNotNull(umlAttribute)
-		assertTrue(corresponds(cm, pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY))
+		assertTrue(corresponds(pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY))
 		assertTrue(pcmAttribute.entityName == umlAttribute.name)
 		// parent CompositeType should correspond to parent uml::Class
 		assertTrue(
-			corresponds(cm, pcmAttribute.compositeDataType_InnerDeclaration, umlAttribute.class_,
+			corresponds(pcmAttribute.compositeDataType_InnerDeclaration, umlAttribute.class_,
 				TagLiterals.COMPOSITE_DATATYPE__CLASS))
 		// types should correspond
-		assertTrue(isCorrect_DataType_Property_Correspondence(cm, pcmAttribute.datatype_InnerDeclaration, umlAttribute))
+		assertTrue(isCorrect_DataType_Property_Correspondence(pcmAttribute.datatype_InnerDeclaration, umlAttribute))
 	}
 
 	def protected checkAttributeConcept(InnerDeclaration pcmAttribute) {
 		val umlAttribute = helper.getModifiableCorr(pcmAttribute, Property, TagLiterals.INNER_DECLARATION__PROPERTY)
-		checkAttributeConcept(correspondenceModel, pcmAttribute, umlAttribute)
+		checkAttributeConcept(pcmAttribute, umlAttribute)
 		checkJavaAttribute(umlAttribute)
 	}
 
 	def protected checkAttributeConcept(Property umlAttribute) {
 		val pcmAttribute = helper.getModifiableCorr(umlAttribute, InnerDeclaration,
 			TagLiterals.INNER_DECLARATION__PROPERTY)
-		checkAttributeConcept(correspondenceModel, pcmAttribute, umlAttribute)
+		checkAttributeConcept(pcmAttribute, umlAttribute)
 		checkJavaAttribute(umlAttribute)
 	}
 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/MediaStoreRepositoryCreationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/MediaStoreRepositoryCreationTest.xtend
@@ -304,10 +304,10 @@ class MediaStoreRepositoryCreationTest extends PcmUmlJavaLinearTransitiveChangeT
 	def protected getJavaClassFromCompilationUnit(String name, String ... namespaces){
 		// This roundabout way works to retrieve the read-only instance of the VSUM but still fails when trying to load the CU from the URI.
 //		val javaPkg = getJavaPackageElement(namespaces)
-//		val umlPkg = CorrespondenceModelUtil.getCorrespondingEObjectsByType(correspondenceModel, javaPkg, org.eclipse.uml2.uml.Package).head
+//		val umlPkg = getCorrespondingEObjects(javaPkg, org.eclipse.uml2.uml.Package).head
 //		val umlCompImpl = umlPkg.packagedElements.filterNull.filter(org.eclipse.uml2.uml.Class)
 //			.findFirst[it.name.toLowerCase.contains(javaPkg.name.toLowerCase)]
-//		val javaCompImpl = CorrespondenceModelUtil.getCorrespondingEObjectsByType(correspondenceModel, umlCompImpl, org.emftext.language.java.classifiers.Class).head
+//		val javaCompImpl = getCorrespondingEObjects(umlCompImpl, org.emftext.language.java.classifiers.Class).head
 //		// here it fails, because the CU cannot be loaded into the view-ResourceSet
 //		// because the UUID resolver fails on trying to register the 'Object extends Object'-ClassifierReference 
 //		val modifiableJavaCompImpl = getModelElement(EcoreUtil.getURI(javaCompImpl)) as org.emftext.language.java.classifiers.Class

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/ParameterConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/ParameterConceptTest.xtend
@@ -13,7 +13,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -34,31 +33,30 @@ class ParameterConceptTest extends PcmUmlJavaLinearTransitiveChangeTest {
 		return umlDirection == PcmUmlClassHelper.getMatchingParameterDirection(pcmModifier)
 	}
 
-	def static checkParameterConcept(
-		CorrespondenceModel cm,
+	def checkParameterConcept(
 		Parameter pcmParameter,
 		org.eclipse.uml2.uml.Parameter umlParameter
 	) {
 		assertNotNull(pcmParameter)
 		assertNotNull(umlParameter)
-		assertTrue(corresponds(cm, pcmParameter, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER))
+		assertTrue(corresponds(pcmParameter, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER))
 		assertTrue(pcmParameter.parameterName == umlParameter.name)
 		assertTrue(checkParameterModifiers(pcmParameter.modifier__Parameter, umlParameter.direction))
-		assertTrue(isCorrect_DataType_Parameter_Correspondence(cm, pcmParameter.dataType__Parameter, umlParameter))
+		assertTrue(isCorrect_DataType_Parameter_Correspondence(pcmParameter.dataType__Parameter, umlParameter))
 		assertTrue(
-			corresponds(cm, pcmParameter.operationSignature__Parameter, umlParameter.operation,
+			corresponds(pcmParameter.operationSignature__Parameter, umlParameter.operation,
 				TagLiterals.SIGNATURE__OPERATION))
 	}
 
 	def protected checkParameterConcept(Parameter pcmParameter) {
 		val mumlParameter = helper.getModifiableCorr(pcmParameter, org.eclipse.uml2.uml.Parameter,
 			TagLiterals.PARAMETER__REGULAR_PARAMETER)
-		checkParameterConcept(correspondenceModel, pcmParameter, mumlParameter)
+		checkParameterConcept(pcmParameter, mumlParameter)
 	}
 
 	def protected checkParameterConcept(org.eclipse.uml2.uml.Parameter umlParameter) {
 		val pcmParameter = helper.getModifiableCorr(umlParameter, Parameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
-		checkParameterConcept(correspondenceModel, pcmParameter, umlParameter)
+		checkParameterConcept(pcmParameter, umlParameter)
 		checkJavaParameterConcept(umlParameter, pcmParameter)
 	}
 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/RequiredRoleConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/RequiredRoleConceptTest.xtend
@@ -10,7 +10,6 @@ import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -28,8 +27,7 @@ class RequiredRoleConceptTest extends PcmUmlJavaLinearTransitiveChangeTest {
 
 	val REQUIRED_ROLE_NAME = "testRequiredRole"
 
-	def static void checkRequiredRoleConcept(
-		CorrespondenceModel cm,
+	def void checkRequiredRoleConcept(
 		OperationRequiredRole pcmRequired,
 		Property umlRequiredInstance,
 		Parameter umlRequiredParameter
@@ -37,17 +35,17 @@ class RequiredRoleConceptTest extends PcmUmlJavaLinearTransitiveChangeTest {
 		assertNotNull(pcmRequired)
 		assertNotNull(umlRequiredInstance)
 		assertNotNull(umlRequiredParameter)
-		assertTrue(corresponds(cm, pcmRequired, umlRequiredInstance, TagLiterals.REQUIRED_ROLE__PROPERTY))
-		assertTrue(corresponds(cm, pcmRequired, umlRequiredParameter, TagLiterals.REQUIRED_ROLE__PARAMETER))
+		assertTrue(corresponds(pcmRequired, umlRequiredInstance, TagLiterals.REQUIRED_ROLE__PROPERTY))
+		assertTrue(corresponds(pcmRequired, umlRequiredParameter, TagLiterals.REQUIRED_ROLE__PARAMETER))
 		// the respective type references have to correspond
-		assertTrue(corresponds(cm, pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredInstance.type))
-		assertTrue(corresponds(cm, pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredParameter.type))
+		assertTrue(corresponds(pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredInstance.type))
+		assertTrue(corresponds(pcmRequired.requiredInterface__OperationRequiredRole, umlRequiredParameter.type))
 		// the owning component and component implementation have to correspond
 		assertTrue(
-			corresponds(cm, pcmRequired.requiringEntity_RequiredRole, umlRequiredInstance.class_,
+			corresponds(pcmRequired.requiringEntity_RequiredRole, umlRequiredInstance.class_,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(
-			corresponds(cm, pcmRequired.requiringEntity_RequiredRole, umlRequiredParameter.operation?.class_,
+			corresponds(pcmRequired.requiringEntity_RequiredRole, umlRequiredParameter.operation?.class_,
 				TagLiterals.IPRE__IMPLEMENTATION))
 		assertTrue(pcmRequired.entityName == umlRequiredInstance.name)
 		assertTrue(pcmRequired.entityName == umlRequiredParameter.name)
@@ -57,7 +55,7 @@ class RequiredRoleConceptTest extends PcmUmlJavaLinearTransitiveChangeTest {
 		val umlRequiredInstance = helper.getModifiableCorr(pcmRequired, Property, TagLiterals.REQUIRED_ROLE__PROPERTY)
 		val umlRequiredParameter = helper.getModifiableCorr(pcmRequired, Parameter,
 			TagLiterals.REQUIRED_ROLE__PARAMETER)
-		checkRequiredRoleConcept(correspondenceModel, pcmRequired, umlRequiredInstance, umlRequiredParameter)
+		checkRequiredRoleConcept(pcmRequired, umlRequiredInstance, umlRequiredParameter)
 		val pcmRepository = pcmRequired.requiredInterface__OperationRequiredRole.repository__Interface
 		checkRequiredRoleJavaConcept(umlRequiredParameter.operation, umlRequiredInstance, pcmRepository)
 	}

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/SignatureConceptTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/SignatureConceptTest.xtend
@@ -14,7 +14,6 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTestHelper
-import tools.vitruv.framework.correspondence.CorrespondenceModel
 
 import static org.junit.jupiter.api.Assertions.*
 import java.nio.file.Path
@@ -30,8 +29,7 @@ class SignatureConceptTest extends PcmUmlJavaLinearTransitiveChangeTest {
 
 	static val TEST_SIGNATURE_NAME = "testSignature"
 
-	def static void checkSignatureConcept(
-		CorrespondenceModel cm,
+	def void checkSignatureConcept(
 		OperationSignature pcmSignature,
 		Operation umlOperation
 	) {
@@ -41,29 +39,29 @@ class SignatureConceptTest extends PcmUmlJavaLinearTransitiveChangeTest {
 		assertNotNull(pcmSignature)
 		assertNotNull(umlOperation)
 		assertNotNull(returnParam)
-		assertTrue(corresponds(cm, pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION))
-		assertTrue(corresponds(cm, pcmSignature, returnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER))
+		assertTrue(corresponds(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION))
+		assertTrue(corresponds(pcmSignature, returnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER))
 		assertTrue(pcmSignature.entityName == umlOperation.name)
 		// the name needs to be set, so that its TUID is distinct and the object is not confused with new instances
 		assertTrue(returnParam.name == DefaultLiterals.RETURN_PARAM_NAME)
 		// return types of both model elements should correspond to each other if they are set
 		assertTrue(
-			isCorrect_DataType_Parameter_Correspondence(cm, pcmSignature.returnType__OperationSignature, returnParam))
+			isCorrect_DataType_Parameter_Correspondence(pcmSignature.returnType__OperationSignature, returnParam))
 		// should both be contained in corresponding interfaces
 		assertTrue(
-			corresponds(cm, pcmSignature.interface__OperationSignature, umlOperation.interface,
+			corresponds(pcmSignature.interface__OperationSignature, umlOperation.interface,
 				TagLiterals.INTERFACE_TO_INTERFACE))
 	}
 
 	def protected checkSignatureConcept(OperationSignature pcmSignature) {
 		val umlOperation = helper.getModifiableCorr(pcmSignature, Operation, TagLiterals.SIGNATURE__OPERATION)
-		checkSignatureConcept(correspondenceModel, pcmSignature, umlOperation)
+		checkSignatureConcept(pcmSignature, umlOperation)
 		checkJavaSignatureConcept(umlOperation, pcmSignature)
 	}
 
 	def protected checkSignatureConcept(Operation umlOperation) {
 		val pcmSignature = helper.getModifiableCorr(umlOperation, OperationSignature, TagLiterals.SIGNATURE__OPERATION)
-		checkSignatureConcept(correspondenceModel, pcmSignature, umlOperation)
+		checkSignatureConcept(pcmSignature, umlOperation)
 		checkJavaSignatureConcept(umlOperation, pcmSignature)
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/META-INF/MANIFEST.MF
+++ b/tests/tools.vitruv.applications.umljava.tests/META-INF/MANIFEST.MF
@@ -9,9 +9,10 @@ Require-Bundle: org.junit.jupiter.api,
  tools.vitruv.applications.umljava,
  tools.vitruv.framework.applications,
  tools.vitruv.testutils,
- tools.vitruv.extensions.dslsruntime.reactions,
  org.hamcrest.core,
  org.apache.commons.io,
- edu.kit.ipd.sdq.activextendannotations
+ edu.kit.ipd.sdq.activextendannotations,
+ org.eclipse.xtend.lib,
+ org.apache.log4j
 Bundle-Vendor: vitruv.tools
 Export-Package: tools.vitruv.applications.umljava.tests.util

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlTransformationTest.xtend
@@ -12,7 +12,6 @@ import org.eclipse.uml2.uml.Property
 import java.util.List
 import org.emftext.language.java.members.EnumConstant
 import org.emftext.language.java.members.Member
-import tools.vitruv.framework.correspondence.CorrespondenceModelUtil
 import org.eclipse.uml2.uml.UMLPackage
 import java.util.ArrayList
 import org.junit.jupiter.api.BeforeEach
@@ -213,8 +212,7 @@ abstract class JavaToUmlTransformationTest extends AbstractUmlJavaTest {
 	}
 
 	def protected getRegisteredUmlModel() {
-		val model = CorrespondenceModelUtil.getCorrespondingEObjectsByType(correspondenceModel,
-			UMLPackage.Literals.MODEL, Model).head
+		val model = getCorrespondingEObjects(UMLPackage.Literals.MODEL, Model).head
 		return model
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/AbstractUmlJavaTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/AbstractUmlJavaTest.xtend
@@ -21,7 +21,6 @@ abstract class AbstractUmlJavaTest extends LegacyVitruvApplicationTest {
 	/**
 	 * Retrieves all corresponding objects of obj.
 	 * 
-	 * {@link tools.vitruv.framework.tests.VitruviusUnmonitoredApplicationTest#getCorrespondenceModel}
 	 * @param obj the object for which the corresponding objects should be retrieved
 	 * @return the corresponding objects of obj or null if none could be found
 	 * @throws IllegalArgumentException if obj is null
@@ -30,7 +29,7 @@ abstract class AbstractUmlJavaTest extends LegacyVitruvApplicationTest {
 		if (obj === null) {
 			throw new IllegalArgumentException("Cannot retrieve correspondence for null")
 		}
-		val corrList = getCorrespondenceModel.getCorrespondingEObjects(#[obj]).flatten
+		val corrList = getCorrespondingEObjects(obj, EObject)
 		if (corrList.nullOrEmpty) {
 			logger.warn("No Correspondences found for " + obj)
 			return null


### PR DESCRIPTION
Adapts to reduced access to the `CorrespondenceModel` in application tests in https://github.com/vitruv-tools/Vitruv/pull/461.
Simplifies several correspondence retrievals.