### PR TITLE
Cleanup Java namespace helper methods

### DIFF
--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaStandardType.xtend
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaStandardType.xtend
@@ -14,7 +14,7 @@ import org.emftext.language.java.types.TypesFactory
 import org.emftext.language.java.types.Void
 
 import static tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * Util class with for Java-PrimitiveTypes and Java-String.
@@ -89,7 +89,7 @@ class JavaStandardType {
             case LONG: return TypesFactory.eINSTANCE.createLong
             case SHORT: return TypesFactory.eINSTANCE.createShort
             case VOID: return TypesFactory.eINSTANCE.createVoid
-            case STRING: return createNamespaceReferenceFromClassifier(createJavaClass(STRING, JavaVisibility.PUBLIC, false, false))
+            case STRING: return createNamespaceClassifierReference(createJavaClass(STRING, JavaVisibility.PUBLIC, false, false))
             default: throw new IllegalArgumentException("Unknown standard primitive type name: " + standardTypeName)
         }
     }

--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaTypeUtil.xtend
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaTypeUtil.xtend
@@ -24,7 +24,6 @@ import org.emftext.language.java.types.Type
 import org.emftext.language.java.types.TypeReference
 import org.emftext.language.java.types.TypedElement
 import org.emftext.language.java.types.TypesFactory
-import tools.vitruv.domains.java.util.JavaModificationUtil
 
 import static tools.vitruv.applications.util.temporary.other.UriUtil.normalizeURI
 import static tools.vitruv.domains.java.util.JavaModificationUtil.*
@@ -119,33 +118,18 @@ class JavaTypeUtil {
     def static EList<NamespaceClassifierReference> createNamespaceReferenceFromList(List<? extends ConcreteClassifier> list) {
         val typeReferences = new BasicEList<NamespaceClassifierReference>
         for (ConcreteClassifier i : list) {
-            typeReferences += createNamespaceReferenceFromClassifier(i)
+            typeReferences += createNamespaceClassifierReference(i)
         }
         return typeReferences
     }
 
     def static TypeReference createCollectiontypeReference(String collectionQualifiedName, ConcreteClassifier innerTypeClass) {
-        val innerTypeReference = createNamespaceReferenceFromClassifier(innerTypeClass)
+        val innerTypeReference = createNamespaceClassifierReference(innerTypeClass)
         val qualifiedTypeArgument = GenericsFactory.eINSTANCE.createQualifiedTypeArgument()
         qualifiedTypeArgument.typeReference = innerTypeReference
-        val collectionClassNamespaceReference = createNamespaceReferenceFromClassifier(createJavaClassImport(collectionQualifiedName).classifier)
+        val collectionClassNamespaceReference = createNamespaceClassifierReferenceForName(collectionQualifiedName)
         collectionClassNamespaceReference.classifierReferences.get(0).typeArguments += qualifiedTypeArgument
         return collectionClassNamespaceReference
-    }
-
-    /**
-     * Wraps a copy of the given concreteClassifier into a ClassfierReference which is then wrapped into a namespaceClassifierReference
-     * @throws IllegalArgumentException if concreteCLassifier is null
-     */
-    def static NamespaceClassifierReference createNamespaceReferenceFromClassifier(ConcreteClassifier concreteClassifier) {
-        if (concreteClassifier === null) {
-            throw new IllegalArgumentException("Cannot create a NamespaceClassifierReference for null")
-        }
-        val namespaceClassifierReference = TypesFactory.eINSTANCE.createNamespaceClassifierReference
-        var classifierRef = TypesFactory.eINSTANCE.createClassifierReference
-        classifierRef.target = concreteClassifier
-        namespaceClassifierReference.classifierReferences.add(classifierRef)
-        return namespaceClassifierReference
     }
 
     def static setTypeReference(TypedElement typedElement, TypeReference typeRef) {
@@ -318,7 +302,7 @@ class JavaTypeUtil {
         // wrap typeReference if necessary
         var wrappedInnerReference = innerTypeReference
         if (wrappedInnerReference instanceof PrimitiveType) {
-            wrappedInnerReference = JavaModificationUtil.getWrapperTypeReferenceForPrimitiveType(wrappedInnerReference)
+            wrappedInnerReference = getWrapperTypeReferenceForPrimitiveType(wrappedInnerReference)
         }
 
         // set the inner type reference on the NamespaceClassifierReference of the Collection type
@@ -333,7 +317,7 @@ class JavaTypeUtil {
         ConcreteClassifier collectionTypeClassifier,
         TypeReference innerTypeReference
     ) {
-        val collectionTypeReference = JavaModificationUtil.createNamespaceClassifierReference(collectionTypeClassifier)
+        val collectionTypeReference = createNamespaceClassifierReference(collectionTypeClassifier)
         return createCollectionTypeReference(collectionTypeReference, innerTypeReference)
     }
 
@@ -343,7 +327,7 @@ class JavaTypeUtil {
     ) {
         val collectionNamespace = collectionType.name.replace("." + collectionType.simpleName, "")
         val collectionSimpleName = collectionType.simpleName
-        val collectionTypeReference = JavaModificationUtil.createNamespaceClassifierReferenceForName(collectionNamespace, collectionSimpleName)
+        val collectionTypeReference = createNamespaceClassifierReferenceForName(collectionNamespace, collectionSimpleName)
 
         return createCollectionTypeReference(collectionTypeReference, innerTypeReference)
     }

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlAttributeTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlAttributeTest.xtend
@@ -12,8 +12,8 @@ import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaStandardType.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlTypeUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import org.junit.jupiter.api.BeforeEach
@@ -78,7 +78,7 @@ class JavaToUmlAttributeTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def testCreateAttribute() {
-		val attr = createJavaAttribute(STANDARD_ATTRIBUTE_NAME, createNamespaceReferenceFromClassifier(typeClass),
+		val attr = createJavaAttribute(STANDARD_ATTRIBUTE_NAME, createNamespaceClassifierReference(typeClass),
 			JavaVisibility.PRIVATE, false, false)
 		jClass.members += attr
 		propagate
@@ -125,7 +125,7 @@ class JavaToUmlAttributeTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def testChangeAttributeType() {
-		jAttr.typeReference = createNamespaceReferenceFromClassifier(typeClass)
+		jAttr.typeReference = createNamespaceClassifierReference(typeClass)
 		propagate
 
 		val uAttr = getCorrespondingAttribute(jAttr)

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlClassMethodTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlClassMethodTest.xtend
@@ -5,7 +5,6 @@ import org.emftext.language.java.members.ClassMethod
 import org.junit.jupiter.api.Test
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
@@ -18,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * A test class to test the class method reactions.
@@ -52,7 +52,7 @@ class JavaToUmlClassMethodTest extends JavaToUmlTransformationTest {
 		typeClass = createSimpleJavaClassWithCompilationUnit(TYPE_NAME)
 		typeClass2 = createSimpleJavaClassWithCompilationUnit(TYPE_NAME2)
 		jMeth = createSimpleJavaOperation(OPERATION_NAME)
-		jParam = createJavaParameter(PARAMETER_NAME, createNamespaceReferenceFromClassifier(typeClass2))
+		jParam = createJavaParameter(PARAMETER_NAME, createNamespaceClassifierReference(typeClass2))
 		jParamMeth = createJavaClassMethod(OPERATION_NAME2, TypesFactory.eINSTANCE.createBoolean, JavaVisibility.PUBLIC,
 			false, false, #[jParam])
 		jClass.members += jMeth
@@ -80,7 +80,7 @@ class JavaToUmlClassMethodTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def void testChangeReturnType() {
-		jMeth.typeReference = createNamespaceReferenceFromClassifier(typeClass)
+		jMeth.typeReference = createNamespaceClassifierReference(typeClass)
 		propagate
 
 		val uOperation = getCorrespondingMethod(jMeth)
@@ -208,7 +208,7 @@ class JavaToUmlClassMethodTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def testCreateParameter() {
-		val param = createJavaParameter(PARAMETER_NAME2, createNamespaceReferenceFromClassifier(typeClass))
+		val param = createJavaParameter(PARAMETER_NAME2, createNamespaceClassifierReference(typeClass))
 		jMeth.parameters += param
 		propagate
 
@@ -250,7 +250,7 @@ class JavaToUmlClassMethodTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def testChangeParameterType() {
-		jParam.typeReference = createNamespaceReferenceFromClassifier(typeClass)
+		jParam.typeReference = createNamespaceClassifierReference(typeClass)
 		propagate
 
 		val uParam = getCorrespondingParameter(jParam)

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlClassTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlClassTest.xtend
@@ -1,5 +1,6 @@
 package tools.vitruv.applications.transitivechange.tests.linear.java2uml
 
+import java.nio.file.Path
 import org.eclipse.emf.ecore.util.EcoreUtil
 import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.VisibilityKind
@@ -7,8 +8,8 @@ import org.junit.jupiter.api.Test
 
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import org.junit.jupiter.api.BeforeEach
@@ -18,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertEquals
-import java.nio.file.Path
 
 /**
  * A Test class to test classes and their traits.
@@ -164,7 +164,7 @@ class JavaToUmlClassTest extends JavaToUmlTransformationTest {
 	@Test
 	def testSuperClassChanged() {
 		val superClass = createSimpleJavaClassWithCompilationUnit(SUPER_CLASS_NAME)
-		jClass.extends = createNamespaceReferenceFromClassifier(superClass)
+		jClass.extends = createNamespaceClassifierReference(superClass)
 		propagate
 
 		val uClass = getCorrespondingClass(jClass)
@@ -180,7 +180,7 @@ class JavaToUmlClassTest extends JavaToUmlTransformationTest {
 	@Test
 	def testRemoveSuperClass() {
 		val superClass = createSimpleJavaClassWithCompilationUnit(SUPER_CLASS_NAME)
-		jClass.extends = createNamespaceReferenceFromClassifier(superClass)
+		jClass.extends = createNamespaceClassifierReference(superClass)
 		propagate
 
 		var uClass = getCorrespondingClass(jClass)
@@ -208,7 +208,7 @@ class JavaToUmlClassTest extends JavaToUmlTransformationTest {
 	@Test
 	def testAddClassImplement() {
 		val implInterface = createSimpleJavaInterfaceWithCompilationUnit(INTERFACE_NAME)
-		jClass.implements += createNamespaceReferenceFromClassifier(implInterface)
+		jClass.implements += createNamespaceClassifierReference(implInterface)
 		propagate
 
 		val uClass = getCorrespondingClass(jClass)
@@ -233,8 +233,8 @@ class JavaToUmlClassTest extends JavaToUmlTransformationTest {
 	def testRemoveClassImplement() {
 		val implInterface = createSimpleJavaInterfaceWithCompilationUnit(INTERFACE_NAME)
 		val implInterface2 = createSimpleJavaInterfaceWithCompilationUnit(INTERFACE_NAME2)
-		jClass.implements += createNamespaceReferenceFromClassifier(implInterface)
-		jClass.implements += createNamespaceReferenceFromClassifier(implInterface2)
+		jClass.implements += createNamespaceClassifierReference(implInterface)
+		jClass.implements += createNamespaceClassifierReference(implInterface2)
 		propagate
 
 		var uClass = getCorrespondingClass(jClass)

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlEnumTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlEnumTest.xtend
@@ -10,13 +10,13 @@ import tools.vitruv.applications.util.temporary.java.JavaVisibility
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import org.junit.jupiter.api.BeforeEach
 
 import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This class contains Tests for creating, deleting and renaming enums.
@@ -111,7 +111,7 @@ class JavaToUmlEnumTest extends JavaToUmlTransformationTest {
 	@Test
 	def void testAddEnumAttribute() {
 		val typeClass = createJavaClassWithCompilationUnit(TYPECLASS, JavaVisibility.PUBLIC, false, false)
-		val jAttr = createJavaAttribute(ATTRIBUTE_NAME, createNamespaceReferenceFromClassifier(typeClass),
+		val jAttr = createJavaAttribute(ATTRIBUTE_NAME, createNamespaceClassifierReference(typeClass),
 			JavaVisibility.PRIVATE, false, false)
 		jEnum.members += jAttr
 		propagate

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlInterfaceMethodTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlInterfaceMethodTest.xtend
@@ -1,7 +1,6 @@
 package tools.vitruv.applications.transitivechange.tests.linear.java2uml
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import org.junit.jupiter.api.Test
@@ -11,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This class contains test cases for the creation, renaming and deleting of interface methods.
@@ -77,7 +77,7 @@ class JavaToUmlInterfaceMethodTest extends JavaToUmlTransformationTest {
 
 	@Test
 	def testChangeInterfaceMethodReturnType() {
-		jMeth.typeReference = createNamespaceReferenceFromClassifier(typeClass)
+		jMeth.typeReference = createNamespaceClassifierReference(typeClass)
 		propagate
 
 		val uOperation = getCorrespondingMethod(jMeth)
@@ -88,7 +88,7 @@ class JavaToUmlInterfaceMethodTest extends JavaToUmlTransformationTest {
 
 	@Test
 	def testCreateInterfaceParameter() {
-		val jParam = createJavaParameter(PARAMETER_NAME, createNamespaceReferenceFromClassifier(typeClass))
+		val jParam = createJavaParameter(PARAMETER_NAME, createNamespaceClassifierReference(typeClass))
 		jMeth.parameters += jParam
 		propagate
 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlInterfaceTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlInterfaceTest.xtend
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test
 
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import org.junit.jupiter.api.BeforeEach
 
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * A Test class for interface tests. Checks their creation, renaming, deleting and the 
@@ -63,7 +63,7 @@ class JavaToUmlInterfaceTest extends JavaToUmlTransformationTest {
 	@Test
 	def testAddSuperInterface() {
 		val superInterface = createSimpleJavaInterfaceWithCompilationUnit(SUPERINTERFACENAME_1)
-		jInterface.extends += createNamespaceReferenceFromClassifier(superInterface)
+		jInterface.extends += createNamespaceClassifierReference(superInterface)
 		propagate
 
 		val uInterface = getCorrespondingInterface(jInterface)
@@ -76,8 +76,8 @@ class JavaToUmlInterfaceTest extends JavaToUmlTransformationTest {
 	def testRemoveSuperInterface() {
 		val superInterface = createSimpleJavaInterfaceWithCompilationUnit(SUPERINTERFACENAME_1)
 		val superInterface2 = createSimpleJavaInterfaceWithCompilationUnit(SUPERINTERFACENAME_2)
-		jInterface.extends += createNamespaceReferenceFromClassifier(superInterface)
-		jInterface.extends += createNamespaceReferenceFromClassifier(superInterface2)
+		jInterface.extends += createNamespaceClassifierReference(superInterface)
+		jInterface.extends += createNamespaceClassifierReference(superInterface2)
 		propagate
 
 		jInterface.extends.remove(0)

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/MediaStoreRepositoryCreationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/pcmumlclassjava/MediaStoreRepositoryCreationTest.xtend
@@ -12,7 +12,6 @@ import tools.vitruv.applications.util.temporary.java.JavaVisibility
 
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaStandardType.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Disabled
 import static org.junit.jupiter.api.Assertions.assertNotNull
@@ -22,6 +21,7 @@ import org.emftext.language.java.containers.CompilationUnit
 import java.util.List
 import org.emftext.language.java.containers.ContainersFactory
 import org.emftext.language.java.containers.Package import org.emftext.language.java.classifiers.Interface
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 
 /**
@@ -221,14 +221,14 @@ class MediaStoreRepositoryCreationTest extends PcmUmlJavaLinearTransitiveChangeT
 		
 		var jPkg_contracts = getJavaPackage(REPOSITORY_PKG_NAME, CONTRACTS_PKG_NAME)
 		var jI_IFileStorage = createJavaInterfaceInPackage(jPkg_contracts, INTERFACE_NAME_IFileStorage, #[])
-		var jDtRef_AudioCollectionRequest = createNamespaceReferenceFromClassifier(jDt_AudioCollectionRequest)
+		var jDtRef_AudioCollectionRequest = createNamespaceClassifierReference(jDt_AudioCollectionRequest)
 		var jParam_audioRequest = createJavaParameter(PARAMETER_NAME_audioRequest, jDtRef_AudioCollectionRequest)
-		var jDtRef_FileContent = createNamespaceReferenceFromClassifier(jDt_FileContent)
+		var jDtRef_FileContent = createNamespaceClassifierReference(jDt_FileContent)
 		var jMeth_getFile = createJavaInterfaceMethod(METHOD_NAME_getFile, jDtRef_FileContent, #[jParam_audioRequest])
 		jI_IFileStorage.members += jMeth_getFile
 		propagate
 		var jI_IMediaAccess = createJavaInterfaceInPackage(jPkg_contracts, INTERFACE_NAME_IMediaAccess, #[])
-		jDtRef_FileContent = createNamespaceReferenceFromClassifier(jDt_FileContent)
+		jDtRef_FileContent = createNamespaceClassifierReference(jDt_FileContent)
 		var jParam_file = createJavaParameter(PARAMETER_NAME_file, jDtRef_FileContent)
 		var jMeth_upload = createJavaInterfaceMethod(METHOD_NAME_upload, null, #[jParam_file])
 		jI_IMediaAccess.members += jMeth_upload
@@ -243,8 +243,8 @@ class MediaStoreRepositoryCreationTest extends PcmUmlJavaLinearTransitiveChangeT
 		propagate
 		var jClass_MediaAccessImpl = getJavaClassFromCompilationUnit(COMPONENT_IMPL_NAME, REPOSITORY_PKG_NAME, COMPONENT_PKG_NAME) // TODO here it fails
 		assertNotNull(jClass_MediaAccessImpl)
-		var jIRef_IFileStorage = createNamespaceReferenceFromClassifier(jI_IFileStorage) // required
-		var jIRef_IMediaAccess = createNamespaceReferenceFromClassifier(jI_IFileStorage) // provided
+		var jIRef_IFileStorage = createNamespaceClassifierReference(jI_IFileStorage) // required
+		var jIRef_IMediaAccess = createNamespaceClassifierReference(jI_IFileStorage) // provided
 		jClass_MediaAccessImpl.implements += jIRef_IMediaAccess
 		var jAtt_requiredIFileStorage = createJavaAttribute(ATTRIBUTE_NAME, jIRef_IFileStorage, JavaVisibility.PRIVATE, false, false)
 		jClass_MediaAccessImpl.members += jAtt_requiredIFileStorage

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaAssociationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaAssociationTest.xtend
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This test class contains basic test for associations.
@@ -44,7 +45,7 @@ class UmlToJavaAssociationTest extends UmlToJavaTransformationTest {
 		val jClass1 = getCorrespondingClass(uClass1)
 		val jAttribute = getCorrespondingAttribute(uAttribute)
 		val jClass2 = getCorrespondingClass(uClass2)
-		assertJavaElementHasTypeRef(jAttribute, createNamespaceReferenceFromClassifier(jClass2))
+		assertJavaElementHasTypeRef(jAttribute, createNamespaceClassifierReference(jClass2))
 		assertClassEquals(uClass1, jClass1)
 		assertAttributeEquals(uAttribute, jAttribute)
 	}
@@ -59,7 +60,7 @@ class UmlToJavaAssociationTest extends UmlToJavaTransformationTest {
 		val jClass1 = getCorrespondingClass(uClass1)
 		val jAttribute = getCorrespondingAttribute(uAttribute)
 		val jClass2 = getCorrespondingClass(uClass2)
-		assertJavaElementHasTypeRef(jAttribute, createNamespaceReferenceFromClassifier(jClass2))
+		assertJavaElementHasTypeRef(jAttribute, createNamespaceClassifierReference(jClass2))
 		assertClassEquals(uClass1, jClass1)
 		assertTrue(javaGetterForAttributeExists(jAttribute))
 		assertTrue(javaSetterForAttributeExists(jAttribute))
@@ -78,7 +79,7 @@ class UmlToJavaAssociationTest extends UmlToJavaTransformationTest {
 		val arrayListReference = getClassifierFromTypeReference(jAttribute.typeReference)
 		assertEquals("ArrayList", arrayListReference.name)
 		val innerTypeRef = getInnerTypeReferenceOfCollectionTypeReference(jAttribute.typeReference)
-		assertTypeEquals(createNamespaceReferenceFromClassifier(jClass2), innerTypeRef)
+		assertTypeEquals(createNamespaceClassifierReference(jClass2), innerTypeRef)
 	}
 
 }

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaAttributeTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaAttributeTest.xtend
@@ -16,9 +16,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlPropertyAndAssociationUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This Test class checks the creating, deleting and modifying of attributes in den uml to java
@@ -70,7 +70,7 @@ class UmlToJavaAttributeTest extends UmlToJavaTransformationTest {
 		val jtypeClass = getCorrespondingClass(typeClass)
 		val jAttr = getCorrespondingAttribute(attr)
 		assertJavaAttributeTraits(jAttr, STANDARD_ATTRIBUTE_NAME, JavaVisibility.PUBLIC,
-			createNamespaceReferenceFromClassifier(jtypeClass), false, false, jClass)
+			createNamespaceClassifierReference(jtypeClass), false, false, jClass)
 		assertAttributeEquals(attr, jAttr)
 
 	}

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaClassMethodTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaClassMethodTest.xtend
@@ -16,9 +16,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlOperationAndParameterUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * A Test class to test class methods and its traits.
@@ -85,7 +85,7 @@ class UmlToJavaClassMethodTest extends UmlToJavaTransformationTest {
 
 		val jMethod = getCorrespondingClassMethod(uOperation)
 		val jTypeClass = getCorrespondingClass(typeClass)
-		assertJavaElementHasTypeRef(jMethod, createNamespaceReferenceFromClassifier(jTypeClass))
+		assertJavaElementHasTypeRef(jMethod, createNamespaceClassifierReference(jTypeClass))
 		assertClassMethodEquals(uOperation, jMethod)
 	}
 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaEnumTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaEnumTest.xtend
@@ -8,9 +8,9 @@ import tools.vitruv.applications.util.temporary.java.JavaVisibility
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlOperationAndParameterUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -118,7 +118,7 @@ class UmlToJavaEnumTest extends UmlToJavaTransformationTest {
 		val jTypeClass = getCorrespondingClass(typeClass)
 		val jAttr = getCorrespondingAttribute(attr)
 		assertJavaAttributeTraits(jAttr, ATTRIBUTE_NAME, JavaVisibility.PUBLIC,
-			createNamespaceReferenceFromClassifier(jTypeClass), false, false, jEnum)
+			createNamespaceClassifierReference(jTypeClass), false, false, jEnum)
 		assertAttributeEquals(attr, jAttr)
 
 	}

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaInterfaceMethodTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaInterfaceMethodTest.xtend
@@ -9,9 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlOperationAndParameterUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This class provides basic tests for creating, deleting and changing traits of interface methods.
@@ -94,7 +94,7 @@ class UmlToJavaInterfaceMethodTest extends UmlToJavaTransformationTest {
 
 		val jMethod = getCorrespondingInterfaceMethod(uOperation)
 		val jTypeClass = getCorrespondingClass(typeClass)
-		assertJavaElementHasTypeRef(jMethod, createNamespaceReferenceFromClassifier(jTypeClass))
+		assertJavaElementHasTypeRef(jMethod, createNamespaceClassifierReference(jTypeClass))
 		assertInterfaceMethodEquals(uOperation, jMethod)
 	}
 }

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaParameterTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaParameterTest.xtend
@@ -11,9 +11,9 @@ import tools.vitruv.applications.util.temporary.uml.UmlTypeUtil
 
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlOperationAndParameterUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -60,7 +60,7 @@ class UmlToJavaParameterTest extends UmlToJavaTransformationTest {
 
 		val jParam = getCorrespondingParameter(uParam)
 		val jTypeClass = getCorrespondingClass(typeClass)
-		assertJavaParameterTraits(jParam, STANDARD_PARAMETER_NAME, createNamespaceReferenceFromClassifier(jTypeClass))
+		assertJavaParameterTraits(jParam, STANDARD_PARAMETER_NAME, createNamespaceClassifierReference(jTypeClass))
 		assertParameterEquals(uParam, jParam)
 	}
 
@@ -92,7 +92,7 @@ class UmlToJavaParameterTest extends UmlToJavaTransformationTest {
 
 		val jParam = getCorrespondingParameter(uParam)
 		val jTypeClass = getCorrespondingClass(typeClass)
-		assertJavaParameterTraits(jParam, PARAMETER_NAME, createNamespaceReferenceFromClassifier(jTypeClass))
+		assertJavaParameterTraits(jParam, PARAMETER_NAME, createNamespaceClassifierReference(jTypeClass))
 		assertParameterEquals(uParam, jParam)
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlAttributeTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlAttributeTest.xtend
@@ -12,7 +12,6 @@ import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaStandardType.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlTypeUtil.*
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
@@ -21,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * Test class for testing the attribute reactions.
@@ -78,7 +78,7 @@ class JavaToUmlAttributeTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def testCreateAttribute() {
-		val attr = createJavaAttribute(STANDARD_ATTRIBUTE_NAME, createNamespaceReferenceFromClassifier(typeClass),
+		val attr = createJavaAttribute(STANDARD_ATTRIBUTE_NAME, createNamespaceClassifierReference(typeClass),
 			JavaVisibility.PRIVATE, false, false)
 		jClass.members += attr
 		propagate
@@ -125,7 +125,7 @@ class JavaToUmlAttributeTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def testChangeAttributeType() {
-		jAttr.typeReference = createNamespaceReferenceFromClassifier(typeClass)
+		jAttr.typeReference = createNamespaceClassifierReference(typeClass)
 		propagate
 
 		val uAttr = getCorrespondingAttribute(jAttr)

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlClassMethodTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlClassMethodTest.xtend
@@ -5,7 +5,6 @@ import org.emftext.language.java.members.ClassMethod
 import org.junit.jupiter.api.Test
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
@@ -18,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * A test class to test the class method reactions.
@@ -52,7 +52,7 @@ class JavaToUmlClassMethodTest extends JavaToUmlTransformationTest {
 		typeClass = createSimpleJavaClassWithCompilationUnit(TYPE_NAME)
 		typeClass2 = createSimpleJavaClassWithCompilationUnit(TYPE_NAME2)
 		jMeth = createSimpleJavaOperation(OPERATION_NAME)
-		jParam = createJavaParameter(PARAMETER_NAME, createNamespaceReferenceFromClassifier(typeClass2))
+		jParam = createJavaParameter(PARAMETER_NAME, createNamespaceClassifierReference(typeClass2))
 		jParamMeth = createJavaClassMethod(OPERATION_NAME2, TypesFactory.eINSTANCE.createBoolean, JavaVisibility.PUBLIC,
 			false, false, #[jParam])
 		jClass.members += jMeth
@@ -80,7 +80,7 @@ class JavaToUmlClassMethodTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def void testChangeReturnType() {
-		jMeth.typeReference = createNamespaceReferenceFromClassifier(typeClass)
+		jMeth.typeReference = createNamespaceClassifierReference(typeClass)
 		propagate
 
 		val uOperation = getCorrespondingMethod(jMeth)
@@ -208,7 +208,7 @@ class JavaToUmlClassMethodTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def testCreateParameter() {
-		val param = createJavaParameter(PARAMETER_NAME2, createNamespaceReferenceFromClassifier(typeClass))
+		val param = createJavaParameter(PARAMETER_NAME2, createNamespaceClassifierReference(typeClass))
 		jMeth.parameters += param
 		propagate
 
@@ -250,7 +250,7 @@ class JavaToUmlClassMethodTest extends JavaToUmlTransformationTest {
 	 */
 	@Test
 	def testChangeParameterType() {
-		jParam.typeReference = createNamespaceReferenceFromClassifier(typeClass)
+		jParam.typeReference = createNamespaceClassifierReference(typeClass)
 		propagate
 
 		val uParam = getCorrespondingParameter(jParam)

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlClassTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlClassTest.xtend
@@ -1,5 +1,6 @@
 package tools.vitruv.applications.umljava.tests.java2uml
 
+import java.nio.file.Path
 import org.eclipse.emf.ecore.util.EcoreUtil
 import org.eclipse.uml2.uml.Class
 import org.eclipse.uml2.uml.VisibilityKind
@@ -7,7 +8,6 @@ import org.junit.jupiter.api.Test
 
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.domains.java.util.JavaPersistenceHelper.*
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertEquals
-import java.nio.file.Path
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * A Test class to test classes and their traits.
@@ -164,7 +164,7 @@ class JavaToUmlClassTest extends JavaToUmlTransformationTest {
 	@Test
 	def testSuperClassChanged() {
 		val superClass = createSimpleJavaClassWithCompilationUnit(SUPER_CLASS_NAME)
-		jClass.extends = createNamespaceReferenceFromClassifier(superClass)
+		jClass.extends = createNamespaceClassifierReference(superClass)
 		propagate
 
 		val uClass = getCorrespondingClass(jClass)
@@ -180,7 +180,7 @@ class JavaToUmlClassTest extends JavaToUmlTransformationTest {
 	@Test
 	def testRemoveSuperClass() {
 		val superClass = createSimpleJavaClassWithCompilationUnit(SUPER_CLASS_NAME)
-		jClass.extends = createNamespaceReferenceFromClassifier(superClass)
+		jClass.extends = createNamespaceClassifierReference(superClass)
 		propagate
 
 		var uClass = getCorrespondingClass(jClass)
@@ -208,7 +208,7 @@ class JavaToUmlClassTest extends JavaToUmlTransformationTest {
 	@Test
 	def testAddClassImplement() {
 		val implInterface = createSimpleJavaInterfaceWithCompilationUnit(INTERFACE_NAME)
-		jClass.implements += createNamespaceReferenceFromClassifier(implInterface)
+		jClass.implements += createNamespaceClassifierReference(implInterface)
 		propagate
 
 		val uClass = getCorrespondingClass(jClass)
@@ -233,8 +233,8 @@ class JavaToUmlClassTest extends JavaToUmlTransformationTest {
 	def testRemoveClassImplement() {
 		val implInterface = createSimpleJavaInterfaceWithCompilationUnit(INTERFACE_NAME)
 		val implInterface2 = createSimpleJavaInterfaceWithCompilationUnit(INTERFACE_NAME2)
-		jClass.implements += createNamespaceReferenceFromClassifier(implInterface)
-		jClass.implements += createNamespaceReferenceFromClassifier(implInterface2)
+		jClass.implements += createNamespaceClassifierReference(implInterface)
+		jClass.implements += createNamespaceClassifierReference(implInterface2)
 		propagate
 
 		var uClass = getCorrespondingClass(jClass)

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlEnumTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlEnumTest.xtend
@@ -10,13 +10,13 @@ import tools.vitruv.applications.util.temporary.java.JavaVisibility
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import org.junit.jupiter.api.BeforeEach
 
 import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This class contains Tests for creating, deleting and renaming enums.
@@ -111,7 +111,7 @@ class JavaToUmlEnumTest extends JavaToUmlTransformationTest {
 	@Test
 	def void testAddEnumAttribute() {
 		val typeClass = createJavaClassWithCompilationUnit(TYPECLASS, JavaVisibility.PUBLIC, false, false)
-		val jAttr = createJavaAttribute(ATTRIBUTE_NAME, createNamespaceReferenceFromClassifier(typeClass),
+		val jAttr = createJavaAttribute(ATTRIBUTE_NAME, createNamespaceClassifierReference(typeClass),
 			JavaVisibility.PRIVATE, false, false)
 		jEnum.members += jAttr
 		propagate

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlInterfaceMethodTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlInterfaceMethodTest.xtend
@@ -1,7 +1,6 @@
 package tools.vitruv.applications.umljava.tests.java2uml
 
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import org.junit.jupiter.api.Test
@@ -11,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach
 
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This class contains test cases for the creation, renaming and deleting of interface methods.
@@ -77,7 +77,7 @@ class JavaToUmlInterfaceMethodTest extends JavaToUmlTransformationTest {
 
 	@Test
 	def testChangeInterfaceMethodReturnType() {
-		jMeth.typeReference = createNamespaceReferenceFromClassifier(typeClass)
+		jMeth.typeReference = createNamespaceClassifierReference(typeClass)
 		propagate
 
 		val uOperation = getCorrespondingMethod(jMeth)
@@ -88,7 +88,7 @@ class JavaToUmlInterfaceMethodTest extends JavaToUmlTransformationTest {
 
 	@Test
 	def testCreateInterfaceParameter() {
-		val jParam = createJavaParameter(PARAMETER_NAME, createNamespaceReferenceFromClassifier(typeClass))
+		val jParam = createJavaParameter(PARAMETER_NAME, createNamespaceClassifierReference(typeClass))
 		jMeth.parameters += jParam
 		propagate
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlInterfaceTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlInterfaceTest.xtend
@@ -7,11 +7,11 @@ import org.junit.jupiter.api.Test
 
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.UmlTestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import org.junit.jupiter.api.BeforeEach
 
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * A Test class for interface tests. Checks their creation, renaming, deleting and the 
@@ -63,7 +63,7 @@ class JavaToUmlInterfaceTest extends JavaToUmlTransformationTest {
 	@Test
 	def testAddSuperInterface() {
 		val superInterface = createSimpleJavaInterfaceWithCompilationUnit(SUPERINTERFACENAME_1)
-		jInterface.extends += createNamespaceReferenceFromClassifier(superInterface)
+		jInterface.extends += createNamespaceClassifierReference(superInterface)
 		propagate
 
 		val uInterface = getCorrespondingInterface(jInterface)
@@ -76,8 +76,8 @@ class JavaToUmlInterfaceTest extends JavaToUmlTransformationTest {
 	def testRemoveSuperInterface() {
 		val superInterface = createSimpleJavaInterfaceWithCompilationUnit(SUPERINTERFACENAME_1)
 		val superInterface2 = createSimpleJavaInterfaceWithCompilationUnit(SUPERINTERFACENAME_2)
-		jInterface.extends += createNamespaceReferenceFromClassifier(superInterface)
-		jInterface.extends += createNamespaceReferenceFromClassifier(superInterface2)
+		jInterface.extends += createNamespaceClassifierReference(superInterface)
+		jInterface.extends += createNamespaceClassifierReference(superInterface2)
 		propagate
 
 		jInterface.extends.remove(0)

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAssociationTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAssociationTest.xtend
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertTrue
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This test class contains basic test for associations.
@@ -44,7 +45,7 @@ class UmlToJavaAssociationTest extends UmlToJavaTransformationTest {
 		val jClass1 = getCorrespondingClass(uClass1)
 		val jAttribute = getCorrespondingAttribute(uAttribute)
 		val jClass2 = getCorrespondingClass(uClass2)
-		assertJavaElementHasTypeRef(jAttribute, createNamespaceReferenceFromClassifier(jClass2))
+		assertJavaElementHasTypeRef(jAttribute, createNamespaceClassifierReference(jClass2))
 		assertClassEquals(uClass1, jClass1)
 		assertAttributeEquals(uAttribute, jAttribute)
 	}
@@ -59,7 +60,7 @@ class UmlToJavaAssociationTest extends UmlToJavaTransformationTest {
 		val jClass1 = getCorrespondingClass(uClass1)
 		val jAttribute = getCorrespondingAttribute(uAttribute)
 		val jClass2 = getCorrespondingClass(uClass2)
-		assertJavaElementHasTypeRef(jAttribute, createNamespaceReferenceFromClassifier(jClass2))
+		assertJavaElementHasTypeRef(jAttribute, createNamespaceClassifierReference(jClass2))
 		assertClassEquals(uClass1, jClass1)
 		assertTrue(javaGetterForAttributeExists(jAttribute))
 		assertTrue(javaSetterForAttributeExists(jAttribute))
@@ -78,7 +79,7 @@ class UmlToJavaAssociationTest extends UmlToJavaTransformationTest {
 		val arrayListReference = getClassifierFromTypeReference(jAttribute.typeReference)
 		assertEquals("ArrayList", arrayListReference.name)
 		val innerTypeRef = getInnerTypeReferenceOfCollectionTypeReference(jAttribute.typeReference)
-		assertTypeEquals(createNamespaceReferenceFromClassifier(jClass2), innerTypeRef)
+		assertTypeEquals(createNamespaceClassifierReference(jClass2), innerTypeRef)
 	}
 
 }

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAttributeTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAttributeTest.xtend
@@ -16,9 +16,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlPropertyAndAssociationUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This Test class checks the creating, deleting and modifying of attributes in den uml to java
@@ -70,7 +70,7 @@ class UmlToJavaAttributeTest extends UmlToJavaTransformationTest {
 		val jtypeClass = getCorrespondingClass(typeClass)
 		val jAttr = getCorrespondingAttribute(attr)
 		assertJavaAttributeTraits(jAttr, STANDARD_ATTRIBUTE_NAME, JavaVisibility.PUBLIC,
-			createNamespaceReferenceFromClassifier(jtypeClass), false, false, jClass)
+			createNamespaceClassifierReference(jtypeClass), false, false, jClass)
 		assertAttributeEquals(attr, jAttr)
 
 	}

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaClassMethodTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaClassMethodTest.xtend
@@ -16,9 +16,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlOperationAndParameterUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * A Test class to test class methods and its traits.
@@ -85,7 +85,7 @@ class UmlToJavaClassMethodTest extends UmlToJavaTransformationTest {
 
 		val jMethod = getCorrespondingClassMethod(uOperation)
 		val jTypeClass = getCorrespondingClass(typeClass)
-		assertJavaElementHasTypeRef(jMethod, createNamespaceReferenceFromClassifier(jTypeClass))
+		assertJavaElementHasTypeRef(jMethod, createNamespaceClassifierReference(jTypeClass))
 		assertClassMethodEquals(uOperation, jMethod)
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaEnumTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaEnumTest.xtend
@@ -8,13 +8,13 @@ import tools.vitruv.applications.util.temporary.java.JavaVisibility
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlOperationAndParameterUtil.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * A Test class for creating, renaming and deleting enums.
@@ -118,7 +118,7 @@ class UmlToJavaEnumTest extends UmlToJavaTransformationTest {
 		val jTypeClass = getCorrespondingClass(typeClass)
 		val jAttr = getCorrespondingAttribute(attr)
 		assertJavaAttributeTraits(jAttr, ATTRIBUTE_NAME, JavaVisibility.PUBLIC,
-			createNamespaceReferenceFromClassifier(jTypeClass), false, false, jEnum)
+			createNamespaceClassifierReference(jTypeClass), false, false, jEnum)
 		assertAttributeEquals(attr, jAttr)
 
 	}

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaInterfaceMethodTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaInterfaceMethodTest.xtend
@@ -9,9 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlOperationAndParameterUtil.*
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This class provides basic tests for creating, deleting and changing traits of interface methods.
@@ -94,7 +94,7 @@ class UmlToJavaInterfaceMethodTest extends UmlToJavaTransformationTest {
 
 		val jMethod = getCorrespondingInterfaceMethod(uOperation)
 		val jTypeClass = getCorrespondingClass(typeClass)
-		assertJavaElementHasTypeRef(jMethod, createNamespaceReferenceFromClassifier(jTypeClass))
+		assertJavaElementHasTypeRef(jMethod, createNamespaceClassifierReference(jTypeClass))
 		assertInterfaceMethodEquals(uOperation, jMethod)
 	}
 }

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaParameterTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaParameterTest.xtend
@@ -11,7 +11,6 @@ import tools.vitruv.applications.util.temporary.uml.UmlTypeUtil
 
 import static tools.vitruv.applications.umljava.tests.util.JavaTestUtil.*
 import static tools.vitruv.applications.umljava.tests.util.TestUtil.*
-import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static tools.vitruv.applications.util.temporary.uml.UmlOperationAndParameterUtil.*
 import org.junit.jupiter.api.BeforeEach
@@ -19,6 +18,7 @@ import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertEquals
+import static tools.vitruv.domains.java.util.JavaModificationUtil.*
 
 /**
  * This class tests the change of parameter traits.
@@ -60,7 +60,7 @@ class UmlToJavaParameterTest extends UmlToJavaTransformationTest {
 
 		val jParam = getCorrespondingParameter(uParam)
 		val jTypeClass = getCorrespondingClass(typeClass)
-		assertJavaParameterTraits(jParam, STANDARD_PARAMETER_NAME, createNamespaceReferenceFromClassifier(jTypeClass))
+		assertJavaParameterTraits(jParam, STANDARD_PARAMETER_NAME, createNamespaceClassifierReference(jTypeClass))
 		assertParameterEquals(uParam, jParam)
 	}
 
@@ -92,7 +92,7 @@ class UmlToJavaParameterTest extends UmlToJavaTransformationTest {
 
 		val jParam = getCorrespondingParameter(uParam)
 		val jTypeClass = getCorrespondingClass(typeClass)
-		assertJavaParameterTraits(jParam, PARAMETER_NAME, createNamespaceReferenceFromClassifier(jTypeClass))
+		assertJavaParameterTraits(jParam, PARAMETER_NAME, createNamespaceClassifierReference(jTypeClass))
 		assertParameterEquals(uParam, jParam)
 	}
 


### PR DESCRIPTION
Unifies the namespace reference helper methods to only use those of the Java domain rather than the ones from the temporary util package.
Relates to #3 
Relates to (but does not require) [Vitruv-Domains-ComponentBasedSystems#103](https://github.com/vitruv-tools/Vitruv-Domains-ComponentBasedSystems/pull/103) 