### PR TITLE
Correspondence-Related Transformations Improvements

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -938,11 +938,9 @@ reaction DeletedProvidedRoleFromComponent {
 
 routine removeProvidedRole(pcm::ProvidedRole providedRole) {
 	match {
-		val requiredInterfaceImport = retrieve java::ClassifierImport corresponding to providedRole
 		val typeReference = retrieve java::TypeReference corresponding to providedRole
 	}
 	action {
-		delete requiredInterfaceImport
 		delete typeReference.getPureClassifierReference // seems to be necessary to properly delete reference if it is a NamespaceClassifierReference
 		delete typeReference
 	}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -898,11 +898,6 @@ routine addProvidedRole(pcm::OperationProvidedRole providedRole) {
 		val javaClass = retrieve java::Class corresponding to providedRole.providingEntity_ProvidedRole
 	}
 	action { 
-		// TODO HK This should be partly in the context of the compilation unit
-		val interfaceImport = create java::ClassifierImport and initialize {
-			addImportToCompilationUnitOfClassifier(interfaceImport, javaClass, operationProvidingInterface)
-		}
-		add correspondence between interfaceImport and providedRole
 		val namespaceClassifierReference = create java::NamespaceClassifierReference and initialize {
 			createNamespaceClassifierReference(namespaceClassifierReference, operationProvidingInterface)
 		}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -257,6 +257,42 @@ reaction JavaPackageRenamed {
 	}
 }
 
+reaction JavaPackageRemoved {
+	after element java::Package deleted
+	call {
+		removeRepository(affectedEObject)
+		removeSystem(affectedEObject)
+		removeComponent(affectedEObject)
+	}
+}
+
+routine removeRepository(java::Package javaPackage) {
+	match {
+		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged with "package_root"
+	}
+	action {
+		delete pcmRepository
+	}
+}
+
+routine removeSystem(java::Package javaPackage) {
+	match {
+		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged with "root_system"
+	}
+	action {
+		delete pcmSystem
+	}
+}
+
+routine removeComponent(java::Package javaPackage) {
+	match {
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaPackage
+	}
+	action {
+		delete pcmComponent
+	}
+}
+
 routine renameRepository(java::Package javaPackage) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged with "package_root"

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -140,28 +140,30 @@ reaction RepositoryDeleted {
 routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 	match {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-		val umlRepositoryPkg = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		val umlRepositoryPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val umlContractsPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		val umlDatatypesPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	action {
 		call{
-			// remove correspondences
-			ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(correspondenceModel,
-				pcmRepo, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
+			// remove correspondences and UML model contents if desired
+			umlRepositoryPkg.ifPresent[umlRepositoryPackage |
+				ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
+					correspondenceModel, pcmRepo, umlRepositoryPackage, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
+				// ask if the corresponding model should also be deleted
+				val deleteCorrespondingUmlRepository = userInteractor.confirmationDialogBuilder
+						.message(DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
+	
+				if (deleteCorrespondingUmlRepository) {// DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL_YES
+					umlContractsPkg.ifPresent[umlRepositoryPackage.packagedElements -= it]
+					umlDatatypesPkg.ifPresent[umlRepositoryPackage.packagedElements -= it]
+					umlModel.packagedElements -= umlRepositoryPackage // remove parent package last to allow the recorder to notice the child package deletion
+				}
+			]
 			umlContractsPkg.ifPresent[ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
 				correspondenceModel, pcmRepo, it, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)]
 			umlDatatypesPkg.ifPresent[ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
 				correspondenceModel, pcmRepo, it, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)]
-			// ask if the corresponding model should also be deleted
-			val deleteCorrespondingUmlRepository = userInteractor.confirmationDialogBuilder
-					.message(DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
-
-			if (deleteCorrespondingUmlRepository) {// DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL_YES
-				umlContractsPkg.ifPresent[umlRepositoryPkg.packagedElements -= it]
-				umlDatatypesPkg.ifPresent[umlRepositoryPkg.packagedElements -= it]
-				umlModel.packagedElements -= umlRepositoryPkg // remove parent package last to allow the recorder to notice the child package deletion
-			}
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -60,7 +60,8 @@ routine insertCorrespondingRepositoryOrSystem(uml::Package umlPackage, uml::Pack
 				//no move-operation necessary since both repository and system are root elements
 			} else {
 				// nested component repositories and component based systems are not allowed
-				deleteCorrespondingRepositoryOrSystem(umlPackage)
+				deleteCorrespondingRepository(umlPackage)
+				deleteCorrespondingSystem(umlPackage)
 			}
 		}
 	}
@@ -212,20 +213,9 @@ routine createCorrespondingSystem(uml::Package umlPkg, uml::Package umlParentPkg
 
 reaction RepositoryOrSystemPackageDeleted {
 	after element uml::Package deleted
-	call deleteCorrespondingRepositoryOrSystem(affectedEObject)
-}
-
-
-routine deleteCorrespondingRepositoryOrSystem(uml::Package umlPackage) {
-	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmSystem = retrieve optional pcm::System corresponding to umlPackage tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
-	}
-	action {
-		call {
-			pcmRepository.ifPresent[deleteCorrespondingRepository(umlPackage)]
-			pcmSystem.ifPresent[deleteCorrespondingSystem(umlPackage)]
-		}
+	call {
+		deleteCorrespondingRepository(affectedEObject)
+		deleteCorrespondingSystem(affectedEObject)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -32,298 +32,298 @@ execute actions in Java
 
 
 reaction UmlClassInserted {
-    after element uml::Class inserted in uml::Package[packagedElement]
-    call {
-        createOrFindJavaClass(newValue)
-        insertJavaClassifier(newValue, affectedEObject)
-    }
+	after element uml::Class inserted in uml::Package[packagedElement]
+	call {
+		createOrFindJavaClass(newValue)
+		insertJavaClassifier(newValue, affectedEObject)
+	}
 }
-    
+	
 routine createOrFindJavaClass(uml::Classifier umlClassifier) {
-    match{
-        require absence of java::Class corresponding to umlClassifier
-        require absence of java::CompilationUnit corresponding to umlClassifier
-        val javaPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
-    }
-    action {
-        call {
-           if (javaPackage.isPresent) {
-               createOrFindJavaClassInPackage(umlClassifier, javaPackage.get)
-           } else {
-                createJavaClass(umlClassifier)
-           }
-        }
-    }
+	match{
+		require absence of java::Class corresponding to umlClassifier
+		require absence of java::CompilationUnit corresponding to umlClassifier
+		val javaPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
+	}
+	action {
+		call {
+		   if (javaPackage.isPresent) {
+			   createOrFindJavaClassInPackage(umlClassifier, javaPackage.get)
+		   } else {
+				createJavaClass(umlClassifier)
+		   }
+		}
+	}
 }
 
 routine createOrFindJavaClassInPackage(uml::Classifier umlClassifier, java::Package javaPackage) {
-    action {
-        call {
-            val foundClass = findClassifier(umlClassifier.name, javaPackage, org.emftext.language.java.classifiers.Class)
-            if(foundClass === null) {
-                createJavaClass(umlClassifier)
-            } else {
-                addMissingClassifierCorrespondence(umlClassifier, foundClass)
-            }
-        }
-    }
+	action {
+		call {
+			val foundClass = findClassifier(umlClassifier.name, javaPackage, org.emftext.language.java.classifiers.Class)
+			if(foundClass === null) {
+				createJavaClass(umlClassifier)
+			} else {
+				addMissingClassifierCorrespondence(umlClassifier, foundClass)
+			}
+		}
+	}
 }
 
 routine createJavaClass(uml::Classifier umlClassifier) {
-    action {
-        val javaClassifier = create java::Class and initialize {
-            javaClassifier.name = umlClassifier.name
-            javaClassifier.makePublic
-        }
-        call createJavaCompilationUnit (umlClassifier, javaClassifier)
-        add correspondence between umlClassifier and javaClassifier
-    }
+	action {
+		val javaClassifier = create java::Class and initialize {
+			javaClassifier.name = umlClassifier.name
+			javaClassifier.makePublic
+		}
+		call createJavaCompilationUnit (umlClassifier, javaClassifier)
+		add correspondence between umlClassifier and javaClassifier
+	}
 }
 
 routine addMissingClassifierCorrespondence(uml::Classifier umlClassifier, java::ConcreteClassifier javaClassifier) {
-    action {
-        add correspondence between javaClassifier and umlClassifier
-        add correspondence between javaClassifier.containingCompilationUnit and umlClassifier
-    }
+	action {
+		add correspondence between javaClassifier and umlClassifier
+		add correspondence between javaClassifier.containingCompilationUnit and umlClassifier
+	}
 }
 
 routine createJavaCompilationUnit(uml::Classifier umlClassifier, java::ConcreteClassifier jClassifier) {
-    match {
-        require absence of java::CompilationUnit corresponding to umlClassifier
-    }
-    action {
-        val javaCompilationUnit = create java::CompilationUnit and initialize {
-            javaCompilationUnit.classifiers += jClassifier
-        }
-        add correspondence between umlClassifier and javaCompilationUnit
-    }
+	match {
+		require absence of java::CompilationUnit corresponding to umlClassifier
+	}
+	action {
+		val javaCompilationUnit = create java::CompilationUnit and initialize {
+			javaCompilationUnit.classifiers += jClassifier
+		}
+		add correspondence between umlClassifier and javaCompilationUnit
+	}
 }
 
 routine insertJavaClassifier(uml::Classifier umlClassifier, uml::Package umlPackage) {
-    match {
-        val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-        val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifier
-        val javaPackage = retrieve optional java::Package corresponding to umlPackage
-    }
-    action {
-        update javaCompilationUnit {
-            var modified = javaCompilationUnit.updateNamespaces(javaPackage)
-            val newName = getCompilationUnitName(javaPackage, javaClassifier.name)
-            modified = javaCompilationUnit.updateName(newName) || modified
-            if (modified) {
-                persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit))
-            }
-        }
-        call javaPackage.ifPresent [
-            if (!compilationUnits.contains(javaCompilationUnit)) {
-                compilationUnits += javaCompilationUnit
-            }
-        ]
-    }
+	match {
+		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
+		val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifier
+		val javaPackage = retrieve optional java::Package corresponding to umlPackage
+	}
+	action {
+		update javaCompilationUnit {
+			var modified = javaCompilationUnit.updateNamespaces(javaPackage)
+			val newName = getCompilationUnitName(javaPackage, javaClassifier.name)
+			modified = javaCompilationUnit.updateName(newName) || modified
+			if (modified) {
+				persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit))
+			}
+		}
+		call javaPackage.ifPresent [
+			if (!compilationUnits.contains(javaCompilationUnit)) {
+				compilationUnits += javaCompilationUnit
+			}
+		]
+	}
 }
 
 reaction UmlClassifierRenamed {
-    after attribute replaced at uml::Classifier[name]
-    call renameJavaClassifier(affectedEObject)
+	after attribute replaced at uml::Classifier[name]
+	call renameJavaClassifier(affectedEObject)
 }
 
 routine renameJavaClassifier(uml::Classifier umlClassifier) {
-    match {
-        val jPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
-        val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-        val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifier
-        check umlClassifier.name != javaClassifier.name
-    }
-    action {
-        update javaClassifier {
-            javaClassifier.name = umlClassifier.name
-        }
-        call insertJavaClassifier(umlClassifier, umlClassifier.eContainer as org.eclipse.uml2.uml.Package)
-    }
+	match {
+		val jPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
+		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
+		val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifier
+		check umlClassifier.name != javaClassifier.name
+	}
+	action {
+		update javaClassifier {
+			javaClassifier.name = umlClassifier.name
+		}
+		call insertJavaClassifier(umlClassifier, umlClassifier.eContainer as org.eclipse.uml2.uml.Package)
+	}
 }
 
 reaction UmlClassifierDeleted {
-    after element uml::Classifier deleted
-    call deleteJavaClass(affectedEObject)
+	after element uml::Classifier deleted
+	call deleteJavaClass(affectedEObject)
 }
 
 routine deleteJavaClass(uml::Classifier umlClassifer) {
-    match {
-        val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifer
-        val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifer
-    }
-    action {
-        delete javaClassifier
-        delete javaCompilationUnit
-    }
+	match {
+		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifer
+		val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifer
+	}
+	action {
+		delete javaClassifier
+		delete javaCompilationUnit
+	}
 }
 
 reaction UmlClassMadeFinal {
-    after attribute replaced at uml::Class[isFinalSpecialization]
-    call setJavaClassFinal(affectedEObject)
+	after attribute replaced at uml::Class[isFinalSpecialization]
+	call setJavaClassFinal(affectedEObject)
 }
 
 routine setJavaClassFinal(uml::Class umlClass) {
-    match {
-        val jClass = retrieve java::Class corresponding to umlClass
-    }
-    action {
-        update jClass {
-            jClass.final = umlClass.finalSpecialization
-        }
-    }
+	match {
+		val jClass = retrieve java::Class corresponding to umlClass
+	}
+	action {
+		update jClass {
+			jClass.final = umlClass.finalSpecialization
+		}
+	}
 }
 
 reaction UmlClassMadeAbstract {
-    after attribute replaced at uml::Class[isAbstract]
-    call setJavaClassAbstract(affectedEObject)
+	after attribute replaced at uml::Class[isAbstract]
+	call setJavaClassAbstract(affectedEObject)
 }
 
 routine setJavaClassAbstract(uml::Class umlClass) {
-    match {
-        val jClass = retrieve java::Class corresponding to umlClass
-    }
-    action {
-        update jClass {
-            jClass.abstract = umlClass.abstract
-        }
-    }
+	match {
+		val jClass = retrieve java::Class corresponding to umlClass
+	}
+	action {
+		update jClass {
+			jClass.abstract = umlClass.abstract
+		}
+	}
 }
 
 reaction UmlSuperClassAdded {
-    after element uml::Generalization inserted in uml::Class[generalization]
-    call addJavaSuperClass(affectedEObject, newValue)
+	after element uml::Generalization inserted in uml::Class[generalization]
+	call addJavaSuperClass(affectedEObject, newValue)
 }
 
 routine addJavaSuperClass(uml::Class uClass, uml::Generalization uGeneralization) {
-    match {
-        val jClass = retrieve java::Class corresponding to uClass
-        val jSuperClass = retrieve java::Class corresponding to uGeneralization.general
-        require absence of java::TypeReference corresponding to uGeneralization
-    }
-    action {
-        execute {
-            if (uClass.generals.size == 1) {
-                var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null, userInteractor)
-                addJavaImport(jClass.containingCompilationUnit, typeReference)
-                jClass.extends = typeReference
-                addGeneralizationCorrespondence(uGeneralization, typeReference)
-            } else {
-                userInteractor.notificationDialogBuilder.message("Can not synchronize multiple inheritance for " + uClass)
-                    .title("Warning").notificationType(NotificationType.WARNING).windowModality(WindowModality.MODAL)
-                    .startInteraction()
-                logger.warn("Routine not executed: Tried to set multiple inheritance for " + uClass)
-            }
-        }
-    }
+	match {
+		val jClass = retrieve java::Class corresponding to uClass
+		val jSuperClass = retrieve java::Class corresponding to uGeneralization.general
+		require absence of java::TypeReference corresponding to uGeneralization
+	}
+	action {
+		execute {
+			if (uClass.generals.size == 1) {
+				var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null, userInteractor)
+				addJavaImport(jClass.containingCompilationUnit, typeReference)
+				jClass.extends = typeReference
+				addGeneralizationCorrespondence(uGeneralization, typeReference)
+			} else {
+				userInteractor.notificationDialogBuilder.message("Can not synchronize multiple inheritance for " + uClass)
+					.title("Warning").notificationType(NotificationType.WARNING).windowModality(WindowModality.MODAL)
+					.startInteraction()
+				logger.warn("Routine not executed: Tried to set multiple inheritance for " + uClass)
+			}
+		}
+	}
 }
 
 reaction UmlSuperClassDeleted {
-    after element uml::Generalization removed from uml::Class[generalization]
-    call deleteJavaSuperClass(oldValue)
+	after element uml::Generalization removed from uml::Class[generalization]
+	call deleteJavaSuperClass(oldValue)
 }
 
 routine deleteJavaSuperClass(uml::Generalization uGeneralization) {
-    match {
-        val jReference = retrieve java::TypeReference corresponding to uGeneralization
-    }
-    action {
-        delete jReference
-    }
+	match {
+		val jReference = retrieve java::TypeReference corresponding to uGeneralization
+	}
+	action {
+		delete jReference
+	}
 }
 
 reaction UmlSuperClassReplaced{
-    after element uml::Class replaced at uml::Generalization[general]
-    with {affectedEObject.specific !== null && affectedEObject.specific instanceof Class}
-    call {
-        val uGeneralization = affectedEObject
-        val uClass = affectedEObject.specific as Class
-        if (oldValue !== null)
-            deleteJavaSuperClass(uGeneralization)
-        if (newValue !== null)
-            addJavaSuperClass(uClass, uGeneralization)
-    }
+	after element uml::Class replaced at uml::Generalization[general]
+	with {affectedEObject.specific !== null && affectedEObject.specific instanceof Class}
+	call {
+		val uGeneralization = affectedEObject
+		val uClass = affectedEObject.specific as Class
+		if (oldValue !== null)
+			deleteJavaSuperClass(uGeneralization)
+		if (newValue !== null)
+			addJavaSuperClass(uClass, uGeneralization)
+	}
 }
 
 reaction UmlInterfaceRealizationCreated {
-    after element uml::InterfaceRealization inserted in uml::Class[interfaceRealization]
-    call createJavaClassImplementsReference(newValue, affectedEObject)
+	after element uml::InterfaceRealization inserted in uml::Class[interfaceRealization]
+	call createJavaClassImplementsReference(newValue, affectedEObject)
 }
 
 routine createJavaClassImplementsReference(uml::InterfaceRealization uRealization, uml::Class uClass){
-    match {
-        val jClass = retrieve java::Class corresponding to uClass
-        val jInterface = retrieve java::Interface corresponding to uRealization.contract
-        require absence of java::TypeReference corresponding to uRealization
-    }
-    action {
-        execute {
-            val matchingReference = jClass.implements.filter[target == jInterface]
-            checkState(matchingReference.size <= 1, "There is more than one implementation of Java interface %s in class %s", jInterface, jClass)
-            if (matchingReference.size == 1) {
-                addImplementsCorrespondence(uRealization, matchingReference.get(0))
-            } else {
-                var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null, userInteractor)
-                addJavaImport(jClass.containingCompilationUnit, typeReference)
-                jClass.implements += typeReference
-                addImplementsCorrespondence(uRealization, typeReference)
-            }
-            
-        }
-    }
+	match {
+		val jClass = retrieve java::Class corresponding to uClass
+		val jInterface = retrieve java::Interface corresponding to uRealization.contract
+		require absence of java::TypeReference corresponding to uRealization
+	}
+	action {
+		execute {
+			val matchingReference = jClass.implements.filter[target == jInterface]
+			checkState(matchingReference.size <= 1, "There is more than one implementation of Java interface %s in class %s", jInterface, jClass)
+			if (matchingReference.size == 1) {
+				addImplementsCorrespondence(uRealization, matchingReference.get(0))
+			} else {
+				var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null, userInteractor)
+				addJavaImport(jClass.containingCompilationUnit, typeReference)
+				jClass.implements += typeReference
+				addImplementsCorrespondence(uRealization, typeReference)
+			}
+			
+		}
+	}
 }
 
 routine addImplementsCorrespondence(uml::InterfaceRealization uRealization, java::TypeReference jReference) {
-    match {
-        require absence of java::TypeReference corresponding to uRealization
-    }
-    action {
-        add correspondence between uRealization and jReference
-    }
+	match {
+		require absence of java::TypeReference corresponding to uRealization
+	}
+	action {
+		add correspondence between uRealization and jReference
+	}
 }
 
 reaction UmlInterfaceRealizationRemoved {
-    after element uml::InterfaceRealization removed from uml::Class[interfaceRealization]
-    call deleteJavaClassImplementsReference(oldValue, affectedEObject)
+	after element uml::InterfaceRealization removed from uml::Class[interfaceRealization]
+	call deleteJavaClassImplementsReference(oldValue, affectedEObject)
 }
 
 routine deleteJavaClassImplementsReference(uml::InterfaceRealization uRealization, uml::Class uClass) {
-    match {
-        val jClass = retrieve java::Class corresponding to uClass
-        val jReference = retrieve java::TypeReference corresponding to uRealization
-    }
-    action {
-        update uRealization {
-            uRealization.clients -= uClass
-        }
-        delete jReference
-    }
+	match {
+		val jClass = retrieve java::Class corresponding to uClass
+		val jReference = retrieve java::TypeReference corresponding to uRealization
+	}
+	action {
+		update uRealization {
+			uRealization.clients -= uClass
+		}
+		delete jReference
+	}
 }
 
 reaction UmlInterfaceRealizationReplaced {
-    after element replaced at uml::InterfaceRealization[contract]
-    with affectedEObject.implementingClassifier !== null
-        && affectedEObject.implementingClassifier instanceof Class
-    call {
-        val uRealization = affectedEObject
-        val uClass = affectedEObject.implementingClassifier as Class
-        if (oldValue !== null)
-            deleteJavaClassImplementsReference(uRealization, uClass)
-        if (newValue !== null)
-            createJavaClassImplementsReference(uRealization, uClass)
-    }
+	after element replaced at uml::InterfaceRealization[contract]
+	with affectedEObject.implementingClassifier !== null
+		&& affectedEObject.implementingClassifier instanceof Class
+	call {
+		val uRealization = affectedEObject
+		val uClass = affectedEObject.implementingClassifier as Class
+		if (oldValue !== null)
+			deleteJavaClassImplementsReference(uRealization, uClass)
+		if (newValue !== null)
+			createJavaClassImplementsReference(uRealization, uClass)
+	}
 }
 
 
 
 reaction UmlDataTypeInserted {
-    after element uml::DataType inserted in uml::Package[packagedElement]
-    with !(newValue instanceof PrimitiveType)
-        && !(newValue instanceof Enumeration)
-    call {
-        createOrFindJavaClass(newValue)
-        insertJavaClassifier(newValue, affectedEObject)
-    }
+	after element uml::DataType inserted in uml::Package[packagedElement]
+	with !(newValue instanceof PrimitiveType)
+		&& !(newValue instanceof Enumeration)
+	call {
+		createOrFindJavaClass(newValue)
+		insertJavaClassifier(newValue, affectedEObject)
+	}
 }
 
 //===========================================
@@ -332,109 +332,109 @@ reaction UmlDataTypeInserted {
 
 
 reaction UmlInterfaceInserted {
-    after element uml::Interface inserted in uml::Package[packagedElement]
-    call {
-        createOrFindJavaInterface(newValue)
-        insertJavaClassifier(newValue, affectedEObject)
-    }
+	after element uml::Interface inserted in uml::Package[packagedElement]
+	call {
+		createOrFindJavaInterface(newValue)
+		insertJavaClassifier(newValue, affectedEObject)
+	}
 }
 
 routine createOrFindJavaInterface(uml::Interface umlInterface) {
-    match {
-        require absence of java::Interface corresponding to umlInterface
-        val javaPackage = retrieve optional java::Package corresponding to umlInterface.eContainer
-    }
-    action {
-        call {
-            if (javaPackage.isPresent) {
-                createOrFindJavaInterfaceInPackage(umlInterface, javaPackage.get)
-            } else {
-                createJavaInterface(umlInterface)
-            }
-        }
-    }
+	match {
+		require absence of java::Interface corresponding to umlInterface
+		val javaPackage = retrieve optional java::Package corresponding to umlInterface.eContainer
+	}
+	action {
+		call {
+			if (javaPackage.isPresent) {
+				createOrFindJavaInterfaceInPackage(umlInterface, javaPackage.get)
+			} else {
+				createJavaInterface(umlInterface)
+			}
+		}
+	}
 }
 
 routine createOrFindJavaInterfaceInPackage(uml::Interface umlInterface, java::Package javaPackage) {
-    action {
-        call {
-            val foundInterface = findClassifier(umlInterface.name, javaPackage, org.emftext.language.java.classifiers.Interface)
-            if(foundInterface === null) {
-                createJavaInterface(umlInterface)
-            } else {
-                addMissingClassifierCorrespondence(umlInterface, foundInterface)
-            }
-        }
-    }
+	action {
+		call {
+			val foundInterface = findClassifier(umlInterface.name, javaPackage, org.emftext.language.java.classifiers.Interface)
+			if(foundInterface === null) {
+				createJavaInterface(umlInterface)
+			} else {
+				addMissingClassifierCorrespondence(umlInterface, foundInterface)
+			}
+		}
+	}
 }
 
 routine createJavaInterface(uml::Interface umlInterface) {
-    match {
-        require absence of java::Interface corresponding to umlInterface
-    }
-    action {
-        val javaInterface = create java::Interface and initialize {
-            javaInterface.name = umlInterface.name
-            javaInterface.makePublic
-        }
-        call createJavaCompilationUnit(umlInterface, javaInterface)
-        add correspondence between umlInterface and javaInterface
-    }
+	match {
+		require absence of java::Interface corresponding to umlInterface
+	}
+	action {
+		val javaInterface = create java::Interface and initialize {
+			javaInterface.name = umlInterface.name
+			javaInterface.makePublic
+		}
+		call createJavaCompilationUnit(umlInterface, javaInterface)
+		add correspondence between umlInterface and javaInterface
+	}
 }
 
 reaction UmlSuperInterfaceAdded {
-    after element uml::Generalization inserted in uml::Interface[generalization]
-    call addJavaSuperInterface(affectedEObject, newValue)
+	after element uml::Generalization inserted in uml::Interface[generalization]
+	call addJavaSuperInterface(affectedEObject, newValue)
 }
 
 routine addJavaSuperInterface(uml::Interface uInterface, uml::Generalization uGeneralization) {
-    match {
-        val jInterface = retrieve java::Interface corresponding to uInterface
-        val jSuperInterface = retrieve java::Interface corresponding to uGeneralization.general
-        require absence of java::TypeReference corresponding to uGeneralization
-    }
-    action {
-        execute{
-            var typeReference = createTypeReference(uGeneralization.general as Interface, Optional.^of(jSuperInterface), null, userInteractor)
-            addJavaImport(jInterface.containingCompilationUnit, typeReference)
-            jInterface.extends += typeReference
-            addGeneralizationCorrespondence(uGeneralization, typeReference)
-        }
-    }
+	match {
+		val jInterface = retrieve java::Interface corresponding to uInterface
+		val jSuperInterface = retrieve java::Interface corresponding to uGeneralization.general
+		require absence of java::TypeReference corresponding to uGeneralization
+	}
+	action {
+		execute{
+			var typeReference = createTypeReference(uGeneralization.general as Interface, Optional.^of(jSuperInterface), null, userInteractor)
+			addJavaImport(jInterface.containingCompilationUnit, typeReference)
+			jInterface.extends += typeReference
+			addGeneralizationCorrespondence(uGeneralization, typeReference)
+		}
+	}
 }
 
 routine addGeneralizationCorrespondence(uml::Generalization uGeneralization, java::TypeReference jReference) {
-    match {
-        require absence of uml::Generalization corresponding to jReference
-        require absence of java::TypeReference corresponding to uGeneralization
-    }
-    action {
-        add correspondence between uGeneralization and jReference
-    }
+	match {
+		require absence of uml::Generalization corresponding to jReference
+		require absence of java::TypeReference corresponding to uGeneralization
+	}
+	action {
+		add correspondence between uGeneralization and jReference
+	}
 }
 
 reaction UmlSuperInterfaceDeleted {
-    after element uml::Generalization removed from uml::Interface[generalization]
-    call deleteJavaSuperInterface(oldValue)
+	after element uml::Generalization removed from uml::Interface[generalization]
+	call deleteJavaSuperInterface(oldValue)
 }
 
 routine deleteJavaSuperInterface(uml::Generalization uGeneralization) {
-    match {
-        val jReference = retrieve java::TypeReference corresponding to uGeneralization
-    }
-    action {
-        delete jReference
-    }
+	match {
+		val jReference = retrieve java::TypeReference corresponding to uGeneralization
+	}
+	action {
+		delete jReference
+	}
 }
 
 reaction UmlSuperInterfaceReplaced {
-    after element uml::Interface replaced at uml::Generalization[general]
-    call {
-        if(oldValue !== null)
-            deleteJavaSuperInterface(affectedEObject)
-        if(affectedEObject.specific !== null && affectedEObject.specific instanceof Interface)
-            addJavaSuperInterface(affectedEObject.specific as Interface, affectedEObject)
-    }
+	after element uml::Interface replaced at uml::Generalization[general]
+	call {
+		if(oldValue !== null)
+			deleteJavaSuperInterface(affectedEObject)
+		if(affectedEObject.specific !== null && affectedEObject.specific instanceof Interface)
+			addJavaSuperInterface(affectedEObject.specific as Interface, affectedEObject)
+	}
 }
 
 //===========================================
@@ -443,62 +443,62 @@ reaction UmlSuperInterfaceReplaced {
 
 
 reaction UmlEnumInserted {
-    after element uml::Enumeration inserted in uml::Package[packagedElement]
-    call {
-        createJavaEnum(newValue)
-        insertJavaClassifier(newValue, affectedEObject)
-    }
+	after element uml::Enumeration inserted in uml::Package[packagedElement]
+	call {
+		createJavaEnum(newValue)
+		insertJavaClassifier(newValue, affectedEObject)
+	}
 }
 
 routine createJavaEnum(uml::Enumeration uEnum) {
-    match {
-        require absence of java::Enumeration corresponding to uEnum
-    }
-    action {
-        val jEnum = create java::Enumeration and initialize {
-            jEnum.name = uEnum.name
-            jEnum.makePublic
-        }
-        call {
-            createJavaCompilationUnit(uEnum, jEnum)
-        }
-        add correspondence between uEnum and jEnum
-    }
+	match {
+		require absence of java::Enumeration corresponding to uEnum
+	}
+	action {
+		val jEnum = create java::Enumeration and initialize {
+			jEnum.name = uEnum.name
+			jEnum.makePublic
+		}
+		call {
+			createJavaCompilationUnit(uEnum, jEnum)
+		}
+		add correspondence between uEnum and jEnum
+	}
 }
 
 reaction UmlEnumLiteralInserted {
-    after element uml::EnumerationLiteral inserted in uml::Enumeration[ownedLiteral]
-    call createJavaEnumConstant(newValue, affectedEObject)
+	after element uml::EnumerationLiteral inserted in uml::Enumeration[ownedLiteral]
+	call createJavaEnumConstant(newValue, affectedEObject)
 }
 
 routine createJavaEnumConstant(uml::EnumerationLiteral uLiteral, uml::Enumeration uEnum) {
-    match {
-        val jEnum = retrieve java::Enumeration corresponding to uEnum
-        require absence of java::EnumConstant corresponding to uLiteral
-    }
-    action {
-        val jConstant = create java::EnumConstant and initialize {
-            jConstant.name = uLiteral.name
-        }
-        update jEnum {
-            jEnum.constants += jConstant
-        }
-        add correspondence between jConstant and uLiteral
-    }
+	match {
+		val jEnum = retrieve java::Enumeration corresponding to uEnum
+		require absence of java::EnumConstant corresponding to uLiteral
+	}
+	action {
+		val jConstant = create java::EnumConstant and initialize {
+			jConstant.name = uLiteral.name
+		}
+		update jEnum {
+			jEnum.constants += jConstant
+		}
+		add correspondence between jConstant and uLiteral
+	}
 }
 
 reaction UmlEnumLiteralRemoved {
-    after element uml::EnumerationLiteral removed from uml::Enumeration[ownedLiteral]
-    call deleteJavaEnumConstant(oldValue)
+	after element uml::EnumerationLiteral removed from uml::Enumeration[ownedLiteral]
+	call deleteJavaEnumConstant(oldValue)
 }
 
 routine deleteJavaEnumConstant(uml::EnumerationLiteral uLiteral) {
-    match {
-        val jConst = retrieve java::EnumConstant corresponding to uLiteral
-    }
-    action {
-        delete jConst
-    }
+	match {
+		val jConst = retrieve java::EnumConstant corresponding to uLiteral
+	}
+	action {
+		delete jConst
+	}
 }
 
 //===========================================
@@ -506,134 +506,134 @@ routine deleteJavaEnumConstant(uml::EnumerationLiteral uLiteral) {
 //===========================================
 
 reaction UmlModelCreated {
-    after element uml::Model inserted as root
-    call checkIfUmlModelCorrespondenceExists(newValue)
+	after element uml::Model inserted as root
+	call checkIfUmlModelCorrespondenceExists(newValue)
 }
 routine checkIfUmlModelCorrespondenceExists(uml::Model newModel) {
-    match {
-        val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
-        check !alreadyCorrespondingModels.contains(newModel)
-    }
-    action {
-        add correspondence between UMLPackage.Literals.MODEL and newModel
-    }
+	match {
+		val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
+		check !alreadyCorrespondingModels.contains(newModel)
+	}
+	action {
+		add correspondence between UMLPackage.Literals.MODEL and newModel
+	}
 }
 
 reaction UmlPackageInserted {
-    after element uml::Package inserted in uml::Package[packagedElement]
-    call {
-        createOrFindJavaPackage(newValue)
-        renameJavaPackage(newValue, newValue.namespace)
-    }
+	after element uml::Package inserted in uml::Package[packagedElement]
+	call {
+		createOrFindJavaPackage(newValue)
+		renameJavaPackage(newValue, newValue.namespace)
+	}
 }
 
 routine createOrFindJavaPackage(uml::Package uPackage) {
-    match {
-        require absence of java::Package corresponding to uPackage
-        val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
-        with matchingPackages.namespacesAsString + matchingPackages.name == getUmlNamespaceAsString(uPackage)
-    }
-    action {
-        call {
-            if(matchingPackages.empty) {
-                createJavaPackage(uPackage)
-            } else {
-                addPackageCorrespondence(uPackage, matchingPackages.head)
-            }
-        }
-    }
+	match {
+		require absence of java::Package corresponding to uPackage
+		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
+		with matchingPackages.namespacesAsString + matchingPackages.name == getUmlNamespaceAsString(uPackage)
+	}
+	action {
+		call {
+			if(matchingPackages.empty) {
+				createJavaPackage(uPackage)
+			} else {
+				addPackageCorrespondence(uPackage, matchingPackages.head)
+			}
+		}
+	}
 }
 
 routine addPackageCorrespondence(uml::Package uPackage, java::Package jPackage) {
-    action {
-        add correspondence between jPackage and uPackage
-    }
+	action {
+		add correspondence between jPackage and uPackage
+	}
 }
 
 routine createJavaPackage(uml::Package uPackage) {
-    match {
-        require absence of java::Package corresponding to uPackage
-    }
-    action {
-        val jPackage = create java::Package
-        add correspondence between jPackage and uPackage
-        // Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
-        add correspondence between jPackage and ContainersPackage.Literals.PACKAGE
-    }
+	match {
+		require absence of java::Package corresponding to uPackage
+	}
+	action {
+		val jPackage = create java::Package
+		add correspondence between jPackage and uPackage
+		// Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
+		add correspondence between jPackage and ContainersPackage.Literals.PACKAGE
+	}
 }
 
 reaction UmlPackageRenamed {
-    after attribute replaced at uml::Package[name]
-    with !(affectedEObject instanceof Model)
-    call renameJavaPackage(affectedEObject, affectedEObject.namespace)
+	after attribute replaced at uml::Package[name]
+	with !(affectedEObject instanceof Model)
+	call renameJavaPackage(affectedEObject, affectedEObject.namespace)
 }
 
 routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
-    match {
-        val jPackage = retrieve java::Package corresponding to uPackage
-        check uPackage.name != jPackage.name || uPackage.umlParentNamespaceAsStringList != jPackage.namespaces
-    }
-    action {
-        call {
-            var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList.map[toFirstLower])
-            modified = jPackage.updateName(uPackage.name.toFirstLower) || modified
-            if (modified) {
-                persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
-                for (compUnit : copyOf(jPackage.compilationUnits)) {
-                    changePackageOfJavaCompilationUnit(jPackage, compUnit, uNamespace)
-                }
-                // TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
-                for (nestedPackage : copyOf(uPackage.nestedPackages)) {
-                    renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
-                }
-            }
-        }
-    }
+	match {
+		val jPackage = retrieve java::Package corresponding to uPackage
+		check uPackage.name != jPackage.name || uPackage.umlParentNamespaceAsStringList != jPackage.namespaces
+	}
+	action {
+		call {
+			var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList.map[toFirstLower])
+			modified = jPackage.updateName(uPackage.name.toFirstLower) || modified
+			if (modified) {
+				persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
+				for (compUnit : copyOf(jPackage.compilationUnits)) {
+					changePackageOfJavaCompilationUnit(jPackage, compUnit, uNamespace)
+				}
+				// TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
+				for (nestedPackage : copyOf(uPackage.nestedPackages)) {
+					renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
+				}
+			}
+		}
+	}
 }
 
 routine changePackageOfJavaCompilationUnit(java::Package jPackage, java::CompilationUnit jCompUnit, uml::Namespace uNamespace) {
-    action {
-        update jCompUnit {
-            if (jCompUnit.updateNamespaces(jPackage)) {
-                persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))    
-            }
-        }
-    }
+	action {
+		update jCompUnit {
+			if (jCompUnit.updateNamespaces(jPackage)) {
+				persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))	
+			}
+		}
+	}
 }
 
 reaction UmlPackageDeleted {
-    after element uml::Package deleted
-    call deleteJavaPackage(affectedEObject)
+	after element uml::Package deleted
+	call deleteJavaPackage(affectedEObject)
 }
 
 routine deleteJavaPackage(uml::Package uPackage) {
-    match {
-        val jPackage = retrieve optional java::Package corresponding to uPackage
-    }
-    action {
-    	call {
-    		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).forEach[deleteJavaPackage()]
-    		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Class).forEach[deleteJavaClass()]
-    	} 
-        delete jPackage.orElse(null)
-    }
+	match {
+		val jPackage = retrieve optional java::Package corresponding to uPackage
+	}
+	action {
+		call {
+			uPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).forEach[deleteJavaPackage()]
+			uPackage.packagedElements.filter(org.eclipse.uml2.uml.Class).forEach[deleteJavaClass()]
+		} 
+		delete jPackage.orElse(null)
+	}
 }
 
 reaction UmlPrimitiveTypeInserted {
-    after element uml::PrimitiveType inserted in uml::Model[packagedElement]
-    call warnUserToUsePredefinedPrimitiveTypes()
+	after element uml::PrimitiveType inserted in uml::Model[packagedElement]
+	call warnUserToUsePredefinedPrimitiveTypes()
 }
 
 routine warnUserToUsePredefinedPrimitiveTypes() {
-    action {
-        execute {
-            userInteractor.notificationDialogBuilder
-                .message("Only predefined uml::PrimitiveTypes will be mapped."
-                    + "Please use the types defined in \"pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml\" instead.")
-                .title("Warning")
-                .notificationType(NotificationType.WARNING)
-                .windowModality(WindowModality.MODAL)
-                .startInteraction
-        }
-    }
+	action {
+		execute {
+			userInteractor.notificationDialogBuilder
+				.message("Only predefined uml::PrimitiveTypes will be mapped."
+					+ "Please use the types defined in \"pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml\" instead.")
+				.title("Warning")
+				.notificationType(NotificationType.WARNING)
+				.windowModality(WindowModality.MODAL)
+				.startInteraction
+		}
+	}
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -608,10 +608,14 @@ reaction UmlPackageDeleted {
 
 routine deleteJavaPackage(uml::Package uPackage) {
     match {
-        val jPackage = retrieve java::Package corresponding to uPackage
+        val jPackage = retrieve optional java::Package corresponding to uPackage
     }
     action {
-        delete jPackage
+    	call {
+    		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).forEach[deleteJavaPackage()]
+    		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Class).forEach[deleteJavaClass()]
+    	} 
+        delete jPackage.orElse(null)
     }
 }
 

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -15,7 +15,6 @@ import org.emftext.language.java.classifiers.Class;
 import org.emftext.language.java.classifiers.Classifier;
 import org.emftext.language.java.commons.NamedElement;
 import org.emftext.language.java.containers.CompilationUnit;
-import org.emftext.language.java.imports.ClassifierImport;
 import org.emftext.language.java.imports.Import;
 import org.emftext.language.java.instantiations.NewConstructorCall;
 import org.emftext.language.java.members.Constructor;
@@ -398,17 +397,13 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	protected void assertOperationProvidedRole(final OperationProvidedRole operationProvidedRole) throws Throwable {
 		final Iterable<EObject> correspondingEObjects = getCorrespondingEObjects(operationProvidedRole, EObject.class);
 		int namespaceClassifierReferenceFound = 0;
-		int importFound = 0;
 		for (final EObject eObject : correspondingEObjects) {
 			if (eObject instanceof NamespaceClassifierReference) {
 				namespaceClassifierReferenceFound++;
-			} else if (eObject instanceof ClassifierImport) {
-				importFound++;
 			} else {
 				fail("operation provided role corresponds to unexpected object: " + eObject);
 			}
 		}
-		assertEquals(1, importFound, "unexpected size of corresponding imports");
 		assertEquals(1, namespaceClassifierReferenceFound,
 				"unexpected size of corresponding namespace classifier references");
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationProvidedRoleMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationProvidedRoleMappingTransformationTest.java
@@ -98,7 +98,6 @@ public class OperationProvidedRoleMappingTransformationTest extends Pcm2JavaTran
 
 		this.assertOperationProvidedRole(operationProvidedRole);
 		final CompilationUnit jaMoPPCu = claimOne(getCorrespondingEObjects(basicComponent, CompilationUnit.class));
-		assertEquals(1, jaMoPPCu.getImports().size(), "Unexpected size of imports");
 		final Class jaMoPPClass = (Class) jaMoPPCu.getClassifiers().get(0);
 		assertEquals(1, jaMoPPClass.getImplements().size(), "Unexpected size of implemented interfaces");
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/java2pcm/Java2PcmTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/java2pcm/Java2PcmTransformationTest.java
@@ -119,7 +119,7 @@ public abstract class Java2PcmTransformationTest extends LegacyVitruvApplication
 
 	private static final Logger logger = Logger.getLogger(Java2PcmTransformationTest.class.getSimpleName());
 
-	private static int MAXIMUM_SYNC_WAITING_TIME = 15000;
+	private static int MAXIMUM_SYNC_WAITING_TIME = 25000;
 
 	protected Package mainPackage;
 	protected Package secondPackage;
@@ -239,7 +239,7 @@ public abstract class Java2PcmTransformationTest extends LegacyVitruvApplication
 			// propagation process and before we check the models afterwards. Until we have found 
 			// out how to fix that, we need to wait a high enough amount of time to ensure that 
 			// no failures occur.
-			Thread.sleep(100);
+			Thread.sleep(150);
 			// Trigger the build to start change propagation
 			refreshAndBuildProject();
 			int wakeups = 0;
@@ -255,7 +255,7 @@ public abstract class Java2PcmTransformationTest extends LegacyVitruvApplication
 					fail("Waiting for synchronization timed out");
 				}
 			}
-			Thread.sleep(100);
+			Thread.sleep(150);
 		} catch (InterruptedException e) {
 			fail("An interrupt occurred unexpectedly");
 		}

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlPackageTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlPackageTest.xtend
@@ -70,7 +70,6 @@ class JavaToUmlPackageTest extends JavaToUmlTransformationTest {
 			delete(null)
 		]
 		assertTrue(getUmlPackagedElementsbyName(Package, PACKAGE_LEVEL_1).nullOrEmpty)
-
 	}
 
 	@Test


### PR DESCRIPTION
This PR provides minor improvements to the transformations that will lead to errors as soon as correspondence handling within the framework is corrected. Currently, some correspondences are removed unintendedly, because _every_ correspondence of a an element removed by a Reactions is removed, thus even the correspondences to completely different domains. For example, when removing a PCM repository leading to a UML package removal, this will erroneously also remove the correspondence between the UML package and the Java package.
After fixing that framework ug, some actual bugs in the transformations will lead to failures that were hidden because of accidentially removed correspondences before. This PR prepares for that and provides some additional improvements.
* Reactions now remove contained Java packages after removing a UML package (while contained UML packages are removed implicitly through containments, Java packages are not)
* Reactions now remove PCM repositories, systems and components upon Java package removals
* Reactions now properly remove UML model contents after a UML package deletion leading to a PCM repository deletion was performed.
* Reactions for PCM to Java do not create obsolete imports anymore.

The changes are reasonable even without the framework PR https://github.com/vitruv-tools/Vitruv/pull/470 for which they have been developed, but only after merging the framework PR there will (implicitly) be regression tests for the changes.