### PR TITLE
Remove Correspondence setup to Java::CompilationUnit

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -513,15 +513,14 @@ routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType)
 routine addSuperTypeToDataType(pcm::DataType dataType, java::TypeReference innerTypeReference, String superTypeQualifiedName) {
 	match {
 		val dataTypeImplementation = retrieve java::Class corresponding to dataType
-		val dataTypeImplementationCU = retrieve java::CompilationUnit corresponding to dataType
 	}
 	action {
-		update dataTypeImplementationCU {
+		update dataTypeImplementation.containingCompilationUnit {
 			val collectionTypeClassImport = createJavaClassImport(superTypeQualifiedName);
-			dataTypeImplementationCU.imports += collectionTypeClassImport;
+			dataTypeImplementation.containingCompilationUnit.imports += collectionTypeClassImport;
 		}
 		val namespaceClassifier = create java::NamespaceClassifierReference and initialize {
-			createNamespaceClassifierReference(namespaceClassifier, dataTypeImplementationCU.imports.filter(ClassifierImport).last.classifier);
+			createNamespaceClassifierReference(namespaceClassifier, dataTypeImplementation.containingCompilationUnit.imports.filter(ClassifierImport).last.classifier);
 			val qualifiedTypeArgument = GenericsFactory.eINSTANCE.createQualifiedTypeArgument();
 			qualifiedTypeArgument.typeReference = innerTypeReference;
 			namespaceClassifier.classifierReferences.get(0).typeArguments += qualifiedTypeArgument;
@@ -776,7 +775,6 @@ routine createOrFindJavaInterface(pcm::Interface pcmInterface) {
 	match {
 		val contractsPackage = retrieve java::Package corresponding to pcmInterface.repository__Interface tagged with "contracts"
 		require absence of java::Interface corresponding to pcmInterface
-		require absence of java::CompilationUnit corresponding to pcmInterface
 	}
 	action {
 		call {
@@ -804,7 +802,6 @@ routine createJavaInterface(pcm::Interface pcmInterface, java::Package containin
 routine addMissingClassifierCorrespondence(pcm::NamedElement pcmElement, java::ConcreteClassifier javaClassifier) {
 	action {
 		add correspondence between javaClassifier and pcmElement
-		add correspondence between javaClassifier.containingCompilationUnit and pcmElement
 	}
 }
 
@@ -819,13 +816,11 @@ routine createCompilationUnit(pcm::NamedElement sourceElementMappedToClass, java
 			persistProjectRelative(sourceElementMappedToClass, compilationUnit, buildJavaFilePath(compilationUnit));
 		}
 		call containingPackage.compilationUnits += compilationUnit
-		add correspondence between compilationUnit and sourceElementMappedToClass
 	}
 }
 
 routine renameJavaClassifier(pcm::NamedElement classSourceElement, java::Package containingPackage, String className) {
 	match {
-		val compilationUnit = retrieve java::CompilationUnit corresponding to classSourceElement
 		// move containing model to project-relative location: buildJavaFilePath(compilationUnit)
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to classSourceElement
 	}
@@ -833,7 +828,8 @@ routine renameJavaClassifier(pcm::NamedElement classSourceElement, java::Package
 		update javaClassifier {
 			javaClassifier.updateName(className.toFirstUpper)
 		}
-		update compilationUnit {
+		update javaClassifier.containingCompilationUnit {
+		    val compilationUnit = javaClassifier.containingCompilationUnit
 			val newNamespaces = new ArrayList(containingPackage.namespaces)
 			newNamespaces += containingPackage.name
 			var modified = compilationUnit.updateNamespaces(newNamespaces)
@@ -849,11 +845,9 @@ routine renameJavaClassifier(pcm::NamedElement classSourceElement, java::Package
 routine deleteJavaClassifier(pcm::NamedElement sourceElement) {
 	match {
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to sourceElement
-		val compilationUnit = retrieve java::CompilationUnit corresponding to sourceElement
 	}
 	action {
-		delete javaClassifier
-		delete compilationUnit
+		delete javaClassifier.containingCompilationUnit
 	}
 }
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -416,8 +416,7 @@ routine addInterfaceCorrespondence(pcm::OperationInterface pcmInterface, java::I
 		require absence of pcm::Interface corresponding to javaInterface
 	}
 	action {
-		add correspondence between pcmInterface and javaInterface
-		add correspondence between pcmInterface and compilationUnit 
+		add correspondence between pcmInterface and javaInterface 
 	}
 }
 
@@ -615,7 +614,6 @@ routine createCollectionDataType(java::Class javaClass, java::CompilationUnit co
 routine addDataTypeCorrespondence(java::Class javaClass, java::CompilationUnit compilationUnit, pcm::DataType dataType) {
 	action {
 		add correspondence between dataType and javaClass
-		add correspondence between compilationUnit and javaClass
 	}
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -102,10 +102,7 @@ routine rootElementPreSetup(EObject alreadyPersistedEObject) {
 
 reaction JavaCompilationUnitInsertedAsRoot {
 	after element java::CompilationUnit inserted as root
-	call {
-	    rootElementPreSetup(newValue)
-	    newValue.classifiers.forEach[insertUmlClassifier(it, newValue)]
-	} 
+	call newValue.classifiers.forEach[insertUmlClassifier(it, newValue)]
 }
 
 reaction JavaCompilationUnitInsertedInPackage {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -8,6 +8,7 @@ import tools.vitruv.extensions.dslsruntime.reactions.helper.PersistenceHelper
 
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlPackage
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlClass
+import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlEnum
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlInterface
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
 import static tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.registerPredefinedUmlPrimitiveTypes
@@ -27,16 +28,11 @@ execute actions in UML
 //=========================================== All Types
 //===========================================
 
-routine addTypeCorrespondence(java::ConcreteClassifier jClassifier, uml::Type uType, java::CompilationUnit jCompUnit) {
+routine addTypeCorrespondence(java::ConcreteClassifier jClassifier, uml::Type umlType) {
 	action {
-		add correspondence between uType and jClassifier
-		add correspondence between uType and jCompUnit
+		add correspondence between umlType and jClassifier
 	}
 }
-
-//===========================================
-//=========================================== Class
-//===========================================
 
 routine detectOrCreateUmlModel(EObject alreadyPersistedEObject) { // TODO TS This routine needs to be broken up!
 	match {
@@ -91,89 +87,154 @@ routine registerUmlModelInCorrespondenceModel(uml::Model uModel) {
 	}
 }
 
-reaction JavaClassCreated {
-	after element java::Class created and inserted in java::CompilationUnit[classifiers]
+routine rootElementPreSetup(EObject alreadyPersistedEObject) {
+    action {
+        call {
+            detectOrCreateUmlModel(alreadyPersistedEObject)
+            registerPredefinedUmlPrimitiveTypes(correspondenceModel, alreadyPersistedEObject.eResource.resourceSet)
+        }
+    }
+}
+
+//===========================================
+//=========================================== CompilationUnit
+//===========================================
+
+reaction JavaCompilationUnitInsertedAsRoot {
+	after element java::CompilationUnit inserted as root
 	call {
-		detectOrCreateUmlModel(affectedEObject)
-		registerPredefinedUmlPrimitiveTypes(correspondenceModel, affectedEObject.eResource.resourceSet)
-		createOrFindUmlClass(newValue, affectedEObject)
-	}
+	    rootElementPreSetup(newValue)
+	    newValue.classifiers.forEach[insertUmlClassifier(it, newValue)]
+	} 
 }
 
-routine createOrFindUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
-	match {
-		val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-		require absence of uml::Class corresponding to jClass
-		require absence of uml::DataType corresponding to jClass
-	}
-	action {
-		call {
-			val uClass = findUmlClass(uModel, jClass.name, jCompUnit.namespaces.last)
-			if(uClass === null) {
-				createUmlClass(jClass, jCompUnit)
-			} else {
-				addTypeCorrespondence(jClass, uClass, jCompUnit)
-			}
-		}
-	}
+reaction JavaCompilationUnitInsertedInPackage {
+    after element java::CompilationUnit inserted in java::Package[compilationUnits]
+    call {
+        rootElementPreSetup(newValue)
+        newValue.classifiers.forEach[insertUmlClassifierIntoPackage(it, affectedEObject)]
+    }
 }
 
-routine createUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
-	action {
-		val uClass = create uml::Class and initialize {
-			uClass.name = jClass.name
-			uClass.visibility = getUmlVisibilityKindFromJavaElement(jClass)
-		}
-		call {
-			addTypeCorrespondence(jClass, uClass, jCompUnit)
-			addUmlElementToModelOrPackage(jCompUnit, uClass)
-		}
-	}
+routine insertUmlClassifier(java::ConcreteClassifier jClassifier, java::CompilationUnit jCompUnit) {
+    match {
+        val umlClassifier = retrieve uml::Classifier corresponding to jClassifier
+    }
+    action {
+        call addUmlElementToModelOrPackage(jCompUnit, umlClassifier)
+    }
+}
+
+routine insertUmlClassifierIntoPackage(java::ConcreteClassifier jClassifier, java::Package jPackage) {
+    match {
+        val uClassifier = retrieve uml::Classifier corresponding to jClassifier
+        val uPackage = retrieve uml::Package corresponding to jPackage
+    }
+    action {
+        update uPackage {
+            uPackage.packagedElements += uClassifier
+        }
+    }
+}
+
+routine addUmlElementToModelOrPackage(java::JavaRoot javaRoot, uml::PackageableElement umlPackageableElement) {
+    match {
+        val uModel = retrieve asserted uml::Model corresponding to UMLPackage.Literals.MODEL
+    }
+    action {
+        call {
+            val uPackage = if (javaRoot.namespaces.nullOrEmpty) {
+                uModel
+            } else {
+                findUmlPackage(uModel, javaRoot.namespaces.last)
+            }
+            checkState(uPackage !== null, "Package %s does not exist in UML model", javaRoot.namespaces)
+            if (uPackage !== umlPackageableElement.eContainer) {
+                addUmlElementToPackage(umlPackageableElement, uPackage)
+            }
+        }
+    }
 }
 
 routine addUmlElementToPackage(uml::PackageableElement uPackageable, uml::Package uPackage) {
-	action {
-		update uPackage {
-			uPackage.packagedElements += uPackageable
-		}
-	}
-}
-
-reaction JavaCompUnitCreated {
-	after element java::CompilationUnit inserted as root
-	call potentiallyMoveClassifier(newValue)
-}
-
-// If there is a corresponding class or interface, move it
-routine potentiallyMoveClassifier(java::CompilationUnit compUnit) {
-	match {
-		val umlClassifier = retrieve uml::Classifier corresponding to compUnit
-	}
-	action {
-		call {
-			addUmlElementToModelOrPackage(compUnit, umlClassifier)
-		}
-	}
+    action {
+        update uPackage {
+            uPackage.packagedElements += uPackageable
+        }
+    }
 }
 
 reaction JavaCompUnitDeleted {
-	after element java::CompilationUnit deleted and removed as root
-	call deleteUmlClassifier(oldValue.classifiers.head, oldValue)
+	after element java::CompilationUnit deleted
+	call affectedEObject.classifiers.forEach[deleteUmlClassifier(it)]
 }
 
 reaction JavaClassifierDeleted {
-	after element java::ConcreteClassifier deleted and removed from java::CompilationUnit[classifiers]
-	call deleteUmlClassifier(oldValue, affectedEObject)
+	after element java::ConcreteClassifier deleted
+	call deleteUmlClassifier(affectedEObject)
 }
 
-routine deleteUmlClassifier(java::ConcreteClassifier jClassifier, java::CompilationUnit jCompUnit) {
+routine deleteUmlClassifier(java::ConcreteClassifier javaClassifier) {
 	match {
-		val uClassfier = retrieve uml::Classifier corresponding to jClassifier
+		val umlClassfier = retrieve uml::Classifier corresponding to javaClassifier
 	}
 	action {
-		delete uClassfier
-		delete jCompUnit
+		delete umlClassfier
 	}
+}
+
+reaction JavaClassifierRemoved {
+    after element java::ConcreteClassifier removed from java::CompilationUnit[classifiers]
+    call cleanUpJavaCompilationUnit(affectedEObject)
+}
+
+routine cleanUpJavaCompilationUnit(java::CompilationUnit jCompUnit) {
+    action {
+        delete jCompUnit
+    }
+}
+
+//===========================================
+//=========================================== Class
+//===========================================
+
+reaction JavaClassInserted {
+    after element java::Class inserted in java::CompilationUnit[classifiers]
+    call {
+        rootElementPreSetup(affectedEObject)
+        createOrFindUmlClass(newValue, affectedEObject)
+        insertUmlClassifier(newValue, affectedEObject)
+    }
+}
+
+routine createOrFindUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
+    match {
+        val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
+        require absence of uml::Class corresponding to jClass
+        require absence of uml::DataType corresponding to jClass
+    }
+    action {
+        call {
+            val uClass = findUmlClass(uModel, jClass.name, jCompUnit.namespaces.last)
+            if(uClass === null) {
+                createUmlClass(jClass, jCompUnit)
+            } else {
+                addTypeCorrespondence(jClass, uClass)
+            }
+        }
+    }
+}
+
+routine createUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
+    action {
+        val uClass = create uml::Class and initialize {
+            uClass.name = jClass.name
+            uClass.visibility = getUmlVisibilityKindFromJavaElement(jClass)
+        }
+        call {
+            addTypeCorrespondence(jClass, uClass)
+        }
+    }
 }
 
 reaction JavaClassMadeAbstract {
@@ -258,7 +319,7 @@ routine deleteUmlSuperClassGeneralization(java::TypeReference jReference){
 }
 
 reaction JavaClassImplementAdded {
-	after element java::TypeReference created and inserted in java::Class[implements]
+	after element java::TypeReference inserted in java::Class[implements]
 	call {
 		val jInterface = getNormalizedClassifierFromTypeReference(newValue) as Interface
 		addUmlClassImplement(affectedEObject, newValue, jInterface)
@@ -320,11 +381,11 @@ routine removeUmlClassImplement(java::Class jClass, java::TypeReference jReferen
 //===========================================
 
 reaction JavaInterfaceCreated {
-	after element java::Interface created and inserted in java::CompilationUnit[classifiers]
+	after element java::Interface inserted in java::CompilationUnit[classifiers]
 	call {
-		detectOrCreateUmlModel(affectedEObject)
-		registerPredefinedUmlPrimitiveTypes(correspondenceModel, affectedEObject.eResource.resourceSet)
+		rootElementPreSetup(affectedEObject)
 		createOrFindUmlInterface(newValue, affectedEObject)
+		insertUmlClassifier(newValue, affectedEObject)
 	}
 }
 
@@ -339,7 +400,7 @@ routine createOrFindUmlInterface(java::Interface jInterface, java::CompilationUn
 			if(uInterface === null) {
 				createUmlInterface(jInterface, jCompUnit)
 			} else {
-				addTypeCorrespondence(jInterface, uInterface, jCompUnit)
+				addTypeCorrespondence(jInterface, uInterface)
 			}
 		}
 	}
@@ -352,8 +413,7 @@ routine createUmlInterface(java::Interface jInterface, java::CompilationUnit jCo
 			uInterface.visibility = getUmlVisibilityKindFromJavaElement(jInterface)
 		}
 		call {
-			addTypeCorrespondence(jInterface, uInterface, jCompUnit)
-			addUmlElementToModelOrPackage(jCompUnit, uInterface)
+			addTypeCorrespondence(jInterface, uInterface)
 		}
 	}
 }
@@ -412,17 +472,112 @@ routine removeUmlSuperInterface(java::Interface jInterface, java::TypeReference 
 }
 
 //===========================================
+//=========================================== Enum
+//===========================================
+
+reaction JavaEnumCreated {
+    after element java::Enumeration inserted in java::CompilationUnit[classifiers]
+    call {
+        rootElementPreSetup(affectedEObject)
+        createOrFindUmlEnum(newValue, affectedEObject)
+        insertUmlClassifier(newValue, affectedEObject)
+    }
+}
+
+routine createOrFindUmlEnum(java::Enumeration jEnum, java::CompilationUnit jCompUnit) {
+    match {
+        val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
+        require absence of uml::Enumeration corresponding to jEnum
+    }
+    action {
+        call {
+            val uEnum = findUmlEnum(uModel, jEnum.name, jCompUnit.namespaces.last)
+            if(uEnum === null) {
+                createUmlEnum(jEnum, jCompUnit)
+            } else {
+                addTypeCorrespondence(jEnum, uEnum)
+            }
+        }
+    }
+}
+
+routine createUmlEnum(java::Enumeration jEnum, java::CompilationUnit jCompUnit) {
+    match {
+        require absence of uml::Enumeration corresponding to jEnum
+    }
+    action {
+        val uEnum = create uml::Enumeration and initialize {
+            uEnum.name = jEnum.name
+            uEnum.visibility = getUmlVisibilityKindFromJavaElement(jEnum)
+        }
+        call {
+            addTypeCorrespondence(jEnum, uEnum)
+        }
+    }
+}
+
+reaction JavaEnumConstantCreated {
+    after element java::EnumConstant inserted in java::Enumeration[constants]
+    call createUmlEnumLiteral(affectedEObject, newValue)
+}
+
+routine createUmlEnumLiteral(java::Enumeration jEnum, java::EnumConstant jConstant) {
+    match {
+        val uEnum = retrieve uml::Enumeration corresponding to jEnum
+        require absence of uml::EnumerationLiteral corresponding to jConstant
+    }
+    action {
+        val uLiteral = create uml::EnumerationLiteral and initialize {
+            uLiteral.name = jConstant.name
+        }
+        add correspondence between uLiteral and jConstant
+        update uEnum {
+            uEnum.ownedLiterals += uLiteral
+        }
+    }
+}
+
+reaction JavaEnumConstantDeleted {
+    after element java::EnumConstant removed from java::Enumeration[constants]
+    call deleteUmlEnumLiteral(oldValue)
+}
+
+routine deleteUmlEnumLiteral(java::EnumConstant jConstant) {
+    match {
+        val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
+    }
+    action {
+        delete uLiteral
+    }
+}
+
+reaction JavaEnumConstantRenamed {
+    after attribute replaced at java::EnumConstant[name]
+    call renameUmlEnumLiteral(affectedEObject)
+}
+
+routine renameUmlEnumLiteral(java::EnumConstant jConstant) {
+    match {
+        val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
+    }
+    action {
+        update uLiteral {
+            uLiteral.name = jConstant.name
+        }
+    }
+}
+
+//===========================================
 //=========================================== Package
 //===========================================
 
 reaction JavaPackageInserted {
 	after element java::Package inserted as root
 	call {
+	    rootElementPreSetup(newValue)
 		createPackageEClassCorrespondence(newValue)
-		detectOrCreateUmlModel(newValue)
-		registerPredefinedUmlPrimitiveTypes(correspondenceModel, newValue.eResource.resourceSet)
-		potentiallyMoveUmlPackage(newValue)
 		createOrFindUmlPackage(newValue)
+		potentiallyMoveUmlPackage(newValue)
 	}
 }
 
@@ -505,8 +660,8 @@ routine createUmlPackage(java::Package jPackage, uml::Model uModel) {
 }
 
 reaction JavaPackageDeleted {
-	after element java::Package deleted and removed as root
-	call deleteCorrespondingUmlPackage(oldValue)
+	after element java::Package deleted
+	call deleteCorrespondingUmlPackage(affectedEObject)
 }
 
 routine deleteCorrespondingUmlPackage(java::Package jPackage) {
@@ -528,132 +683,16 @@ routine deleteUmlPackage(uml::Package umlPackage) {
 	}
 }
 
-reaction JavaCompilationUnitInsertedInPackage {
-	after element java::CompilationUnit inserted in java::Package[compilationUnits]
-	call addUmlPackageOfClass(affectedEObject, newValue.classifiers.head)
-}
-
-reaction JavaCompilationUnitRemovedFromPackage {
-	after element java::CompilationUnit removed from java::Package[compilationUnits]
-	call removeUmlPackageOfClass(affectedEObject, oldValue.classifiers.head)
-}
-
-routine addUmlPackageOfClass(java::Package jPackage, java::ConcreteClassifier jClassifier) {
-	match {
-		val uClassifier = retrieve uml::Classifier corresponding to jClassifier
-		val uPackage = retrieve uml::Package corresponding to jPackage
-	}
-	action {
-		update uPackage {
-			uPackage.packagedElements += uClassifier
-		}
-	}
-}
-
-routine removeUmlPackageOfClass(java::Package jPackage, java::ConcreteClassifier jClassifier) {
-	match {
-		val uClassifier = retrieve uml::Classifier corresponding to jClassifier
-		val uPackage = retrieve uml::Package corresponding to jPackage
-	}
-	action {
-		update uPackage {
-			uPackage.packagedElements -= uClassifier
-		}
-	}
-}
-
-routine addUmlElementToModelOrPackage(java::JavaRoot javaRoot, uml::PackageableElement umlPackageableElement) {
-	match {
-		val uModel = retrieve asserted uml::Model corresponding to UMLPackage.Literals.MODEL
-	}
-	action {
-		call {
-			val uPackage = if (javaRoot.namespaces.nullOrEmpty) {
-				uModel
-			} else {
-				findUmlPackage(uModel, javaRoot.namespaces.last)
-			}
-			checkState(uPackage !== null, "Package %s does not exist in UML model", javaRoot.namespaces)
-			if (uPackage !== umlPackageableElement.eContainer) {
-				addUmlElementToPackage(umlPackageableElement, uPackage)
-			}
-		}
-	}
-}
-
-//===========================================
-//=========================================== Enum
-//===========================================
-
-reaction JavaEnumCreated {
-	after element java::Enumeration created and inserted in java::CompilationUnit[classifiers]
-	call {
-		detectOrCreateUmlModel(affectedEObject)
-		registerPredefinedUmlPrimitiveTypes(correspondenceModel, affectedEObject.eResource.resourceSet)
-		createUmlEnum(newValue, affectedEObject)
-	}
-}
-
-routine createUmlEnum(java::Enumeration jEnum, java::CompilationUnit jCompUnit) {
-	match {
-		require absence of uml::Enumeration corresponding to jEnum
-	}
-	action {
-		val uEnum = create uml::Enumeration and initialize {
-			uEnum.name = jEnum.name
-			uEnum.visibility = getUmlVisibilityKindFromJavaElement(jEnum)
-		}
-		call addUmlElementToModelOrPackage(jCompUnit, uEnum)
-		add correspondence between uEnum and jEnum
-		add correspondence between uEnum and jCompUnit
-	}
-}
-
-reaction JavaEnumConstantCreated {
-	after element java::EnumConstant created and inserted in java::Enumeration[constants]
-	call createUmlEnumLiteral(affectedEObject, newValue)
-}
-
-routine createUmlEnumLiteral(java::Enumeration jEnum, java::EnumConstant jConstant) {
-	match {
-		val uEnum = retrieve uml::Enumeration corresponding to jEnum
-		require absence of uml::EnumerationLiteral corresponding to jConstant
-	}
-	action {
-		val uLiteral = create uml::EnumerationLiteral and initialize {
-			uLiteral.name = jConstant.name
-		}
-		add correspondence between uLiteral and jConstant
-		update uEnum {
-			uEnum.ownedLiterals += uLiteral
-		}
-	}
-}
-
-reaction JavaEnumConstantDeleted {
-	after element java::EnumConstant deleted and removed from java::Enumeration[constants]
-	call deleteUmlEnumLiteral(oldValue)
-}
-
-routine deleteUmlEnumLiteral(java::EnumConstant jConstant) {
-	match {
-		val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
-	}
-	action {
-		delete uLiteral
-	}
-}
-
 //===========================================
 //=========================================== Unsupported
 //===========================================
 
 reaction JavaEnumerationImplementAdded {
-	after element java::TypeReference created and inserted in java::Enumeration[implements]
+	after element java::TypeReference inserted in java::Enumeration[implements]
 	call showMessage(userInteractor, "Implement relations from enums are not supported. Please remove it from " + affectedEObject)
 }
 
 reaction JavaClassifierMadeStatic {
-	after element java::Static created and inserted in java::ConcreteClassifier[annotationsAndModifiers]
+	after element java::Static inserted in java::ConcreteClassifier[annotationsAndModifiers]
 	call showMessage(userInteractor, "Static classifiers are not supported. Please undo the change at " + affectedEObject)
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -43,7 +43,6 @@ reaction UmlClassInserted {
 routine createOrFindJavaClass(uml::Classifier umlClassifier) {
 	match{
 		require absence of java::Class corresponding to umlClassifier
-		require absence of java::CompilationUnit corresponding to umlClassifier
 		val javaPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
 	}
 	action {
@@ -84,30 +83,25 @@ routine createJavaClass(uml::Classifier umlClassifier) {
 routine addMissingClassifierCorrespondence(uml::Classifier umlClassifier, java::ConcreteClassifier javaClassifier) {
 	action {
 		add correspondence between javaClassifier and umlClassifier
-		add correspondence between javaClassifier.containingCompilationUnit and umlClassifier
 	}
 }
 
 routine createJavaCompilationUnit(uml::Classifier umlClassifier, java::ConcreteClassifier jClassifier) {
-	match {
-		require absence of java::CompilationUnit corresponding to umlClassifier
-	}
 	action {
 		val javaCompilationUnit = create java::CompilationUnit and initialize {
 			javaCompilationUnit.classifiers += jClassifier
 		}
-		add correspondence between umlClassifier and javaCompilationUnit
 	}
 }
 
 routine insertJavaClassifier(uml::Classifier umlClassifier, uml::Package umlPackage) {
 	match {
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-		val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifier
 		val javaPackage = retrieve optional java::Package corresponding to umlPackage
 	}
 	action {
-		update javaCompilationUnit {
+		update javaClassifier.containingCompilationUnit {
+		    val javaCompilationUnit = javaClassifier.containingCompilationUnit
 			var modified = javaCompilationUnit.updateNamespaces(javaPackage)
 			val newName = getCompilationUnitName(javaPackage, javaClassifier.name)
 			modified = javaCompilationUnit.updateName(newName) || modified
@@ -116,6 +110,7 @@ routine insertJavaClassifier(uml::Classifier umlClassifier, uml::Package umlPack
 			}
 		}
 		call javaPackage.ifPresent [
+		    val javaCompilationUnit = javaClassifier.containingCompilationUnit
 			if (!compilationUnits.contains(javaCompilationUnit)) {
 				compilationUnits += javaCompilationUnit
 			}
@@ -132,7 +127,6 @@ routine renameJavaClassifier(uml::Classifier umlClassifier) {
 	match {
 		val jPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-		val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifier
 		check umlClassifier.name != javaClassifier.name
 	}
 	action {
@@ -151,11 +145,9 @@ reaction UmlClassifierDeleted {
 routine deleteJavaClass(uml::Classifier umlClassifer) {
 	match {
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifer
-		val javaCompilationUnit = retrieve java::CompilationUnit corresponding to umlClassifer
 	}
 	action {
-		delete javaClassifier
-		delete javaCompilationUnit
+	    delete javaClassifier.containingCompilationUnit
 	}
 }
 
@@ -233,7 +225,7 @@ routine deleteJavaSuperClass(uml::Generalization uGeneralization) {
 	}
 }
 
-reaction UmlSuperClassReplaced{
+reaction UmlSuperClassReplaced {
 	after element uml::Class replaced at uml::Generalization[general]
 	with {affectedEObject.specific !== null && affectedEObject.specific instanceof Class}
 	call {
@@ -460,9 +452,7 @@ routine createJavaEnum(uml::Enumeration uEnum) {
 			jEnum.name = uEnum.name
 			jEnum.makePublic
 		}
-		call {
-			createJavaCompilationUnit(uEnum, jEnum)
-		}
+		call createJavaCompilationUnit(uEnum, jEnum)
 		add correspondence between uEnum and jEnum
 	}
 }

--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/uml/UmlClassifierAndPackageUtil.xtend
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/uml/UmlClassifierAndPackageUtil.xtend
@@ -80,6 +80,10 @@ class UmlClassifierAndPackageUtil {
         return umlModel.findUmlType(className, packageName, Class)
     }
 
+    def static Enumeration findUmlEnum(Model umlModel, String className, String packageName) {
+        return umlModel.findUmlType(className, packageName, Enumeration)
+    }
+
     def private static <T extends Type> findUmlType(Model umlModel, String typeName, String packageName, java.lang.Class<T> type) {
         val uPackage = umlModel.findUmlPackage(packageName)
         if (uPackage === null) {

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -14,7 +14,6 @@ import org.emftext.language.java.JavaClasspath;
 import org.emftext.language.java.classifiers.Class;
 import org.emftext.language.java.classifiers.Classifier;
 import org.emftext.language.java.commons.NamedElement;
-import org.emftext.language.java.containers.CompilationUnit;
 import org.emftext.language.java.imports.Import;
 import org.emftext.language.java.instantiations.NewConstructorCall;
 import org.emftext.language.java.members.Constructor;
@@ -98,14 +97,14 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	protected void assertDataTypeCorrespondence(final DataType dataType) throws Throwable {
 		if (dataType instanceof CollectionDataType) {
 			final CollectionDataType cdt = (CollectionDataType) dataType;
-			this.assertCorrespondnecesAndCompareNames(cdt, 3,
-					new java.lang.Class[] { CompilationUnit.class, Classifier.class, TypeReference.class },
-					new String[] { cdt.getEntityName() + ".java", cdt.getEntityName(), null });
+			this.assertCorrespondencesAndCompareNames(cdt, 2,
+					new java.lang.Class[] { Classifier.class, TypeReference.class },
+					new String[] { cdt.getEntityName(), null });
 		} else if (dataType instanceof CompositeDataType) {
 			final CompositeDataType cdt = (CompositeDataType) dataType;
-			this.assertCorrespondnecesAndCompareNames(cdt, 2,
-					new java.lang.Class[] { CompilationUnit.class, Classifier.class },
-					new String[] { cdt.getEntityName() + ".java", cdt.getEntityName() });
+			this.assertCorrespondencesAndCompareNames(cdt, 1,
+					new java.lang.Class[] { Classifier.class },
+					new String[] { cdt.getEntityName() });
 		} else if (dataType instanceof PrimitiveDataType) {
 			final PrimitiveDataType pdt = (PrimitiveDataType) dataType;
 			assertTrue(null != DataTypeCorrespondenceHelper.claimJaMoPPTypeForPrimitiveDataType(pdt),
@@ -114,7 +113,7 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 
 	}
 
-	protected <T> Set<NamedElement> assertCorrespondnecesAndCompareNames(final EObject pcmNamedElement,
+	protected <T> Set<NamedElement> assertCorrespondencesAndCompareNames(final EObject pcmNamedElement,
 			final int expectedSize, final java.lang.Class<? extends EObject>[] expectedClasses,
 			final String[] expectedNames) throws Throwable {
 		final Iterable<EObject> correspondences = claimNotEmpty(getCorrespondingEObjects(pcmNamedElement, EObject.class));
@@ -182,7 +181,7 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	protected NamedElement assertSingleCorrespondence(
 			final org.palladiosimulator.pcm.core.entity.NamedElement pcmNamedElement,
 			final java.lang.Class<? extends EObject> expectedClass, final String expectedName) throws Throwable {
-		final Set<NamedElement> namedElements = this.assertCorrespondnecesAndCompareNames(pcmNamedElement, 1,
+		final Set<NamedElement> namedElements = this.assertCorrespondencesAndCompareNames(pcmNamedElement, 1,
 				new java.lang.Class[] { expectedClass }, new String[] { expectedName });
 		return namedElements.iterator().next();
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/BasicComponentMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/BasicComponentMappingTransformationTest.java
@@ -2,7 +2,6 @@ package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.rep
 
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.emftext.language.java.classifiers.Class;
-import org.emftext.language.java.containers.CompilationUnit;
 import org.emftext.language.java.containers.Package;
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.pcm.repository.BasicComponent;

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/BasicComponentMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/BasicComponentMappingTransformationTest.java
@@ -60,9 +60,9 @@ public class BasicComponentMappingTransformationTest extends Pcm2JavaTransformat
 
 	@SuppressWarnings("unchecked")
 	private void assertBasicComponentCorrespondences(final BasicComponent basicComponent) throws Throwable {
-		this.assertCorrespondnecesAndCompareNames(basicComponent, 3,
-				new java.lang.Class[] { CompilationUnit.class, Package.class, Class.class },
-				new String[] { basicComponent.getEntityName() + "Impl", basicComponent.getEntityName(),
+		this.assertCorrespondencesAndCompareNames(basicComponent, 2,
+				new java.lang.Class[] { Package.class, Class.class },
+				new String[] { basicComponent.getEntityName(),
 						basicComponent.getEntityName() + "Impl" });
 
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/CompositeComponentMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/CompositeComponentMappingTransformationTest.java
@@ -2,7 +2,6 @@ package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.rep
 
 import java.io.IOException;
 
-import org.emftext.language.java.containers.CompilationUnit;
 import org.emftext.language.java.containers.Package;
 import org.junit.jupiter.api.Test;
 
@@ -98,10 +97,9 @@ public class CompositeComponentMappingTransformationTest extends Pcm2JavaTransfo
 	@SuppressWarnings("unchecked")
 	private void assertCompositeComponentCorrespondences(final CompositeComponent compositeComponent,
 			final String expectedName) throws Throwable {
-		super.assertCorrespondnecesAndCompareNames(compositeComponent, 3,
-				new java.lang.Class[] { Package.class, org.emftext.language.java.classifiers.Class.class,
-						CompilationUnit.class },
-				new String[] { expectedName, expectedName + "Impl", expectedName + "Impl" });
+		super.assertCorrespondencesAndCompareNames(compositeComponent, 2,
+				new java.lang.Class[] { Package.class, org.emftext.language.java.classifiers.Class.class },
+				new String[] { expectedName, expectedName + "Impl" });
 	}
 
 }

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationInterfaceMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationInterfaceMappingTransformationTest.java
@@ -1,7 +1,6 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository;
 
 import org.emftext.language.java.classifiers.Interface;
-import org.emftext.language.java.containers.CompilationUnit;
 import org.junit.jupiter.api.Test;
 
 import org.palladiosimulator.pcm.repository.OperationInterface;
@@ -34,8 +33,8 @@ public class OperationInterfaceMappingTransformationTest extends Pcm2JavaTransfo
 
 	@SuppressWarnings("unchecked")
 	private void assertOperationInterfaceCorrespondences(final OperationInterface opInterface) throws Throwable {
-		this.assertCorrespondnecesAndCompareNames(opInterface, 2,
-				new java.lang.Class[] { CompilationUnit.class, Interface.class },
-				new String[] { opInterface.getEntityName(), opInterface.getEntityName() });
+		this.assertCorrespondencesAndCompareNames(opInterface, 1,
+				new java.lang.Class[] { Interface.class },
+				new String[] { opInterface.getEntityName() });
 	}
 }

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationProvidedRoleMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/OperationProvidedRoleMappingTransformationTest.java
@@ -1,7 +1,6 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository;
 
 import org.emftext.language.java.classifiers.Class;
-import org.emftext.language.java.containers.CompilationUnit;
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.pcm.repository.BasicComponent;
 import org.palladiosimulator.pcm.repository.OperationInterface;
@@ -97,8 +96,7 @@ public class OperationProvidedRoleMappingTransformationTest extends Pcm2JavaTran
 		propagate();
 
 		this.assertOperationProvidedRole(operationProvidedRole);
-		final CompilationUnit jaMoPPCu = claimOne(getCorrespondingEObjects(basicComponent, CompilationUnit.class));
-		final Class jaMoPPClass = (Class) jaMoPPCu.getClassifiers().get(0);
+		final Class jaMoPPClass = claimOne(getCorrespondingEObjects(basicComponent, Class.class));
 		assertEquals(1, jaMoPPClass.getImplements().size(), "Unexpected size of implemented interfaces");
 	}
 

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/PcmParameterMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/PcmParameterMappingTransformationTest.java
@@ -118,7 +118,7 @@ public class PcmParameterMappingTransformationTest extends Pcm2JavaTransformatio
 	@SuppressWarnings("unchecked")
 	private void assertParameterCorrespondences(final Parameter param) throws Throwable {
 		this.assertDataTypeCorrespondence(param.getDataType__Parameter());
-		this.assertCorrespondnecesAndCompareNames(param, 1, new java.lang.Class[] { OrdinaryParameter.class },
+		this.assertCorrespondencesAndCompareNames(param, 1, new java.lang.Class[] { OrdinaryParameter.class },
 				new String[] { param.getParameterName() });
 	}
 

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/RepositoryMappingTransformaitonTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/repository/RepositoryMappingTransformaitonTest.java
@@ -1,7 +1,6 @@
 package tools.vitruv.applications.pcmjava.tests.pojotransformations.pcm2java.repository;
 
 import org.emftext.language.java.classifiers.Class;
-import org.emftext.language.java.containers.CompilationUnit;
 import org.emftext.language.java.containers.Package;
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.pcm.repository.BasicComponent;
@@ -54,11 +53,9 @@ public class RepositoryMappingTransformaitonTest extends Pcm2JavaTransformationT
 	@SuppressWarnings("unchecked")
 	private void assertBasicComponentCorrespondences(final Repository repository, final BasicComponent basicComponent)
 			throws Throwable {
-		this.assertCorrespondnecesAndCompareNames(basicComponent, 3,
-				new java.lang.Class[] { CompilationUnit.class, Package.class, Class.class },
+		this.assertCorrespondencesAndCompareNames(basicComponent, 2,
+				new java.lang.Class[] { Package.class, Class.class },
 				new String[] {
-						repository.getEntityName() + "." + basicComponent.getEntityName() + "."
-								+ basicComponent.getEntityName() + "Impl",
 						basicComponent.getEntityName(), basicComponent.getEntityName() + "Impl" });
 
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/system/SystemMappingTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/system/SystemMappingTransformationTest.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.resource.Resource;
-import org.emftext.language.java.containers.CompilationUnit;
 import org.emftext.language.java.containers.Package;
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.pcm.system.System;
@@ -56,9 +55,9 @@ public class SystemMappingTransformationTest extends Pcm2JavaTransformationTest 
 	private void assertSystem(final System system) throws Throwable {
 		final String expectedName = system.getEntityName();
 		final String expectedLowerCaseName = Character.toLowerCase(expectedName.charAt(0)) + expectedName.substring(1);
-		this.assertCorrespondnecesAndCompareNames(system, 4,
-				new Class[] { Package.class, CompilationUnit.class, org.emftext.language.java.classifiers.Class.class,
+		this.assertCorrespondencesAndCompareNames(system, 3,
+				new Class[] { Package.class, org.emftext.language.java.classifiers.Class.class,
 						EClass.class },
-				new String[] { expectedLowerCaseName, expectedName + "Impl", expectedName + "Impl", null });
+				new String[] { expectedLowerCaseName, expectedName + "Impl", null });
 	}
 }

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlEnumTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlEnumTest.xtend
@@ -122,6 +122,28 @@ class JavaToUmlEnumTest extends AbstractJavaToUmlTest {
 			assertUmlEnumHasLiteral(umlEnum, UMLFactory.eINSTANCE.createEnumerationLiteral => [name = CONSTANT_NAME])
 		]
 	}
+	
+	@Test
+    def void testRenameEnumConstant() {
+        createJavaEnumInRootPackage(ENUM_NAME)
+        changeJavaView [
+            claimJavaEnum(ENUM_NAME) => [
+                constants += MembersFactory.eINSTANCE.createEnumConstant => [
+                    name = CONSTANT_NAME
+                ]
+            ]
+        ]
+        changeJavaView [
+            claimJavaEnum(ENUM_NAME) => [
+                constants.head.name = CONSTANT_NAME_2
+            ]
+        ]
+        assertSingleEnumWithNameInRootPackage(ENUM_NAME)
+        validateUmlView [
+            val umlEnum = defaultUmlModel.claimEnum(ENUM_NAME)
+            assertUmlEnumHasLiteral(umlEnum, UMLFactory.eINSTANCE.createEnumerationLiteral => [name = CONSTANT_NAME_2])
+        ]
+    }
 
 	@Test
 	def void testDeleteEnumConstant() {

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAttributeTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAttributeTest.xtend
@@ -22,6 +22,7 @@ import org.eclipse.uml2.uml.Model
 import org.eclipse.uml2.uml.PrimitiveType
 import static tools.vitruv.applications.umljava.tests.util.TransformationDirectionConfiguration.configureBidirectionalExecution
 import static tools.vitruv.applications.umljava.tests.util.JavaElementsTestAssertions.*
+import static tools.vitruv.applications.umljava.tests.util.UmlElementsTestAssertions.assertUmlClassDontHaveOperation
 
 /**
  * This test class checks the creating, deleting and modifying of attributes in the UML to Java
@@ -231,6 +232,56 @@ class UmlToJavaAttributeTest extends AbstractUmlToJavaTest {
 		override setupTransformationDirection() {
 			configureBidirectionalExecution()
 		}
+
+	   @Test
+        override testCreatePrimitiveAttribute() {
+            super.testCreatePrimitiveAttribute()
+            validateUmlView [
+                val umlClass = defaultUmlModel.claimClass(CLASS_NAME)
+                assertUmlClassDontHaveOperation(umlClass, buildGetterName(ATTRIBUTE_NAME))
+                assertUmlClassDontHaveOperation(umlClass, buildSetterName(ATTRIBUTE_NAME))
+            ]
+        }
+
+	   @Test
+        override testCreateAttribute() {
+            super.testCreateAttribute()
+            validateUmlView [
+                val umlClass = defaultUmlModel.claimClass(CLASS_NAME)
+                assertUmlClassDontHaveOperation(umlClass, buildGetterName(ATTRIBUTE_NAME))
+                assertUmlClassDontHaveOperation(umlClass, buildSetterName(ATTRIBUTE_NAME))
+            ]
+        }
+
+        @Test
+        override testRenameAttribute() {
+            super.testRenameAttribute()
+            validateUmlView [
+                val umlClass = defaultUmlModel.claimClass(CLASS_NAME)
+                assertUmlClassDontHaveOperation(umlClass, buildGetterName(ATTRIBUTE_RENAME))
+                assertUmlClassDontHaveOperation(umlClass, buildSetterName(ATTRIBUTE_RENAME))
+            ]
+        }
+
+        @Test
+        override testChangeAttributeType() {
+            super.testChangeAttributeType()
+            validateUmlView [
+                val umlClass = defaultUmlModel.claimClass(CLASS_NAME)
+                assertUmlClassDontHaveOperation(umlClass, buildGetterName(ATTRIBUTE_NAME))
+                assertUmlClassDontHaveOperation(umlClass, buildSetterName(ATTRIBUTE_NAME))
+            ]
+        }
+
+        @Test
+        override testMoveAttribute() {
+            super.testMoveAttribute()
+            validateUmlView [
+                val umlClass = defaultUmlModel.claimClass(CLASS_NAME_2)
+                assertUmlClassDontHaveOperation(umlClass, buildGetterName(ATTRIBUTE_NAME))
+                assertUmlClassDontHaveOperation(umlClass, buildSetterName(ATTRIBUTE_NAME))
+            ]
+        }
 	}
 
 }


### PR DESCRIPTION
This PR removes correspondences to `Java::CompilationUnit` from UML <-> Java and PCM <-> Java. Additionally, minor improvements to the reactions and tests are added.

### Correspondences to Compilation Unit

Each Java `Classifier` (`Class`, `Interface`, or `Enum`) is contained in a `CompilationUnit`. A `CompilationUnit` represents the actual Java file. In the current consistency implementations, every element corresponding to a `Classifier` (e.g. a UML class) has a correspondence to its corresponding Java classifier and the classifier's compilation unit. This PR simplifies this such that only one correspondence is created, the one between the classifier and the corresponding element.

#### Short motivation
A `CompilationUnit`, i.e. the file, might be empty. This cannot be modelled with the old setup.

#### Longer motivation
Since any Java classifier has exactly one compilation unit, the compilation unit can always be unambiguously identified. Thus, a second correspondence to the compilation unit creates redundant data that needs to be managed which introduces an unneeded potential for bugs.
Furthermore, when combining multiple domains, all involved consistency specifications need to be aware of this special two correspondences case and set up the correspondences accordingly.

#### Trigger
This refactoring was triggered as when running the existing UML <-> Java tests using a change deriving view, issues related to incorrect correspondence management occurred. Though it would be possible to also fix the existing reactions, due to the motivations above I decided to clean up the correspondences.
<details>
<summary>Failure Log</summary>

````
java.lang.IllegalStateException: Correspondence between
[org.eclipse.uml2.uml.internal.impl.ClassImpl@512b7034 
  (name: ClassName, visibility: package) 
  (isLeaf: false, isAbstract: false, isFinalSpecialization: false) (isActive: false)] 
and 
[org.emftext.language.java.containers.impl.CompilationUnitImpl@218bcbc7
  (name: ClassName.java) (namespaces: [])] 
contains elements
[org.emftext.language.java.containers.impl.CompilationUnitImpl@218bcbc7 
  (name: ClassName.java) (namespaces: [])] 
that are not contained in a resource anymore.
````

</details>

#### Discussion
There are multiple test cases which require that upon deletion of e.g. a UML class the Java compilation unit is deleted by the consistency specification. I kept these assumptions in the test cases. However, I think it would be cleaner to only expect the deletion of the Java classifier from the consistency specification and delegate the cleanup of the compilation unit to the Java domain, i.e. have some algorithm that runs after change propagation is completed.


### Further minor improvements
- adds create-or-find pattern to Java enums -> UML
- adds support for renaming of Java enum constants -> UML incl. test case
- removes compound triggers from Java classifiers -> UML reactions
- adds validation for bidirectional UML -> Java test cases that for a Java accessor created from a UML attribute no additional UML method is created