### PR TITLE
Adapt to simplified domains

### DIFF
--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/PcmUmlClassApplication.java
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/PcmUmlClassApplication.java
@@ -10,11 +10,6 @@ import tools.vitruv.framework.domains.VitruvDomain;
 import tools.vitruv.change.propagation.ChangePropagationSpecification;
 
 public class PcmUmlClassApplication implements VitruvApplication {
-
-	public PcmUmlClassApplication() {
-		patchDomains();
-	}
-
 	@Override
 	public Set<ChangePropagationSpecification> getChangePropagationSpecifications() {
 		Set<ChangePropagationSpecification> specs = new HashSet<ChangePropagationSpecification>();
@@ -28,12 +23,6 @@ public class PcmUmlClassApplication implements VitruvApplication {
 		return "PCM <-> UML Class";
 	}
 
-	private void patchDomains() {
-		new UmlDomainProvider().getDomain().enableTransitiveChangePropagation();
-		new PcmDomainProvider().getDomain().enableTransitiveChangePropagation();
-	}
-
-	@Override
 	public Set<VitruvDomain> getVitruvDomains() {
 		return Set.of(new PcmDomainProvider().getDomain(), new UmlDomainProvider().getDomain());
 	}

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -80,6 +80,11 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	private Path testProjectFolder;
 
 	@BeforeEach
+	protected void disableTransitivePropagation() {
+		this.getVirtualModel().setTransitivePropagationEnabled(false);
+	}
+	
+	@BeforeEach
 	protected void setup(@TestProject Path testProjectPath) {
 		// This is necessary because otherwise Maven tests will fail as resources from
 		// previous

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -55,6 +55,7 @@ import com.google.common.collect.Iterables;
 import tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.Pcm2JavaChangePropagationSpecification;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
 import tools.vitruv.applications.pcmjava.util.pcm2java.DataTypeCorrespondenceHelper;
+import tools.vitruv.applications.util.temporary.java.JamoppLibraryHelper;
 import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil;
 import tools.vitruv.applications.util.temporary.pcm.PcmParameterUtil;
 import tools.vitruv.domains.pcm.PcmNamespace;
@@ -86,10 +87,8 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	
 	@BeforeEach
 	protected void setup(@TestProject Path testProjectPath) {
-		// This is necessary because otherwise Maven tests will fail as resources from
-		// previous
-		// tests are still in the classpath and accidentally resolved
 		JavaClasspath.reset();
+		JamoppLibraryHelper.registerStdLib();
 		this.testProjectFolder = testProjectPath;
 	}
 

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -55,7 +55,7 @@ import com.google.common.collect.Iterables;
 import tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.Pcm2JavaChangePropagationSpecification;
 import tools.vitruv.applications.pcmjava.tests.util.pcm2java.Pcm2JavaTestUtils;
 import tools.vitruv.applications.pcmjava.util.pcm2java.DataTypeCorrespondenceHelper;
-import tools.vitruv.applications.util.temporary.java.JamoppLibraryHelper;
+import tools.vitruv.domains.java.JamoppLibraryHelper;
 import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil;
 import tools.vitruv.applications.util.temporary.pcm.PcmParameterUtil;
 import tools.vitruv.domains.pcm.PcmNamespace;

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -82,7 +82,7 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 
 	@BeforeEach
 	protected void disableTransitivePropagation() {
-		this.getVirtualModel().setTransitivePropagationEnabled(false);
+		this.getVirtualModel().setTransitiveChangePropagationEnabled(false);
 	}
 	
 	@BeforeEach

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.pojotransformations.tests/src/tools/vitruv/applications/pcmjava/tests/pojotransformations/pcm2java/Pcm2JavaTransformationTest.java
@@ -59,6 +59,7 @@ import tools.vitruv.domains.java.JamoppLibraryHelper;
 import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil;
 import tools.vitruv.applications.util.temporary.pcm.PcmParameterUtil;
 import tools.vitruv.domains.pcm.PcmNamespace;
+import tools.vitruv.change.propagation.ChangePropagationMode;
 import tools.vitruv.change.propagation.ChangePropagationSpecification;
 import tools.vitruv.testutils.LegacyVitruvApplicationTest;
 import tools.vitruv.testutils.TestProject;
@@ -81,8 +82,8 @@ public class Pcm2JavaTransformationTest extends LegacyVitruvApplicationTest {
 	private Path testProjectFolder;
 
 	@BeforeEach
-	protected void disableTransitivePropagation() {
-		this.getVirtualModel().setTransitiveChangePropagationEnabled(false);
+	protected void disableTransitiveChangePropagation() {
+		this.getVirtualModel().setChangePropagationMode(ChangePropagationMode.SINGLE_STEP);
 	}
 	
 	@BeforeEach

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/java2pcm/Java2PcmTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/java2pcm/Java2PcmTransformationTest.java
@@ -132,7 +132,7 @@ public abstract class Java2PcmTransformationTest extends LegacyVitruvApplication
 
 	@BeforeEach
 	protected void disableTransitivePropagation() {
-		this.getVirtualModel().setTransitivePropagationEnabled(false);
+		this.getVirtualModel().setTransitiveChangePropagationEnabled(false);
 	}
 	
 	/*

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/java2pcm/Java2PcmTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/java2pcm/Java2PcmTransformationTest.java
@@ -99,6 +99,7 @@ import tools.vitruv.domains.pcm.PcmNamespace;
 import tools.vitruv.change.composite.description.PropagatedChange;
 import tools.vitruv.change.composite.description.VitruviusChange;
 import tools.vitruv.change.composite.propagation.ChangePropagationListener;
+import tools.vitruv.change.propagation.ChangePropagationMode;
 import tools.vitruv.framework.domains.ui.builder.VitruvProjectBuilderApplicator;
 import tools.vitruv.framework.domains.ui.builder.VitruvProjectBuilderApplicatorImpl;
 import tools.vitruv.testutils.DisableAutoBuild;
@@ -131,8 +132,8 @@ public abstract class Java2PcmTransformationTest extends LegacyVitruvApplication
 	}
 
 	@BeforeEach
-	protected void disableTransitivePropagation() {
-		this.getVirtualModel().setTransitiveChangePropagationEnabled(false);
+	protected void disableTransitiveChangePropagation() {
+		this.getVirtualModel().setChangePropagationMode(ChangePropagationMode.SINGLE_STEP);
 	}
 	
 	/*

--- a/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/java2pcm/Java2PcmTransformationTest.java
+++ b/tests/pcmjava/tools.vitruv.applications.pcmjava.tests.util/src/tools/vitruv/applications/pcmjava/tests/util/java2pcm/Java2PcmTransformationTest.java
@@ -130,6 +130,11 @@ public abstract class Java2PcmTransformationTest extends LegacyVitruvApplication
 		return testEclipseProject;
 	}
 
+	@BeforeEach
+	protected void disableTransitivePropagation() {
+		this.getVirtualModel().setTransitivePropagationEnabled(false);
+	}
+	
 	/*
 	 * We need to use platform URIs, because the JDT AST will not recognize changes
 	 * when using file URIs.

--- a/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/CBSCommonalitiesExecutionTest.xtend
+++ b/tests/tools.vitruv.applications.cbs.commonalities.tests/src/tools/vitruv/applications/cbs/commonalities/tests/CBSCommonalitiesExecutionTest.xtend
@@ -14,10 +14,16 @@ import java.nio.file.Path
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import tools.vitruv.applications.cbs.commonalities.CbsCommonalitiesApplication
+import tools.vitruv.change.propagation.ChangePropagationMode
 
 abstract class CBSCommonalitiesExecutionTest extends LegacyVitruvApplicationTest {	
 	def <T> T getModels(DomainModelsProvider<T> modelsProvider) {
 		return modelsProvider.getModels(vitruvApplicationTestAdapter)
+	}
+	
+	@BeforeEach
+	def setupChangePropagationMode() {
+		virtualModel.changePropagationMode = ChangePropagationMode.TRANSITIVE_EXCEPT_LEAVES
 	}
 	
 	@BeforeEach

--- a/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlClassApplicationTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlclass.tests/src/tools/vitruv/applications/pcmumlclass/tests/PcmUmlClassApplicationTest.xtend
@@ -12,8 +12,6 @@ import org.palladiosimulator.pcm.repository.DataType
 import tools.vitruv.applications.pcmumlclass.CombinedPcmToUmlClassReactionsChangePropagationSpecification
 import tools.vitruv.applications.pcmumlclass.CombinedUmlClassToPcmReactionsChangePropagationSpecification
 import tools.vitruv.applications.pcmumlclass.TagLiterals
-import tools.vitruv.domains.pcm.PcmDomainProvider
-import tools.vitruv.domains.uml.UmlDomainProvider
 import org.eclipse.emf.ecore.resource.ResourceSet
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.common.util.URI
@@ -53,11 +51,6 @@ abstract class PcmUmlClassApplicationTest extends LegacyVitruvApplicationTest {
 		]
 	}
 
-	private def patchDomains() {
-		new PcmDomainProvider().domain.enableTransitiveChangePropagation
-		new UmlDomainProvider().domain.enableTransitiveChangePropagation
-	}
-
 	protected var PcmUmlClassApplicationTestHelper helper
 	protected var ResourceSet testResourceSet
 
@@ -67,7 +60,6 @@ abstract class PcmUmlClassApplicationTest extends LegacyVitruvApplicationTest {
 
 	@BeforeEach
 	def protected void setup() {
-		patchDomains
 		helper = new PcmUmlClassApplicationTestHelper(this, [uri|startRecordingChanges(uri.resourceAt)])
 		testResourceSet = new ResourceSetImpl()
 	}

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/AbstractPcmUmlTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/AbstractPcmUmlTest.xtend
@@ -29,6 +29,11 @@ abstract class AbstractPcmUmlTest extends LegacyVitruvApplicationTest {
 	protected val PARAMETER_NAME_2 = "barParameter"
 	protected val ATTRIBUTE_NAME = "fooAttribute"
 
+	@BeforeEach
+	protected def void disableTransitivePropagation() {
+		this.virtualModel.transitivePropagationEnabled = false;
+	}
+	
 	protected static var Repository primitiveTypesRepository = null
 
 	private def Path getProjectModelPath(String modelName) {

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/AbstractPcmUmlTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/AbstractPcmUmlTest.xtend
@@ -15,6 +15,7 @@ import java.nio.file.Path
 import tools.vitruv.testutils.LegacyVitruvApplicationTest
 import tools.vitruv.applications.pcmumlcomponents.PcmToUmlComponentsChangePropagationSpecification
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimOne
+import tools.vitruv.change.propagation.ChangePropagationMode
 
 abstract class AbstractPcmUmlTest extends LegacyVitruvApplicationTest {
 	protected static val MODEL_FILE_EXTENSION = "repository"
@@ -30,8 +31,8 @@ abstract class AbstractPcmUmlTest extends LegacyVitruvApplicationTest {
 	protected val ATTRIBUTE_NAME = "fooAttribute"
 
 	@BeforeEach
-	protected def void disableTransitivePropagation() {
-		this.virtualModel.transitiveChangePropagationEnabled = false;
+	protected def void disableTransitiveChangePropagation() {
+		virtualModel.changePropagationMode = ChangePropagationMode.SINGLE_STEP
 	}
 	
 	protected static var Repository primitiveTypesRepository = null

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/AbstractPcmUmlTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/pcm2uml/AbstractPcmUmlTest.xtend
@@ -31,7 +31,7 @@ abstract class AbstractPcmUmlTest extends LegacyVitruvApplicationTest {
 
 	@BeforeEach
 	protected def void disableTransitivePropagation() {
-		this.virtualModel.transitivePropagationEnabled = false;
+		this.virtualModel.transitiveChangePropagationEnabled = false;
 	}
 	
 	protected static var Repository primitiveTypesRepository = null

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/AbstractUmlPcmTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/AbstractUmlPcmTest.xtend
@@ -41,7 +41,7 @@ abstract class AbstractUmlPcmTest extends LegacyVitruvApplicationTest {
 
 	@BeforeEach
 	protected def void disableTransitivePropagation() {
-		this.virtualModel.transitivePropagationEnabled = false
+		this.virtualModel.transitiveChangePropagationEnabled = false
 	}
 	
 	private def Path getProjectModelPath(String modelName) {

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/AbstractUmlPcmTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/AbstractUmlPcmTest.xtend
@@ -39,6 +39,11 @@ abstract class AbstractUmlPcmTest extends LegacyVitruvApplicationTest {
 	protected static val UML_TYPE_REAL = "Real"
 	protected static val UML_TYPE_STRING = "String"
 
+	@BeforeEach
+	protected def void disableTransitivePropagation() {
+		this.virtualModel.transitivePropagationEnabled = false
+	}
+	
 	private def Path getProjectModelPath(String modelName) {
 		Path.of("model").resolve(modelName + "." + MODEL_FILE_EXTENSION)
 	}

--- a/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/AbstractUmlPcmTest.xtend
+++ b/tests/tools.vitruv.applications.pcmumlcomponents.tests/src/tools/vitruv/applications/pcmumlcomponents/tests/uml2pcm/AbstractUmlPcmTest.xtend
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull
 import static org.junit.jupiter.api.Assertions.assertEquals
 import tools.vitruv.applications.pcmumlcomponents.UmlToPcmComponentsChangePropagationSpecification
 import tools.vitruv.applications.pcmumlcomponents.uml2pcm.UmlToPcmTypesUtil
+import tools.vitruv.change.propagation.ChangePropagationMode
 
 abstract class AbstractUmlPcmTest extends LegacyVitruvApplicationTest {
 	protected static val MODEL_FILE_EXTENSION = "uml"
@@ -40,8 +41,8 @@ abstract class AbstractUmlPcmTest extends LegacyVitruvApplicationTest {
 	protected static val UML_TYPE_STRING = "String"
 
 	@BeforeEach
-	protected def void disableTransitivePropagation() {
-		this.virtualModel.transitiveChangePropagationEnabled = false
+	protected def void disableTransitiveChangePropagation() {
+		virtualModel.changePropagationMode = ChangePropagationMode.SINGLE_STEP
 	}
 	
 	private def Path getProjectModelPath(String modelName) {

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/PcmUmlJavaTransitiveChangeTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/PcmUmlJavaTransitiveChangeTest.xtend
@@ -27,7 +27,6 @@ import org.emftext.language.java.members.Field
 import org.emftext.language.java.members.InterfaceMethod
 import org.emftext.language.java.members.Method
 import org.emftext.language.java.types.TypeReference
-import org.junit.jupiter.api.BeforeEach
 import tools.vitruv.applications.pcmumlclass.tests.PcmUmlClassApplicationTest
 import tools.vitruv.applications.util.temporary.java.JavaVisibility
 import tools.vitruv.domains.java.util.JavaPersistenceHelper
@@ -51,11 +50,6 @@ abstract class PcmUmlJavaTransitiveChangeTest extends PcmUmlClassApplicationTest
 
 	override protected getChangePropagationSpecifications() {
 		linearNetwork.changePropagationSpecifications
-	}
-
-	@BeforeEach
-	def void before() {
-		patchDomains() // ensures all domains execute transitively
 	}
 
 	def protected checkJavaType(Classifier umlClassifier) {

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/PcmUmlJavaTransitiveChangeTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/circular/pcmumlclassjava/PcmUmlJavaTransitiveChangeTest.xtend
@@ -37,6 +37,9 @@ import static extension tools.vitruv.applications.transitivechange.tests.util.Tr
 import org.emftext.language.java.containers.ContainersPackage
 import static tools.vitruv.applications.umljava.tests.util.JavaElementsTestAssertions.*
 import static tools.vitruv.applications.umljava.tests.util.JavaUmlElementEqualityValidation.*
+import org.junit.jupiter.api.BeforeEach
+import org.emftext.language.java.JavaClasspath
+import tools.vitruv.domains.java.JamoppLibraryHelper
 
 /** 
  * Transitive change test class for networks of UML, Java and PCM models.
@@ -47,6 +50,12 @@ abstract class PcmUmlJavaTransitiveChangeTest extends PcmUmlClassApplicationTest
 	protected static final int ARRAY_LIST_SELECTION = 0
 	protected static boolean linearNetwork // set true (before class) to avoid the transformation between PCM and Java
 	static val logger = Logger.getLogger(typeof(PcmUmlJavaTransitiveChangeTest).simpleName)
+
+	@BeforeEach
+	def void setupJavaClasspath() {
+		JavaClasspath.reset()
+		JamoppLibraryHelper.registerStdLib()
+	}
 
 	override protected getChangePropagationSpecifications() {
 		linearNetwork.changePropagationSpecifications

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlTransformationTest.xtend
@@ -30,7 +30,7 @@ abstract class JavaToUmlTransformationTest extends AbstractUmlJavaTest {
 
 	@BeforeEach
 	protected def void disableTransitivePropagation() {
-		this.virtualModel.transitivePropagationEnabled = false
+		this.virtualModel.transitiveChangePropagationEnabled = false
 	}
 	
 	@BeforeEach

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlTransformationTest.xtend
@@ -29,8 +29,12 @@ abstract class JavaToUmlTransformationTest extends AbstractUmlJavaTest {
 	static val UMLMODELNAME = "rootModelName" // Name of the Uml Model used in the java2uml tests
 
 	@BeforeEach
+	protected def void disableTransitivePropagation() {
+		this.virtualModel.transitivePropagationEnabled = false
+	}
+	
+	@BeforeEach
 	def protected setup() {
-		patchDomains
 		userInteraction.addNextTextInput(UMLMODELNAME)
 		userInteraction.addNextTextInput(UMLMODELPATH)
 	}

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/java2uml/JavaToUmlTransformationTest.xtend
@@ -17,6 +17,7 @@ import java.util.ArrayList
 import org.junit.jupiter.api.BeforeEach
 import java.nio.file.Path
 import static tools.vitruv.applications.transitivechange.tests.util.TransitiveChangeSetup.*
+import tools.vitruv.change.propagation.ChangePropagationMode
 
 /**
  * Abstract Class for Java To UML Tests. Contains functions to create Java-CompilationUnits 
@@ -29,8 +30,8 @@ abstract class JavaToUmlTransformationTest extends AbstractUmlJavaTest {
 	static val UMLMODELNAME = "rootModelName" // Name of the Uml Model used in the java2uml tests
 
 	@BeforeEach
-	protected def void disableTransitivePropagation() {
-		this.virtualModel.transitiveChangePropagationEnabled = false
+	protected def void disableTransitiveChangePropagation() {
+		virtualModel.changePropagationMode = ChangePropagationMode.SINGLE_STEP
 	}
 	
 	@BeforeEach

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaTransformationTest.xtend
@@ -41,7 +41,7 @@ abstract class UmlToJavaTransformationTest extends AbstractUmlJavaTest {
 
 	@BeforeEach
 	def protected void disableTransitivePropagation() {
-		this.virtualModel.transitivePropagationEnabled = false
+		this.virtualModel.transitiveChangePropagationEnabled = false
 	}
 	
 	@BeforeEach

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaTransformationTest.xtend
@@ -14,6 +14,7 @@ import static tools.vitruv.testutils.matchers.ModelMatchers.isResource
 import static tools.vitruv.testutils.matchers.ModelMatchers.isNoResource
 import static org.hamcrest.MatcherAssert.assertThat
 import static tools.vitruv.applications.transitivechange.tests.util.TransitiveChangeSetup.*
+import tools.vitruv.change.propagation.ChangePropagationMode
 
 /**
  * Abstract super class for uml to java test cases.
@@ -40,8 +41,8 @@ abstract class UmlToJavaTransformationTest extends AbstractUmlJavaTest {
 	}
 
 	@BeforeEach
-	def protected void disableTransitivePropagation() {
-		this.virtualModel.transitiveChangePropagationEnabled = false
+	def protected void disableTransitiveChangePropagation() {
+		virtualModel.changePropagationMode = ChangePropagationMode.SINGLE_STEP
 	}
 	
 	@BeforeEach

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/linear/uml2java/UmlToJavaTransformationTest.xtend
@@ -40,8 +40,12 @@ abstract class UmlToJavaTransformationTest extends AbstractUmlJavaTest {
 	}
 
 	@BeforeEach
+	def protected void disableTransitivePropagation() {
+		this.virtualModel.transitivePropagationEnabled = false
+	}
+	
+	@BeforeEach
 	def protected void setup() {
-		patchDomains()
 		val umlModel = UMLFactory.eINSTANCE.createModel()
 		umlModel.name = MODEL_NAME
 		resourceAt(MODEL_NAME.projectModelPath).startRecordingChanges => [

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/util/AbstractUmlJavaTest.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/util/AbstractUmlJavaTest.xtend
@@ -6,6 +6,9 @@ import java.util.function.Function
 import org.eclipse.emf.common.util.URI
 import org.eclipse.emf.ecore.resource.Resource
 import tools.vitruv.testutils.LegacyVitruvApplicationTest
+import org.junit.jupiter.api.BeforeEach
+import org.emftext.language.java.JavaClasspath
+import tools.vitruv.domains.java.JamoppLibraryHelper
 
 /**
  * Abstract class for umljava tests in both directions.
@@ -18,6 +21,12 @@ abstract class AbstractUmlJavaTest extends LegacyVitruvApplicationTest {
 
 	protected val Function<URI, Resource> resourceRetriever = [uri|uri.resourceAt]
 
+	@BeforeEach
+	def void setupClasspathAndViewFactory() {
+		JavaClasspath.reset()
+		JamoppLibraryHelper.registerStdLib()
+	}
+	
 	/**
 	 * Retrieves all corresponding objects of obj.
 	 * 

--- a/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/util/TransitiveChangeSetup.xtend
+++ b/tests/tools.vitruv.applications.transitivechange.tests/src/tools/vitruv/applications/transitivechange/tests/util/TransitiveChangeSetup.xtend
@@ -9,9 +9,6 @@ import tools.vitruv.applications.umljava.JavaToUmlChangePropagationSpecification
 import tools.vitruv.applications.pcmjava.pojotransformations.pcm2java.Pcm2JavaChangePropagationSpecification
 import tools.vitruv.applications.pcmjava.pojotransformations.java2pcm.Java2PcmChangePropagationSpecification
 import tools.vitruv.change.propagation.ChangePropagationSpecification
-import tools.vitruv.domains.pcm.PcmDomainProvider
-import tools.vitruv.domains.uml.UmlDomainProvider
-import tools.vitruv.domains.java.JavaDomainProvider
 
 @Utility
 class TransitiveChangeSetup {
@@ -28,9 +25,4 @@ class TransitiveChangeSetup {
 		return specifications
 	}
 	
-	static def patchDomains() {
-		new PcmDomainProvider().domain.enableTransitiveChangePropagation
-		new UmlDomainProvider().domain.enableTransitiveChangePropagation
-		new JavaDomainProvider().domain.enableTransitiveChangePropagation	
-	}
 }

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/AbstractUmlClassCompTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/AbstractUmlClassCompTest.xtend
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach
 import java.nio.file.Path
 
 import org.eclipse.uml2.uml.Model
+import tools.vitruv.change.propagation.ChangePropagationMode
 
 abstract class AbstractUmlClassCompTest extends VitruvApplicationTest {
 	protected def Model getRootElement() {
@@ -15,8 +16,8 @@ abstract class AbstractUmlClassCompTest extends VitruvApplicationTest {
 	}
 
 	@BeforeEach
-	protected def void disableTransitivePropagation() {
-		this.virtualModel.transitiveChangePropagationEnabled = false
+	protected def void disableTransitiveChangePropagation() {
+		virtualModel.changePropagationMode = ChangePropagationMode.SINGLE_STEP
 	}
 	
 	@BeforeEach

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/AbstractUmlClassCompTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/AbstractUmlClassCompTest.xtend
@@ -16,7 +16,7 @@ abstract class AbstractUmlClassCompTest extends VitruvApplicationTest {
 
 	@BeforeEach
 	protected def void disableTransitivePropagation() {
-		this.virtualModel.transitivePropagationEnabled = false
+		this.virtualModel.transitiveChangePropagationEnabled = false
 	}
 	
 	@BeforeEach

--- a/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/AbstractUmlClassCompTest.xtend
+++ b/tests/tools.vitruv.applications.umlclassumlcomponents.tests/src/tools/vitruv/applications/umlclassumlcomponents/tests/util/AbstractUmlClassCompTest.xtend
@@ -15,6 +15,11 @@ abstract class AbstractUmlClassCompTest extends VitruvApplicationTest {
 	}
 
 	@BeforeEach
+	protected def void disableTransitivePropagation() {
+		this.virtualModel.transitivePropagationEnabled = false
+	}
+	
+	@BeforeEach
 	def setup() {
 		if (isInitializeTestModel()) {
 			initializeTestModel()

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/UmlJavaTransformationTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/UmlJavaTransformationTest.xtend
@@ -44,7 +44,7 @@ abstract class UmlJavaTransformationTest extends ViewBasedVitruvApplicationTest 
 
 	@BeforeEach
 	def setupTransformationDirection() {
-		configureUnidirectionalExecution()
+		configureUnidirectionalExecution(virtualModel)
 	}
 
 	protected def getDefaultUmlModel(View view) {

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlAttributeTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlAttributeTest.xtend
@@ -270,7 +270,7 @@ class JavaToUmlAttributeTest extends AbstractJavaToUmlTest {
 
 	static class BidirectionalTest extends JavaToUmlAttributeTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlClassMethodTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlClassMethodTest.xtend
@@ -341,7 +341,7 @@ class JavaToUmlClassMethodTest extends AbstractJavaToUmlTest {
 
 	static class BidirectionalTest extends JavaToUmlClassMethodTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlClassTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlClassTest.xtend
@@ -305,7 +305,7 @@ class JavaToUmlClassTest extends AbstractJavaToUmlTest {
 
 	static class BidirectionalTest extends JavaToUmlClassTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlEnumTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlEnumTest.xtend
@@ -222,7 +222,7 @@ class JavaToUmlEnumTest extends AbstractJavaToUmlTest {
 
 	static class BidirectionalTest extends JavaToUmlEnumTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlInterfaceMethodTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlInterfaceMethodTest.xtend
@@ -131,7 +131,7 @@ class JavaToUmlInterfaceMethodTest extends AbstractJavaToUmlTest {
 
 	static class BidirectionalTest extends JavaToUmlInterfaceMethodTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlInterfaceTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlInterfaceTest.xtend
@@ -168,7 +168,7 @@ class JavaToUmlInterfaceTest extends AbstractJavaToUmlTest {
 
 	static class BidirectionalTest extends JavaToUmlInterfaceTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlPackageTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/JavaToUmlPackageTest.xtend
@@ -115,7 +115,7 @@ class JavaToUmlPackageTest extends AbstractJavaToUmlTest {
 
 	static class BidirectionalTest extends JavaToUmlPackageTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/constructionsimulationtest/JavaConstructionSimulationTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/java2uml/constructionsimulationtest/JavaConstructionSimulationTest.xtend
@@ -335,7 +335,7 @@ class JavaConstructionSimulationTest extends AbstractJavaToUmlTest {
 
 	static class BidirectionalTest extends JavaConstructionSimulationTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAssociationTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAssociationTest.xtend
@@ -67,7 +67,7 @@ class UmlToJavaAssociationTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaAssociationTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAttributeTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaAttributeTest.xtend
@@ -230,7 +230,7 @@ class UmlToJavaAttributeTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaAttributeTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 
 	   @Test

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaClassMethodTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaClassMethodTest.xtend
@@ -361,7 +361,7 @@ class UmlToJavaClassMethodTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaClassMethodTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaClassTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaClassTest.xtend
@@ -247,7 +247,7 @@ class UmlToJavaClassTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaClassTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaEnumTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaEnumTest.xtend
@@ -160,7 +160,7 @@ class UmlToJavaEnumTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaEnumTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaInterfaceMethodTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaInterfaceMethodTest.xtend
@@ -122,7 +122,7 @@ class UmlToJavaInterfaceMethodTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaInterfaceMethodTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaInterfaceTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaInterfaceTest.xtend
@@ -131,7 +131,7 @@ class UmlToJavaInterfaceTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaInterfaceTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaPackageTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaPackageTest.xtend
@@ -127,7 +127,7 @@ class UmlToJavaPackageTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaPackageTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaParameterTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/UmlToJavaParameterTest.xtend
@@ -124,7 +124,7 @@ class UmlToJavaParameterTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlToJavaParameterTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/constructionsimulationtest/UmlConstructionSimulationTest.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/uml2java/constructionsimulationtest/UmlConstructionSimulationTest.xtend
@@ -52,7 +52,7 @@ class UmlConstructionSimulationTest extends AbstractUmlToJavaTest {
 
 	static class BidirectionalTest extends UmlConstructionSimulationTest {
 		override setupTransformationDirection() {
-			configureBidirectionalExecution()
+			configureBidirectionalExecution(virtualModel)
 		}
 	}
 

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/TransformationDirectionConfiguration.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/TransformationDirectionConfiguration.xtend
@@ -1,23 +1,20 @@
 package tools.vitruv.applications.umljava.tests.util
 
-import tools.vitruv.domains.java.JavaDomainProvider
-import tools.vitruv.domains.uml.UmlDomainProvider
 import org.apache.log4j.Logger
 import edu.kit.ipd.sdq.activextendannotations.Utility
+import tools.vitruv.framework.vsum.VirtualModel
 
 @Utility
 class TransformationDirectionConfiguration {
 	static val LOGGER = Logger.getLogger(TransformationDirectionConfiguration)
 
-	def static void configureUnidirectionalExecution() {
+	def static void configureUnidirectionalExecution(VirtualModel virtualModel) {
 		LOGGER.trace("Configuring for unidirectional execution")
-		new JavaDomainProvider().domain.disableTransitiveChangePropagation
-		new UmlDomainProvider().domain.disableTransitiveChangePropagation
+		virtualModel.transitivePropagationEnabled = false
 	}
 
-	def static void configureBidirectionalExecution() {
+	def static void configureBidirectionalExecution(VirtualModel virtualModel) {
 		LOGGER.trace("Configuring for bidirectional execution")
-		new JavaDomainProvider().domain.enableTransitiveChangePropagation
-		new UmlDomainProvider().domain.enableTransitiveChangePropagation
+		virtualModel.transitivePropagationEnabled = true
 	}
 }

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/TransformationDirectionConfiguration.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/TransformationDirectionConfiguration.xtend
@@ -10,11 +10,11 @@ class TransformationDirectionConfiguration {
 
 	def static void configureUnidirectionalExecution(VirtualModel virtualModel) {
 		LOGGER.trace("Configuring for unidirectional execution")
-		virtualModel.transitivePropagationEnabled = false
+		virtualModel.transitiveChangePropagationEnabled = false
 	}
 
 	def static void configureBidirectionalExecution(VirtualModel virtualModel) {
 		LOGGER.trace("Configuring for bidirectional execution")
-		virtualModel.transitivePropagationEnabled = true
+		virtualModel.transitiveChangePropagationEnabled = true
 	}
 }

--- a/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/TransformationDirectionConfiguration.xtend
+++ b/tests/tools.vitruv.applications.umljava.tests/src/tools/vitruv/applications/umljava/tests/util/TransformationDirectionConfiguration.xtend
@@ -3,6 +3,7 @@ package tools.vitruv.applications.umljava.tests.util
 import org.apache.log4j.Logger
 import edu.kit.ipd.sdq.activextendannotations.Utility
 import tools.vitruv.framework.vsum.VirtualModel
+import tools.vitruv.change.propagation.ChangePropagationMode
 
 @Utility
 class TransformationDirectionConfiguration {
@@ -10,11 +11,11 @@ class TransformationDirectionConfiguration {
 
 	def static void configureUnidirectionalExecution(VirtualModel virtualModel) {
 		LOGGER.trace("Configuring for unidirectional execution")
-		virtualModel.transitiveChangePropagationEnabled = false
+		virtualModel.changePropagationMode = ChangePropagationMode.SINGLE_STEP
 	}
 
 	def static void configureBidirectionalExecution(VirtualModel virtualModel) {
 		LOGGER.trace("Configuring for bidirectional execution")
-		virtualModel.transitiveChangePropagationEnabled = true
+		virtualModel.changePropagationMode = ChangePropagationMode.TRANSITIVE_CYCLIC
 	}
 }


### PR DESCRIPTION
This PR adapts the simplification of the `VitruvDomains` interface in vitruv-tools/Vitruv#540. In particular, it replaces all domain-related logic to modify transitive change propagation with logic that configures the `VirtualModel` accordingly.