### PR TITLE
Adapt to framework and domains not providing an aggregated updatesite

### DIFF
--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -58,7 +58,7 @@
 				</property>
 			</activation>
 			<properties>
-				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite.aggregated/target/final</vitruv.framework.url>
+				<vitruv.framework.url>file://${vitruv.framework.path}/releng/tools.vitruv.updatesite/target/repository</vitruv.framework.url>
 			</properties>
 		</profile>
 
@@ -82,7 +82,7 @@
 				</property>
 			</activation>
 			<properties>
-				<vitruv.domains.url>file://${vitruv.domains.path}/releng/tools.vitruv.domains.cbs.updatesite.aggregated/target/final</vitruv.domains.url>
+				<vitruv.domains.url>file://${vitruv.domains.path}/releng/tools.vitruv.domains.cbs.updatesite/target/repository</vitruv.domains.url>
 			</properties>
 		</profile>
 


### PR DESCRIPTION
This PR removes the aggregated updatesite generation from the build, as it is built for the complete Vitruv project in the [updatesite](https://github.com/vitruv-tools/updatesite) repository upon deploying new artifact versions.