### PR TITLE
Replace aggregated Vitruv updatesite with updatesites of dependencies

### DIFF
--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -20,12 +20,6 @@
 	</properties>
 
 	<repositories>
-		<!-- The aggregated Vitruv updatesite to resolve all its dependencies -->
-		<repository>
-			<id>Vitruv</id>
-			<layout>p2</layout>
-			<url>https://vitruv-tools.github.io/updatesite/nightly/</url>
-		</repository>
 		<!-- The specific Vitruv project updatesites to be potentially overwritten by local builds -->
 		<repository>
 			<id>Vitruv Framework</id>
@@ -41,6 +35,21 @@
 			<id>Vitruv Domains</id>
 			<layout>p2</layout>
 			<url>${vitruv.domains.url}</url>
+		</repository>
+		<repository>
+			<id>SDQ Commons</id>
+			<layout>p2</layout>
+			<url>https://kit-sdq.github.io/updatesite/release/commons/</url>
+		</repository>
+		<repository>
+			<id>XAnnotations</id>
+			<layout>p2</layout>
+			<url>https://kit-sdq.github.io/updatesite/release/xannotations/</url>
+		</repository>
+		<repository>
+			<id>EMFText and JaMoPP (P2 Wrapper)</id>
+			<layout>p2</layout>
+			<url>https://kit-sdq.github.io/updatesite/release/p2-wrapper/</url>
 		</repository>
 		<repository>
 			<id>Palladiosimulator</id>

--- a/releng/tools.vitruv.applications.cbs.parent/pom.xml
+++ b/releng/tools.vitruv.applications.cbs.parent/pom.xml
@@ -54,7 +54,7 @@
 		<repository>
 			<id>Palladiosimulator</id>
 			<layout>p2</layout>
-			<url>https://updatesite.palladio-simulator.com/palladio-core-pcm/releases/5.0.0/</url>
+			<url>https://updatesite.palladio-simulator.com/palladio-build-updatesite/releases/5.0.0/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
The aggregated Vitruv updatesite was referenced in the build to resolve the dependencies of the Vitruv projects. This is error prone, because, e.g., when removing a bundle in this project it can still be resolved in the aggregated updatesite, thus leading to a successful build although it should actually fail. Thus, this PR makes the updatesites providing dependencies explicit rather than resolving them transitively using the aggregated Vitruv updatesite.