### PR TITLE
Eclipse 2021-06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>2.0.0</version>
+    <version>2.3.0</version>
   </extension>
 </extensions>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.vitruv</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.1.1</version>
+		<version>1.3.0</version>
 	</parent>
 	<artifactId>applications-cbs-parent</artifactId>
 	<version>0.3.0-SNAPSHOT</version>

--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -134,6 +134,12 @@
 								<artifactId>org.eclipse.xtend.core</artifactId>
 								<version>${xtext.version}</version>
 							</dependency>
+							<!-- Necessary for Eclipse 2021-06 due to bug and workaround described here: https://github.com/eclipse/xtext-xtend/issues/116#issuecomment-271916734 -->
+							<dependency>
+								<groupId>org.eclipse.jdt</groupId>
+								<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+								<version>1.3.1300</version>
+							</dependency>
 						</dependencies>
 					</plugin>
 				</plugins>

--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -26,7 +26,7 @@
 		<repository>
 			<id>Palladiosimulator</id>
 			<layout>p2</layout>
-			<url>https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/4.3.0/</url>
+			<url>https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/5.0.0/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Upgrades parent POM to 1.3.0 (Eclipse 2021-06).

Improves dependency to Tycho 2.3.0 and uses Maven 3.8.1.
Improves Palladio dependency to 5.0.0.
Fixes a bug caused by an incompatibility between Xtext and JDT in Eclipse 2021-06 repository.
