### PR TITLE
Fixed Java to UML element visibility reactions dependability on change order

### DIFF
--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
@@ -113,12 +113,12 @@ routine changeUmlAttributeType(java::Field jAttr, java::TypeReference jType) {
 }
 
 reaction JavaAttributeMadeFinal {
-    after element java::Final created and inserted in java::Field[annotationsAndModifiers]
+    after element java::Final inserted in java::Field[annotationsAndModifiers]
     call setUmlAttributeFinal(affectedEObject, true)
 }
 
 reaction JavaAttributeMadeNonFinal {
-    after element java::Final deleted and removed from java::Field[annotationsAndModifiers]
+    after element java::Final removed from java::Field[annotationsAndModifiers]
     call setUmlAttributeFinal(affectedEObject, false)
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -177,12 +177,12 @@ routine deleteUmlClassifier(java::ConcreteClassifier jClassifier, java::Compilat
 }
 
 reaction JavaClassMadeAbstract {
-	after element java::Abstract created and inserted in java::Class[annotationsAndModifiers]
+	after element java::Abstract inserted in java::Class[annotationsAndModifiers]
 	call setUmlClassAbstract(affectedEObject, true)
 }
 
 reaction JavaClassMadeNonAbstract {
-	after element java::Abstract deleted and removed from java::Class[annotationsAndModifiers]
+	after element java::Abstract removed from java::Class[annotationsAndModifiers]
 	call setUmlClassAbstract(affectedEObject, false)
 }
 
@@ -198,12 +198,12 @@ routine setUmlClassAbstract(java::Class jClass, Boolean isAbstract) {
 }
 
 reaction JavaClassMadeFinal {
-	after element java::Final created and inserted in java::Class[annotationsAndModifiers]
+	after element java::Final inserted in java::Class[annotationsAndModifiers]
 	call setUmlClassFinal(affectedEObject, true)
 }
 
 reaction JavaClassMadeNonFinal {
-	after element java::Final deleted and removed from java::Class[annotationsAndModifiers]
+	after element java::Final removed from java::Class[annotationsAndModifiers]
 	call setUmlClassFinal(affectedEObject, false)
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -30,8 +30,8 @@ reaction JavaClassMethodCreated {
     with (affectedEObject instanceof Class)
         || (affectedEObject instanceof Enumeration)
     call {
-    	createOrFindUmlClassMethod(newValue, affectedEObject)
-    	insertUmlMethod(newValue, affectedEObject)
+        createOrFindUmlClassMethod(newValue, affectedEObject)
+        insertUmlMethod(newValue, affectedEObject)
     }
 }
 
@@ -46,9 +46,9 @@ routine createOrFindUmlClassMethod(java::ClassMethod jMethod, java::ConcreteClas
     action {
         call {
             val foundMethod = (uClassifier as OperationOwner).ownedOperations.findFirst[
-            	name == jMethod.name && 
-            	ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
-            	jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
+                name == jMethod.name && 
+                ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
+                jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
             ]
             if (foundMethod === null) {
                 createUmlClassMethod(jMethod, uClassifier)
@@ -62,7 +62,7 @@ routine createOrFindUmlClassMethod(java::ClassMethod jMethod, java::ConcreteClas
 routine createUmlClassMethod(java::ClassMethod jMethod, uml::Classifier uClassifier) {
     action {
         val uOperation = create uml::Operation and initialize {
-            uOperation.name = jMethod.name;
+            uOperation.name = jMethod.name
             uOperation.visibility = getUmlVisibilityKindFromJavaElement(jMethod)
         }
         add correspondence between uOperation and jMethod
@@ -72,8 +72,8 @@ routine createUmlClassMethod(java::ClassMethod jMethod, uml::Classifier uClassif
 reaction JavaInterfaceMethodCreated {
     after element java::InterfaceMethod inserted in java::Interface[members]
     call {
-    	createOrFindUmlInterfaceMethod(newValue, affectedEObject)
-    	insertUmlMethod(newValue, affectedEObject)
+        createOrFindUmlInterfaceMethod(newValue, affectedEObject)
+        insertUmlMethod(newValue, affectedEObject)
     }
 }
 
@@ -85,9 +85,9 @@ routine createOrFindUmlInterfaceMethod(java::InterfaceMethod jMethod, java::Inte
     action {
         call {
             val foundMethod = uInterface.ownedOperations.findFirst[
-            	name == jMethod.name && 
-            	ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
-            	jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
+                name == jMethod.name && 
+                ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
+                jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
             ]
             if (foundMethod === null) {
                 createUmlInterfaceMethod(jMethod, uInterface)
@@ -101,8 +101,8 @@ routine createOrFindUmlInterfaceMethod(java::InterfaceMethod jMethod, java::Inte
 routine createUmlInterfaceMethod(java::InterfaceMethod jMeth, uml::Interface uInterface) {
     action {
         val uOperation = create uml::Operation and initialize {
-            uOperation.name = jMeth.name;
-            uOperation.isAbstract = true;
+            uOperation.name = jMeth.name
+            uOperation.isAbstract = true
         }
         add correspondence between uOperation and jMeth
     }
@@ -118,8 +118,8 @@ routine addUmlMethodCorrespondence(uml::Operation uOperation, java::Member jMeth
 reaction JavaConstructorCreated {
     after element java::Constructor inserted in java::ConcreteClassifier[members]
     call {
-    	createOrFindUmlConstructor(newValue, affectedEObject)
-    	insertUmlMethod(newValue, affectedEObject)
+        createOrFindUmlConstructor(newValue, affectedEObject)
+        insertUmlMethod(newValue, affectedEObject)
     }
 }
 
@@ -261,8 +261,8 @@ routine setUmlFeatureStatic(java::AnnotableAndModifiable jElem, Boolean isStatic
 reaction JavaVariableLengthParameterCreated {
     after element java::VariableLengthParameter created and inserted in java::Parametrizable[parameters]
     call {
-    	createUmlParameter(affectedEObject, newValue)
-    	setMultiplicityOfCorrespondingParameterToUnlimited(newValue)
+        createUmlParameter(affectedEObject, newValue)
+        setMultiplicityOfCorrespondingParameterToUnlimited(newValue)
     }
 }
 
@@ -278,7 +278,7 @@ routine createUmlParameter(java::Parametrizable jMeth, java::Parameter jParam) {
     }
     action {
         val uParam = create uml::Parameter and initialize {
-            uParam.name = jParam.name;
+            uParam.name = jParam.name
         }
         add correspondence between uParam and jParam
         update uOperation {
@@ -288,17 +288,17 @@ routine createUmlParameter(java::Parametrizable jMeth, java::Parameter jParam) {
 }
 
 routine setMultiplicityOfCorrespondingParameterToUnlimited(java::Parameter parameter) {
-	match {
-		val umlParameter = retrieve uml::Parameter corresponding to parameter
-	}
-	action {
-		update umlParameter {
-			umlParameter => [
-				lower = 0
-				upper = LiteralUnlimitedNatural.UNLIMITED				
-			]
-		}
-	}
+    match {
+        val umlParameter = retrieve uml::Parameter corresponding to parameter
+    }
+    action {
+        update umlParameter {
+            umlParameter => [
+                lower = 0
+                upper = LiteralUnlimitedNatural.UNLIMITED
+            ]
+        }
+    }
 }
 
 reaction JavaParameterDeleted {
@@ -311,7 +311,7 @@ routine deleteJavaParameter(java::Parameter jParam) {
         val uParam = retrieve uml::Parameter corresponding to jParam
     }
     action{
-        delete uParam         
+        delete uParam
     }
 }
 
@@ -355,13 +355,13 @@ routine changeUmlReturnType(java::Method jMeth, java::TypeReference jType) {
 //=========================================== General
 //=========================================== 
 
-reaction JavaElementVisibilityChangedAfterInsertion {
+reaction JavaVisibilityModifierInserted {
     after element java::Modifier inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
     with newValue instanceof Public || newValue instanceof Private || newValue instanceof Protected
     call changeUmlNamedElementVisibility(affectedEObject)
 }
 
-reaction JavaElementMadeVisibilityChangedAfterRemoval {
+reaction JavaVisibilityModifierRemoved {
     after element java::Modifier removed from java::AnnotableAndModifiable[annotationsAndModifiers]
     with oldValue instanceof Private
     || oldValue instanceof Public
@@ -370,12 +370,12 @@ reaction JavaElementMadeVisibilityChangedAfterRemoval {
 }
 
 routine changeUmlNamedElementVisibility(java::AnnotableAndModifiable jElem) {
-	match {
+    match {
         val uElem = retrieve uml::NamedElement corresponding to jElem tagged with ""
     }
     action {
         update uElem {
-            uElem.visibility = getUmlVisibilityKindFromJavaElement(jElem);
+            uElem.visibility = getUmlVisibilityKindFromJavaElement(jElem)
         }
     }
 }
@@ -392,7 +392,7 @@ routine renameUmlNamedElement(java::NamedElement jElement) {
     }
     action {
         update uElement {
-            uElement.name = jElement.name;
+            uElement.name = jElement.name
         }
     }
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -1,3 +1,5 @@
+import org.eclipse.uml2.uml.LiteralUnlimitedNatural
+import org.eclipse.uml2.uml.OperationOwner
 import org.eclipse.uml2.uml.ParameterDirectionKind
 import org.emftext.language.java.classifiers.Class
 import org.emftext.language.java.classifiers.Enumeration
@@ -5,12 +7,10 @@ import org.emftext.language.java.containers.CompilationUnit
 import org.emftext.language.java.modifiers.Private
 import org.emftext.language.java.modifiers.Protected
 import org.emftext.language.java.modifiers.Public
-import org.eclipse.uml2.uml.OperationOwner
 import tools.vitruv.applications.umljava.util.UmlJavaCorrespondenceTag
 
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
 import static tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
-import org.eclipse.uml2.uml.LiteralUnlimitedNatural
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
@@ -190,14 +190,14 @@ routine deleteAccessorCorrespondence(java::Member jMember, String tag) {
 }
 
 reaction JavaMethodMadeAbstract {
-    after element java::Abstract created and inserted in java::ClassMethod[annotationsAndModifiers]
+    after element java::Abstract inserted in java::ClassMethod[annotationsAndModifiers]
     call  {
         setUmlMethodAbstract(affectedEObject, true)
     }
 }
 
 reaction JavaMethodMadeNonAbstract {
-    after element java::Abstract deleted and removed from java::ClassMethod[annotationsAndModifiers]
+    after element java::Abstract removed from java::ClassMethod[annotationsAndModifiers]
     call setUmlMethodAbstract(affectedEObject, false)
 }
 
@@ -213,12 +213,12 @@ routine setUmlMethodAbstract(java::ClassMethod jMeth, Boolean isAbstract) {
 }
 
 reaction JavaMethodMadeFinal {
-    after element java::Final created and inserted in java::ClassMethod[annotationsAndModifiers]
+    after element java::Final inserted in java::ClassMethod[annotationsAndModifiers]
     call setUmlMethodFinal(affectedEObject, true)
 }
 
 reaction JavaMethodMadeNonFinal {
-    after element java::Final deleted and removed from java::ClassMethod[annotationsAndModifiers]
+    after element java::Final removed from java::ClassMethod[annotationsAndModifiers]
     call setUmlMethodFinal(affectedEObject, false)
 }
 
@@ -234,12 +234,12 @@ routine setUmlMethodFinal(java::Method jMethod, Boolean isFinal) {
 }
 
 reaction JavaElementMadeStatic {
-    after element java::Static created and inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
+    after element java::Static inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
     call setUmlFeatureStatic(affectedEObject, true)
 }
 
 reaction JavaMethodMadeNonStatic {
-    after element java::Static deleted and removed from java::AnnotableAndModifiable[annotationsAndModifiers]
+    after element java::Static removed from java::AnnotableAndModifiable[annotationsAndModifiers]
     call setUmlFeatureStatic(affectedEObject, false)
 }
 //UML-Feature =  {Property, Operation}
@@ -355,27 +355,27 @@ routine changeUmlReturnType(java::Method jMeth, java::TypeReference jType) {
 //=========================================== General
 //=========================================== 
 
-reaction JavaElementVisibilityChanged {
-    after element java::Modifier created and inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
+reaction JavaElementVisibilityChangedAfterInsertion {
+    after element java::Modifier inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
     with newValue instanceof Public || newValue instanceof Private || newValue instanceof Protected
-    call changeUmlNamedElementVisibility(affectedEObject, newValue)
+    call changeUmlNamedElementVisibility(affectedEObject)
 }
 
-reaction JavaElementMadePackagePrivate {
-    after element java::Modifier deleted and removed from java::AnnotableAndModifiable[annotationsAndModifiers]
+reaction JavaElementMadeVisibilityChangedAfterRemoval {
+    after element java::Modifier removed from java::AnnotableAndModifiable[annotationsAndModifiers]
     with oldValue instanceof Private
     || oldValue instanceof Public
     || oldValue instanceof Protected
-    call changeUmlNamedElementVisibility(affectedEObject, null)
+    call changeUmlNamedElementVisibility(affectedEObject)
 }
 
-routine changeUmlNamedElementVisibility(java::AnnotableAndModifiable jElem, java::Modifier mod) {
-    match {
+routine changeUmlNamedElementVisibility(java::AnnotableAndModifiable jElem) {
+	match {
         val uElem = retrieve uml::NamedElement corresponding to jElem tagged with ""
     }
     action {
         update uElem {
-            uElem.visibility = getUMLVisibilityKindFromJavaModifier(mod);
+            uElem.visibility = getUmlVisibilityKindFromJavaElement(jElem);
         }
     }
 }

--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaModifierUtil.xtend
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/java/JavaModifierUtil.xtend
@@ -216,14 +216,6 @@ class JavaModifierUtil {
     }
 
     /**
-     * Returns the corresponding UMLVisibility enum constant corresponding to
-     * the given java visibility modifier
-     */
-    def static getUMLVisibilityKindFromJavaModifier(Modifier visibilityModifier) {
-        return getUmlVisibilityKindFromJavaVisibilityConstant(getEnumConstantFromJavaVisibility(visibilityModifier))
-    }
-
-    /**
      * Sets the java visibility modifier corresponding to uVisibility to jModifiable
      * 
      * @param jModifiable the AnnotableAndModifiable for which a java visibility modifier should be set


### PR DESCRIPTION
This PR fixes the behaviour of Java to UML reactions to be independent of the order of changes. 
In Java, visibility is modelled by placing an instance of a visibility class (`Private`, `Protected`, or `Public`) in the `annotationsAndModifiers` collection of the element. To update the visibility, the previous visibility is removed from the collection and the new visibility is inserted. The previous implementation assumed the remove -> insert order while insert -> remove might be possible too (i.e. is occurring when deriving changes using the state-based API). 

Furthermore replaces some compound triggers in trivial reactions by an atomic trigger as suggested in #103.