### PR TITLE
Add workflow_dispatch event to the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   create:
     tags:
+  workflow_dispatch:
   pull_request:
   schedule:
     - cron: '30 4 * * *' # run nightly at 4:30 am


### PR DESCRIPTION
Add workflow_dispatch event to the CI workflow to enable [manual workflow execution](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#manual-events).