### PR TITLE
Properly Transform Package Names Starting Uppercase in UML

### DIFF
--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -575,8 +575,8 @@ routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
     }
     action {
         call {
-            var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList)
-            modified = jPackage.updateName(uPackage.name) || modified 
+            var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList.map[toFirstLower])
+            modified = jPackage.updateName(uPackage.name.toFirstLower) || modified
             if (modified) {
                 persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
                 for (compUnit : copyOf(jPackage.compilationUnits)) {

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaPackageTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaPackageTest.xtend
@@ -46,7 +46,32 @@ class UmlToJavaPackageTest extends UmlToJavaTransformationTest {
 		assertEquals(PACKAGE_NAME, jPackage.name)
 		assertPackageEquals(uPackage, jPackage)
 	}
+	
+	@Test
+	def testCreateUppercasePackage() {
+		val uPackage = createUmlPackageAndAddToSuperPackage(PACKAGE_NAME.toFirstUpper, rootElement)
+		propagate
 
+		val jPackage = getCorrespondingPackage(uPackage)
+		assertEquals(PACKAGE_NAME, jPackage.name)
+		assertPackageEquals(uPackage, jPackage)
+	}
+
+	@Test
+	def testCreateNestedUppercasePackage() {
+		uPackageLevel1.name = uPackageLevel1.name.toFirstUpper
+		propagate
+		
+		val uPackageLevel2 = createUmlPackageAndAddToSuperPackage(PACKAGE_LEVEL_2.toFirstUpper, uPackageLevel1)
+		propagate
+
+		val jPackageLevel1 = getCorrespondingPackage(uPackageLevel1)
+		val jPackageLevel2 = getCorrespondingPackage(uPackageLevel2)
+		assertEquals(PACKAGE_LEVEL_2, jPackageLevel2.name)
+		assertEquals(#[jPackageLevel1.name], jPackageLevel2.namespaces)
+		assertPackageEquals(uPackageLevel2, jPackageLevel2)
+	}
+	
 	@Test
 	def testCreateNestedPackage() {
 		val uPackageLevel2 = createUmlPackageAndAddToSuperPackage(PACKAGE_LEVEL_2, uPackageLevel1)

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/TestUtil.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/TestUtil.xtend
@@ -85,8 +85,8 @@ class TestUtil {
 	 */
 	def static dispatch void assertPackageEquals(org.eclipse.uml2.uml.Package uPackage,
 		org.emftext.language.java.containers.Package jPackage) {
-		assertEquals(uPackage.name, jPackage.name)
-		assertEquals(getUmlParentNamespaceAsStringList(uPackage), jPackage.namespaces)
+		assertEquals(uPackage.name.toFirstLower, jPackage.name)
+		assertEquals(getUmlParentNamespaceAsStringList(uPackage).map[toFirstLower], jPackage.namespaces)
 	}
 
 	def static dispatch void assertPackageEquals(org.eclipse.uml2.uml.Package uPackage,


### PR DESCRIPTION
This PR ensures that UML package names starting uppercase are transformed into packages starting lowercase in Java. It also adds test cases for that situation.

It prepares for #160 to also work on Windows-based systems, as the uppercase tests do not work there properly because of different handling of differences in capitalization in Windows and Unix file systems.