### PR TITLE
Update referenced GitHub actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml', '**/MANIFEST.MF') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: 11
       - name: Build and Verify
         uses: GabrielBB/xvfb-action@v1


### PR DESCRIPTION
Updates versions of used GitHub actions.
Change is performed to be in sync with [Vitruv#525](https://github.com/vitruv-tools/Vitruv/pull/525) and [Vitruv-Domains-CBS#117](https://github.com/vitruv-tools/Vitruv-Domains-ComponentBasedSystems/pull/117).