### PR TITLE
Add local build Maven profile

### DIFF
--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -12,6 +12,11 @@
 	<version>0.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
+	<properties>
+		<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
+		<vitruv.domains.url>https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/</vitruv.domains.url>
+	</properties>
+
 	<repositories>
 		<repository>
 			<id>Vitruv Framework</id>
@@ -32,18 +37,6 @@
 
 	<profiles>
 		<profile>
-			<id>nightly-update-site-framework</id>
-			<activation>
-     			<property>
-        			<name>!vitruv.framework.path</name>
-      			</property>
-      		</activation>
-			<properties>
-				<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
-			</properties>
-		</profile>
-
-		<profile>
 			<id>local-framework</id>
 			<activation>
      			<property>
@@ -52,18 +45,6 @@
       		</activation>
 			<properties>
 				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
-			</properties>
-		</profile>
-
-		<profile>
-			<id>nightly-update-site-domains</id>
-			<activation>
-     			<property>
-        			<name>!vitruv.domains.path</name>
-      			</property>
-      		</activation>
-			<properties>
-				<vitruv.domains.url>https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/</vitruv.domains.url>
 			</properties>
 		</profile>
 

--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -39,10 +39,10 @@
 		<profile>
 			<id>local-framework</id>
 			<activation>
-     			<property>
-        			<name>vitruv.framework.path</name>
-      			</property>
-      		</activation>
+				<property>
+					<name>vitruv.framework.path</name>
+				</property>
+			</activation>
 			<properties>
 				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
 			</properties>
@@ -51,10 +51,10 @@
 		<profile>
 			<id>local-domains</id>
 			<activation>
-     			<property>
-        			<name>vitruv.domains.path</name>
-      			</property>
-      		</activation>
+				<property>
+					<name>vitruv.domains.path</name>
+				</property>
+			</activation>
 			<properties>
 				<vitruv.domains.url>file://${vitruv.domains.path}/releng/tools.vitruv.domains.cbs.updatesite.aggregated/target/final</vitruv.domains.url>
 			</properties>

--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -16,12 +16,12 @@
 		<repository>
 			<id>Vitruv Framework</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/nightly/framework/</url>
+			<url>${vitruv.framework.url}</url>
 		</repository>
 		<repository>
 			<id>Vitruv Domains</id>
 			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/</url>
+			<url>${vitruv.domains.url}</url>
 		</repository>
 		<repository>
 			<id>Palladiosimulator</id>
@@ -31,6 +31,54 @@
 	</repositories>
 
 	<profiles>
+		<profile>
+			<id>nightly-update-site-framework</id>
+			<activation>
+     			<property>
+        			<name>!vitruv.framework.path</name>
+      			</property>
+      		</activation>
+			<properties>
+				<vitruv.framework.url>https://vitruv-tools.github.io/updatesite/nightly/framework/</vitruv.framework.url>
+			</properties>
+		</profile>
+
+		<profile>
+			<id>local-framework</id>
+			<activation>
+     			<property>
+        			<name>vitruv.framework.path</name>
+      			</property>
+      		</activation>
+			<properties>
+				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
+			</properties>
+		</profile>
+
+		<profile>
+			<id>nightly-update-site-domains</id>
+			<activation>
+     			<property>
+        			<name>!vitruv.domains.path</name>
+      			</property>
+      		</activation>
+			<properties>
+				<vitruv.domains.url>https://vitruv-tools.github.io/updatesite/nightly/domains/cbs/</vitruv.domains.url>
+			</properties>
+		</profile>
+
+		<profile>
+			<id>local-domains</id>
+			<activation>
+     			<property>
+        			<name>vitruv.domains.path</name>
+      			</property>
+      		</activation>
+			<properties>
+				<vitruv.domains.url>file://${vitruv.domains.path}/releng/tools.vitruv.domains.cbs.updatesite.aggregated/target/final</vitruv.domains.url>
+			</properties>
+		</profile>
+
 		<profile>
 			<id>compile-dsls</id>
 			<activation>


### PR DESCRIPTION
This PR adds a local build Maven profile as described in [Vitruv#510](https://github.com/vitruv-tools/Vitruv/issues/510).

### Usage:
`mvn clean verify -Dvitruv.framework.path='<path_to_vitruv_folder>' -Dvitruv.domains.path='<path_to_domains_folder>'`

Both arguments are optional, i.e. the nightly update site of the framework but the local domains repository can also be combined.