### PR TITLE
Adapt to removal of domains from DSLs

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -43,8 +43,8 @@ import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: pcm2javaCommon
-in reaction to changes in PCM
-execute actions in Java
+in reaction to changes in pcm
+execute actions in java
 
 // ###################################################
 // ################ PACKAGE REACTIONS ################

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
@@ -20,8 +20,8 @@ import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: pcm2depInjectJava
-in reaction to changes in PCM
-execute actions in Java
+in reaction to changes in pcm
+execute actions in java
 
 import pcm2javaCommon
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/src/tools/vitruv/applications/pcmjava/ejbtransformations/java2pcm/EjbJava2Pcm.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/src/tools/vitruv/applications/pcmjava/ejbtransformations/java2pcm/EjbJava2Pcm.reactions
@@ -17,8 +17,8 @@ import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: ejbjava2pcm 
-in reaction to changes in Java
-execute actions in PCM
+in reaction to changes in java
+execute actions in pcm
 
 // ###################################################
 // ################ create Repository for first package################

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/src/tools/vitruv/applications/pcmjava/ejbtransformations/pcm2java/Pcm2EjbJava.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/src/tools/vitruv/applications/pcmjava/ejbtransformations/pcm2java/Pcm2EjbJava.reactions
@@ -11,8 +11,8 @@ import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: pcm2EjbJava
-in reaction to changes in PCM
-execute actions in Java
+in reaction to changes in pcm
+execute actions in java
 
 import pcm2javaCommon
 

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2Pcm.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2Pcm.reactions
@@ -2,8 +2,8 @@ import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: java2Pcm
-in reaction to changes in Java
-execute actions in PCM
+in reaction to changes in java
+execute actions in pcm
 
 import java2PcmClassifier
 import java2PcmMethod

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmClassifier.reactions
@@ -22,8 +22,8 @@ import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: java2PcmClassifier
-in reaction to changes in Java
-execute actions in PCM
+in reaction to changes in java
+execute actions in pcm
 
 ///Repository
 reaction PackageCreated {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/java2pcm/Java2PcmMethod.reactions
@@ -12,8 +12,8 @@ import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: java2PcmMethod
-in reaction to changes in Java
-execute actions in PCM
+in reaction to changes in java
+execute actions in pcm
 
 
 // General:

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/pcm2java/Pcm2Java.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations/src/tools/vitruv/applications/pcmjava/pojotransformations/pcm2java/Pcm2Java.reactions
@@ -2,7 +2,7 @@ import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: pcm2java
-in reaction to changes in PCM
-execute actions in Java
+in reaction to changes in pcm
+execute actions in java
 
 import pcm2javaCommon

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/Component.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/Component.commonality
@@ -2,6 +2,8 @@ import tools.vitruv.applications.cbs.commonalities.domaincommon.operators._
 import tools.vitruv.applications.cbs.commonalities.oo.operators._
 import tools.vitruv.applications.cbs.commonalities.pcm.operators._
 
+import "http://palladiosimulator.org/PalladioComponentModel/5.2" as PCM
+
 concept ComponentBasedSystems
 
 // Externally contained by ComponentBasedSystems:Repository.components

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/ComponentInterface.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/ComponentInterface.commonality
@@ -1,3 +1,5 @@
+import "http://palladiosimulator.org/PalladioComponentModel/5.2" as PCM
+
 concept ComponentBasedSystems
 
 // Externally contained by ComponentBasedSystems:Repository.componentInterfaces

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/CompositeDataType.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/CompositeDataType.commonality
@@ -1,3 +1,5 @@
+import "http://palladiosimulator.org/PalladioComponentModel/5.2" as PCM
+
 concept ComponentBasedSystems
 
 // Externally contained by ComponentBasedSystems:Repository.compositeDataTypes

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/CompositeDataTypeElement.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/CompositeDataTypeElement.commonality
@@ -1,6 +1,8 @@
 import tools.vitruv.applications.cbs.commonalities.oo.operators._
 import tools.vitruv.applications.cbs.commonalities.pcm.operators._
 
+import "http://palladiosimulator.org/PalladioComponentModel/5.2" as PCM
+
 concept ComponentBasedSystems
 
 // Externally contained by ComponentBasedSystems:CompositeDataType.elements

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/Operation.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/Operation.commonality
@@ -1,6 +1,8 @@
 import tools.vitruv.applications.cbs.commonalities.oo.operators._
 import tools.vitruv.applications.cbs.commonalities.pcm.operators._
 
+import "http://palladiosimulator.org/PalladioComponentModel/5.2" as PCM
+
 concept ComponentBasedSystems
 
 // Externally contained by ComponentBasedSystems:ComponentInterface.operations

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/OperationParameter.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/OperationParameter.commonality
@@ -1,6 +1,8 @@
 import tools.vitruv.applications.cbs.commonalities.oo.operators._
 import tools.vitruv.applications.cbs.commonalities.pcm.operators._
 
+import "http://palladiosimulator.org/PalladioComponentModel/5.2" as PCM
+
 concept ComponentBasedSystems
 
 // Externally contained by ComponentBasedSystems:Operation.parameters

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/Repository.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/cbs/Repository.commonality
@@ -1,5 +1,7 @@
 import tools.vitruv.applications.cbs.commonalities.domaincommon.operators._
 
+import "http://palladiosimulator.org/PalladioComponentModel/5.2" as PCM
+
 concept ComponentBasedSystems
 
 commonality Repository {

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Class.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Class.commonality
@@ -1,6 +1,9 @@
 import tools.vitruv.applications.cbs.commonalities.java.operators._
 import tools.vitruv.applications.cbs.commonalities.uml.operators._
 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as UML
+import "http://www.emftext.org/java" as Java
+
 concept ObjectOrientedDesign
 
 // Optionally externally contained by ObjectOrientedDesign:Package.classes

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/ClassMethod.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/ClassMethod.commonality
@@ -1,6 +1,9 @@
 import tools.vitruv.applications.cbs.commonalities.java.operators._
 import tools.vitruv.applications.cbs.commonalities.uml.operators._
 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as UML
+import "http://www.emftext.org/java" as Java
+
 concept ObjectOrientedDesign
 
 // Externally contained by ObjectOrientedDesign:Class.methods

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Constructor.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Constructor.commonality
@@ -1,6 +1,9 @@
 import tools.vitruv.applications.cbs.commonalities.java.operators._
 import tools.vitruv.applications.cbs.commonalities.uml.operators._
 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as UML
+import "http://www.emftext.org/java" as Java
+
 concept ObjectOrientedDesign
 
 // Externally contained by ObjectOrientedDesign:Class.constructors

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Interface.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Interface.commonality
@@ -1,6 +1,9 @@
 import tools.vitruv.applications.cbs.commonalities.java.operators._
 import tools.vitruv.applications.cbs.commonalities.uml.operators._
 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as UML
+import "http://www.emftext.org/java" as Java
+
 concept ObjectOrientedDesign
 
 // Optionally externally contained by ObjectOrientedDesign:Package.interfaces

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/InterfaceMethod.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/InterfaceMethod.commonality
@@ -2,6 +2,9 @@ import tools.vitruv.applications.cbs.commonalities.domaincommon.operators._
 import tools.vitruv.applications.cbs.commonalities.java.operators._
 import tools.vitruv.applications.cbs.commonalities.uml.operators._
 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as UML
+import "http://www.emftext.org/java" as Java
+
 concept ObjectOrientedDesign
 
 // Externally contained by ObjectOrientedDesign:Interface.methods

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/MethodParameter.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/MethodParameter.commonality
@@ -1,6 +1,9 @@
 import tools.vitruv.applications.cbs.commonalities.java.operators._
 import tools.vitruv.applications.cbs.commonalities.uml.operators._
 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as UML
+import "http://www.emftext.org/java" as Java
+
 concept ObjectOrientedDesign
 
 // Externally contained by ObjectOrientedDesign:InterfaceMethod.parameters

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Package.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Package.commonality
@@ -1,5 +1,8 @@
 import tools.vitruv.applications.cbs.commonalities.java.operators._
 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as UML
+import "http://www.emftext.org/java" as Java
+
 concept ObjectOrientedDesign
 
 // Optionally externally contained by ObjectOrientedDesign:Package.subPackages

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Property.commonality
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/Property.commonality
@@ -1,6 +1,9 @@
 import tools.vitruv.applications.cbs.commonalities.java.operators._
 import tools.vitruv.applications.cbs.commonalities.uml.operators._
 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as UML
+import "http://www.emftext.org/java" as Java
+
 concept ObjectOrientedDesign
 
 // Externally contained by ObjectOrientedDesign:Class.properties

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_component.mappings
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_component.mappings
@@ -1,7 +1,7 @@
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
     	
-mappings: umlXpcmComponent for UML and PCM
+mappings: umlXpcmComponent for uml and pcm
  
 mapping RepositoryComponent {
 			

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_datatypes.mappings
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_datatypes.mappings
@@ -1,7 +1,7 @@
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
     	
-mappings: umlXpcmDatatypes for UML and PCM
+mappings: umlXpcmDatatypes for uml and pcm
  
 mapping CompositeDataype {
 	map(pcm::CompositeDataType type

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_interface.mappings
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_interface.mappings
@@ -1,7 +1,7 @@
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
     	
-mappings: umlXpcmInterface for UML and PCM
+mappings: umlXpcmInterface for uml and pcm
  
 mapping OperationInterface {
 

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_parameters.mappingss
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_parameters.mappingss
@@ -1,7 +1,7 @@
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
     	
-mappings: umlXpcmParameters for UML and PCM
+mappings: umlXpcmParameters for uml and pcm
  
 //TODO: finish mapping 
 

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_repository.mappings
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_repository.mappings
@@ -1,7 +1,7 @@
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
     	
-mappings: umlXpcmRepository for UML and PCM
+mappings: umlXpcmRepository for uml and pcm
  
 mapping Repository {
 

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_roles.mappings
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_roles.mappings
@@ -1,7 +1,7 @@
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
     	
-mappings: umlXpcmRoles for UML and PCM
+mappings: umlXpcmRoles for uml and pcm
  
 mapping RequiredRole {
 

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_signature.mappings
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping.sources/src/tools/vitruv/applications/pcmumlclass/mapping/uml_pcm_signature.mappings
@@ -1,7 +1,7 @@
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
     	
-mappings: umlXpcmSignature for UML and PCM
+mappings: umlXpcmSignature for uml and pcm
 
 mapping Signature{
 	map(pcm::OperationSignature operationSignature

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmComponent_L2R.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmComponent_L2R.reactions
@@ -8,8 +8,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as repository
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmComponent_L2R in reaction to changes in UML
-execute actions in PCM
+reactions: umlXpcmComponent_L2R in reaction to changes in uml
+execute actions in pcm
 import routines umlXpcmRoutines
 
 reaction OnRepositoryComponentPackageInsertedInPackage {

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmComponent_R2L.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmComponent_R2L.reactions
@@ -8,8 +8,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as r
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmComponent_R2L in reaction to changes in PCM
-execute actions in UML
+reactions: umlXpcmComponent_R2L in reaction to changes in pcm
+execute actions in uml
 import routines umlXpcmRoutines
 reaction OnRepositoryComponentRepositoryInsertedAsRoot {
 	after element repository::Repository created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmDatatypes_L2R.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmDatatypes_L2R.reactions
@@ -8,8 +8,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as repository
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmDatatypes_L2R in reaction to changes in UML
-execute actions in PCM
+reactions: umlXpcmDatatypes_L2R in reaction to changes in uml
+execute actions in pcm
 import routines umlXpcmRoutines
 reaction OnCompositeDataypePackageInsertedAsRoot {
 	after element uml::Package created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmDatatypes_R2L.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmDatatypes_R2L.reactions
@@ -8,8 +8,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as r
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmDatatypes_R2L in reaction to changes in PCM
-execute actions in UML
+reactions: umlXpcmDatatypes_R2L in reaction to changes in pcm
+execute actions in uml
 import routines umlXpcmRoutines
 reaction OnCompositeDataypeRepositoryInsertedAsRoot {
 	after element repository::Repository created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmInterface_L2R.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmInterface_L2R.reactions
@@ -8,8 +8,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as repository
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmInterface_L2R in reaction to changes in UML
-execute actions in PCM
+reactions: umlXpcmInterface_L2R in reaction to changes in uml
+execute actions in pcm
 import routines umlXpcmRoutines
 reaction OnOperationInterfacePackageInsertedAsRoot {
 	after element uml::Package created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmInterface_R2L.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmInterface_R2L.reactions
@@ -8,8 +8,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as r
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmInterface_R2L in reaction to changes in PCM
-execute actions in UML
+reactions: umlXpcmInterface_R2L in reaction to changes in pcm
+execute actions in uml
 import routines umlXpcmRoutines
 reaction OnOperationInterfaceRepositoryInsertedAsRoot {
 	after element repository::Repository created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmRepository_L2R.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmRepository_L2R.reactions
@@ -5,8 +5,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as repository
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmRepository_L2R in reaction to changes in UML
-execute actions in PCM
+reactions: umlXpcmRepository_L2R in reaction to changes in uml
+execute actions in pcm
 import routines umlXpcmRoutines
 reaction OnRepositoryPackageInsertedInPackage {
 	after element uml::Package inserted in uml::Package[packagedElement]

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmRepository_R2L.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmRepository_R2L.reactions
@@ -5,8 +5,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as r
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmRepository_R2L in reaction to changes in PCM
-execute actions in UML
+reactions: umlXpcmRepository_R2L in reaction to changes in pcm
+execute actions in uml
 import routines umlXpcmRoutines
 reaction OnRepositoryRepositoryInsertedAsRoot {
 	after element repository::Repository created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmRoles_L2R.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmRoles_L2R.reactions
@@ -14,8 +14,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as r
 import "http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2" as entity
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmRoles_L2R in reaction to changes in UML
-execute actions in PCM
+reactions: umlXpcmRoles_L2R in reaction to changes in uml
+execute actions in pcm
 import routines umlXpcmRoutines
 reaction OnRequiredRoleClassInsertedAsRoot {
 	after element uml::Class created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmRoles_R2L.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmRoles_R2L.reactions
@@ -14,8 +14,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2" as 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmRoles_R2L in reaction to changes in PCM
-execute actions in UML
+reactions: umlXpcmRoles_R2L in reaction to changes in pcm
+execute actions in uml
 import routines umlXpcmRoutines
 reaction OnRequiredRoleOperationInterfaceInsertedAsRoot {
 	after element repository::OperationInterface created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmSignature_L2R.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmSignature_L2R.reactions
@@ -9,8 +9,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as repository
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmSignature_L2R in reaction to changes in UML
-execute actions in PCM
+reactions: umlXpcmSignature_L2R in reaction to changes in uml
+execute actions in pcm
 import routines umlXpcmRoutines
 reaction OnSignatureInterfaceInsertedAsRoot {
 	after element uml::Interface created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmSignature_R2L.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/external-src/tools/vitruv/applications/pcmumlclass/mapping/sources/umlXpcmSignature_R2L.reactions
@@ -9,8 +9,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/Repository/5.2" as r
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
-reactions: umlXpcmSignature_R2L in reaction to changes in PCM
-execute actions in UML
+reactions: umlXpcmSignature_R2L in reaction to changes in pcm
+execute actions in uml
 import routines umlXpcmRoutines
 reaction OnSignatureDataTypeInsertedAsRoot {
 	after element repository::DataType created

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/PcmCollectionDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/PcmCollectionDataType.reactions
@@ -23,8 +23,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		SignatureConceptTest, ParameterConceptTest, AttributeConceptTest
 
 reactions: pcmCollectionDataTypeReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 reaction CollectionDataTypeInnerTypeChanged {
 	after element replaced at pcm::CollectionDataType[innerType_CollectionDataType]

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/PcmDataTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/PcmDataTypePropagation.reactions
@@ -18,8 +18,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmParameter.reactions
 
 reactions: pcmDataTypePropagationReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 routine setUmlParameterType(
 		pcm::DataType pcmType, 

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/UmlReturnAndRegularParameterType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/UmlReturnAndRegularParameterType.reactions
@@ -20,8 +20,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		SignatureConceptTest, ParameterConceptTest
 
 reactions: umlReturnAndRegularParameterTypeReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 //in parameter mapping aufnehmen (falls nicht optional)
 

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/combinedPcmToUml.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/combinedPcmToUml.reactions
@@ -2,8 +2,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: combinedPcmToUml
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 import umlXpcmComponent_R2L using qualified names
 import umlXpcmDatatypes_R2L using qualified names

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/combinedUmlToPcm.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/combinedUmlToPcm.reactions
@@ -2,8 +2,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: combinedUmlToPcm
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 import umlXpcmComponent_L2R using qualified names
 import umlXpcmDatatypes_L2R using qualified names

--- a/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/routines.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass.mapping/src/tools/vitruv/applications/pcmumlclass/mapping/routines.reactions
@@ -12,8 +12,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //will be ignored anyway because we only import the routines
 reactions: umlXpcmRoutines 
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 import routines pcmDataTypePropagationReactions using qualified names
 import routines umlReturnAndRegularParameterTypeReactions using qualified names

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/CombinedPcmToUmlClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/CombinedPcmToUmlClass.reactions
@@ -2,8 +2,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: combinedPcmToUmlClassReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 import pcmRepositoryReactions using qualified names
 import pcmSystemReactions using qualified names

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/CombinedUmlClassToPcm.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/CombinedUmlClassToPcm.reactions
@@ -2,8 +2,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: combinedUmlClassToPcmReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 import umlRepositoryAndSystemPackageReactions using qualified names
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
@@ -15,8 +15,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		AssemblyContextConceptTest
 
 reactions: pcmAssemblyContextReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 reaction AssemblyContextInserted {
 	after element pcm::AssemblyContext inserted in pcm::ComposedProvidingRequiringEntity[assemblyContexts__ComposedStructure]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
@@ -25,8 +25,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		SignatureConceptTest, ParameterConceptTest, AttributeConceptTest
 
 reactions: pcmCollectionDataTypeReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 reaction CollectionDataTypeInnerTypeChanged {
 	after element replaced at pcm::CollectionDataType[innerType_CollectionDataType]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
@@ -15,8 +15,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		CompositeDataTypeConceptTest
 
 reactions: pcmCompositeDataTypeReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 reaction CompositeDataTypeInsertedInRepository {
 	after element pcm::CompositeDataType inserted in pcm::Repository[dataTypes__Repository]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmDataTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmDataTypePropagation.reactions
@@ -18,8 +18,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmParameter.reactions
 
 reactions: pcmDataTypePropagationReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 routine setUmlParameterType(
 		pcm::DataType pcmType, 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
@@ -11,8 +11,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		AttributeConceptTest
 
 reactions: pcmInnerDeclarationReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
  
 import routines pcmDataTypePropagationReactions using qualified names
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
@@ -13,8 +13,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		InterfaceConceptTest
 
 reactions: pcmInterfaceReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 reaction InterfaceInsertedInRepository {
 	after element pcm::OperationInterface inserted in pcm::Repository[interfaces__Repository]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
@@ -13,8 +13,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		ParameterConceptTest
 
 reactions: pcmParameterReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
   
 import routines pcmDataTypePropagationReactions using qualified names
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
@@ -11,8 +11,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		ProvidedRoleTest
 
 reactions: pcmProvidedRoleReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 reaction ProvidedRoleInserted {
 	after element pcm::OperationProvidedRole inserted in pcm::InterfaceProvidingRequiringEntity[providedRoles_InterfaceProvidingEntity]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -24,8 +24,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 // RepositoryConceptTest
 
 reactions: pcmRepositoryReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 import routines sharedRoutines // for UML model handling
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
@@ -20,8 +20,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		RepositoryComponentConceptTest
 
 reactions: pcmRepositoryComponentReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 reaction RepositoryComponentInserted {
 	after element pcm::RepositoryComponent inserted in pcm::Repository[components__Repository]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
@@ -12,8 +12,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		RequiredRoleConceptTest
 
 reactions: pcmRequiredRoleReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 reaction RequiredRoleInserted {
 	after element pcm::OperationRequiredRole inserted in pcm::InterfaceProvidingRequiringEntity[requiredRoles_InterfaceRequiringEntity]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
@@ -14,8 +14,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		SignatureConceptTest
 
 reactions: pcmSignatureReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 import routines pcmDataTypePropagationReactions using qualified names
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
@@ -20,8 +20,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 // RepositoryConceptTest
 
 reactions: pcmSystemReactions
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 import routines sharedRoutines // for UML model handling
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/SharedRoutines.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/SharedRoutines.reactions
@@ -8,8 +8,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: sharedRoutines
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 routine ensureUmlModelExists(EObject source) {
     match {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
@@ -17,8 +17,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		AssemblyContextConceptTest
 
 reactions: umlAssemblyContextPropertyReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 
 reaction AssemblyContextPropertyInserted {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
@@ -6,8 +6,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: umlCompositeDataTypeClassReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 //	The following reactions and routines synchronize a pcm::CompositeDataType in a pcm::Repository
 //	with an uml::Class in the datatypes uml::Package corresponding to the repository.

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
@@ -13,8 +13,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		CompositeDataTypeConceptTest
 
 reactions: umlCompositeDataTypeGeneralizationReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction CompositeDataTypeGeneralizationAdded {
 	after element uml::Generalization inserted in uml::Class[generalization]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREClass.reactions
@@ -17,8 +17,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		RepositoryComponentConceptTest, SystemConceptTest		
 
 reactions: umlIPREClassReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction IPREClassRemoved {
 	after element uml::Class removed from uml::Package[packagedElement]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREConstructorOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREConstructorOperation.reactions
@@ -15,8 +15,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		RepositoryComponentConceptTest, SystemConceptTest
 
 reactions: umlIPREConstructorOperationReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction IPREConstructorOperationNameChanged {
 	after attribute replaced at uml::Operation[name]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
@@ -15,8 +15,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		AttributeConceptTest
 
 reactions: umlInnerDeclarationPropertyReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction InnerDeclarationPropertyInserted {
 	after element uml::Property inserted in uml::Class[ownedAttribute]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
@@ -15,8 +15,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		InterfaceConceptTest
 
 reactions: umlInterfaceReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction InterfaceInserted {
 	after element uml::Interface inserted in uml::Package[packagedElement]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterfaceGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterfaceGeneralization.reactions
@@ -13,8 +13,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		InterfaceConceptTest
 
 reactions: umlInterfaceGeneralizationReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 
 reaction InterfaceGeneralizationAdded {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
@@ -16,8 +16,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		ProvidedRoleTest
 
 reactions: umlProvidedRoleRealizationReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction ProvidedRoleRealizationAdded {
 	after element uml::InterfaceRealization inserted in uml::Class[interfaceRealization]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
@@ -16,8 +16,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		ParameterConceptTest
 
 reactions: umlRegularParameterReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction RegularParameterInserted {
 	after element uml::Parameter inserted in uml::Operation[ownedParameter]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -27,8 +27,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		RepositoryConceptTest, SystemConceptTest
 
 reactions: umlRepositoryAndSystemPackageReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction UmlModelCreated {
     after element uml::Model created and inserted as root

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
@@ -18,8 +18,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		RepositoryComponentConceptTest
 
 reactions: umlRepositoryComponentPackageReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction RepositoryComponentPackageInserted {
 	after element uml::Package inserted in uml::Package[packagedElement]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
@@ -15,8 +15,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		RequiredRoleConceptTest
 
 reactions: umlRequiredRoleParameterReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction RequiredRoleParameterInserted {
 	after element uml::Parameter inserted in uml::Operation[ownedParameter]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
@@ -15,8 +15,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		RequiredRoleConceptTest
 
 reactions: umlRequiredRolePropertyReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction RequiredRolePropertyInserted {
 	after element uml::Property inserted in uml::Class[ownedAttribute]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
@@ -20,8 +20,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		SignatureConceptTest, ParameterConceptTest
 
 reactions: umlReturnAndRegularParameterTypeReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction RegularOrReturnParameterTypeChanged {
 	after element replaced at uml::Parameter[type]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
@@ -14,8 +14,8 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		SignatureConceptTest
 
 reactions: umlSignatureOperationReactions
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 reaction SignatureOperationInserted {
 	after element uml::Operation inserted in uml::Interface[ownedOperation]

--- a/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/pcm2uml/PcmToUml.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/pcm2uml/PcmToUml.reactions
@@ -16,8 +16,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: pcmToUml
-in reaction to changes in PCM
-execute actions in UML
+in reaction to changes in pcm
+execute actions in uml
 
 
 // ###################################################

--- a/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/UmlToPcm.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/UmlToPcm.reactions
@@ -14,8 +14,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: umlToPcm
-in reaction to changes in UML
-execute actions in PCM
+in reaction to changes in uml
+execute actions in pcm
 
 // ###################################################
 // ############### UNIVERSAL REACTIONS ###############

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
@@ -16,8 +16,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as umlclass
 import "http://www.eclipse.org/uml2/5.0.0/UML" as umlcomp
 
 reactions: class2comp
-in reaction to changes in UML
-execute actions in UML
+in reaction to changes in umlclass
+execute actions in umlcomp
 
 
 /*******

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/comp2class/comp2class.reactions
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/comp2class/comp2class.reactions
@@ -13,8 +13,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as umlcomp
 import "http://www.eclipse.org/uml2/5.0.0/UML" as umlclass
 
 reactions: comp2class
-in reaction to changes in UML
-execute actions in UML
+in reaction to changes in umlcomp
+execute actions in umlclass
 
 
 /*******

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUml.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUml.reactions
@@ -2,8 +2,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: javaToUml
-in reaction to changes in Java
-execute actions in UML
+in reaction to changes in java
+execute actions in uml
 
 import javaToUmlAttribute using qualified names
 import javaToUmlClassifier using qualified names

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
@@ -5,8 +5,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: javaToUmlAttribute
-in reaction to changes in Java
-execute actions in UML
+in reaction to changes in java
+execute actions in uml
 
 import routines javaToUmlTypePropagation using qualified names
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -21,8 +21,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: javaToUmlClassifier
-in reaction to changes in Java
-execute actions in UML
+in reaction to changes in java
+execute actions in uml
 
 //===========================================
 //=========================================== All Types

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -16,8 +16,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: javaToUmlMethod
-in reaction to changes in Java
-execute actions in UML
+in reaction to changes in java
+execute actions in uml
 
 import routines javaToUmlTypePropagation using qualified names
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
@@ -11,8 +11,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: javaToUmlTypePropagation
-in reaction to changes in Java
-execute actions in UML
+in reaction to changes in java
+execute actions in uml
 
 routine propagateAttributeTypeChange(java::Field jAtt, uml::Property uAtt) {
 	action {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJava.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJava.reactions
@@ -2,8 +2,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: umlToJava
-in reaction to changes in UML
-execute actions in Java
+in reaction to changes in uml
+execute actions in java
 
 import umlToJavaAttribute using qualified names
 import umlToJavaClassifier using qualified names

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
@@ -13,8 +13,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: umlToJavaAttribute
-in reaction to changes in UML
-execute actions in Java
+in reaction to changes in uml
+execute actions in java
 
 import routines umlToJavaTypePropagation using qualified names
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -24,8 +24,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: umlToJavaClassifier
-in reaction to changes in UML
-execute actions in Java
+in reaction to changes in uml
+execute actions in java
 
 //===========================================
 //=========================================== Class

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -19,8 +19,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: umlToJavaMethod
-in reaction to changes in UML
-execute actions in Java
+in reaction to changes in uml
+execute actions in java
 
 import routines umlToJavaTypePropagation using qualified names
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
@@ -11,8 +11,8 @@ import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://www.emftext.org/java" as java
 
 reactions: umlToJavaTypePropagation
-in reaction to changes in UML
-execute actions in Java
+in reaction to changes in uml
+execute actions in java
 
 routine propagatePropertyTypeChanged(uml::Property uProperty, java::Field jElement,
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null


### PR DESCRIPTION
Adapts the Reactions and Commonalities implementations referring to metamodels instead of domains as changed in https://github.com/vitruv-tools/Vitruv/pull/502.