### PR TITLE
Remove usage of compound reactions triggers

### DIFF
--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -124,24 +124,24 @@ routine renamePackageForRepository(pcm::Repository repository) {
 }
 
 reaction RepositoryDeleted {
-	after element pcm::Repository deleted and removed as root
+	after element pcm::Repository deleted
 	call {
-		for (component : oldValue.components__Repository.filter(BasicComponent)) {
+		for (component : affectedEObject.components__Repository.filter(BasicComponent)) {
 			deleteJavaClassifier(component)
 			deleteJavaPackage(component, "")
 		}
-		for (interface : oldValue.interfaces__Repository.filter(OperationInterface)) {
+		for (interface : affectedEObject.interfaces__Repository.filter(OperationInterface)) {
 			deleteJavaClassifier(interface)
 		}
-		for (dataType : oldValue.dataTypes__Repository.filter(CompositeDataType)) {
+		for (dataType : affectedEObject.dataTypes__Repository.filter(CompositeDataType)) {
 			deleteJavaClassifier(dataType)
 		}
-		for (dataType : oldValue.dataTypes__Repository.filter(CollectionDataType)) {
+		for (dataType : affectedEObject.dataTypes__Repository.filter(CollectionDataType)) {
 			deleteJavaClassifier(dataType);
 		}
-		deleteJavaPackage(oldValue, "repository_root")
-		deleteJavaPackage(oldValue, "contracts")
-		deleteJavaPackage(oldValue, "datatypes")
+		deleteJavaPackage(affectedEObject, "repository_root")
+		deleteJavaPackage(affectedEObject, "contracts")
+		deleteJavaPackage(affectedEObject, "datatypes")
 	}
 }
 
@@ -150,7 +150,7 @@ reaction RepositoryDeleted {
 // ############################# COMPOSED STRUCTURES ##############################
 
 reaction CreatedSystem {
-	after element pcm::System created and inserted as root
+	after element pcm::System inserted as root
 	call {
 		addSystemCorrespondence(newValue)
 		createOrFindJavaPackage(newValue, null, newValue.entityName, "root_system");
@@ -174,11 +174,10 @@ routine createImplementationForSystem(pcm::System system) {
 }
 
 reaction DeletedSystem {
-	after element pcm::System deleted and removed as root
+	after element pcm::System removed as root
 	call {
-		val system = oldValue;
-		deleteJavaPackage(system, "root_system");
-		deleteJavaClassifier(system);
+		deleteJavaPackage(oldValue, "root_system");
+		deleteJavaClassifier(oldValue);
 	}
 }
 
@@ -200,7 +199,7 @@ routine changeSystemImplementationName(pcm::System system) {
 }
 
 reaction AddedAssemblyContextToComposedStructure {
-	after element pcm::AssemblyContext created and inserted in pcm::ComposedStructure[assemblyContexts__ComposedStructure]
+	after element pcm::AssemblyContext inserted in pcm::ComposedStructure[assemblyContexts__ComposedStructure]
 	call {
 		createOrFindAssemblyContextField(newValue, affectedEObject)
 		createOrFindAssemblyContextConstructor(newValue, affectedEObject)
@@ -337,7 +336,7 @@ routine addAssemblyContextImportCorrespondence(pcm::AssemblyContext assemblyCont
 // ################ COMPONENT REACTIONS ################
 
 reaction CreatedComponent {
-	after element pcm::RepositoryComponent created and inserted in pcm::Repository[components__Repository]
+	after element pcm::RepositoryComponent inserted in pcm::Repository[components__Repository]
 	call createComponentImplementation(newValue)
 }
 
@@ -394,10 +393,10 @@ routine renameComponentClass(pcm::RepositoryComponent component) {
 }
 
 reaction DeletedComponent {
-	after element pcm::RepositoryComponent deleted and removed from pcm::Repository[components__Repository]
+	after element pcm::RepositoryComponent deleted
 	call {
-		deleteJavaClassifier(oldValue);
-		deleteJavaPackage(oldValue, "");
+		deleteJavaClassifier(affectedEObject);
+		deleteJavaPackage(affectedEObject, "");
 	}
 }
 
@@ -405,7 +404,7 @@ reaction DeletedComponent {
 // ################ INTERFACE REACTIONS ################
 
 reaction CreatedInterface {
-	after element created and inserted in pcm::Repository[interfaces__Repository]
+	after element inserted in pcm::Repository[interfaces__Repository]
 	call createOrFindJavaInterface(newValue)
 }
 
@@ -428,7 +427,7 @@ routine renameInterface(pcm::OperationInterface interf) {
 // ################ DATA TYPES REACTIONS ################
 
 reaction CreatedCompositeDataType {
-	after element pcm::CompositeDataType created and inserted in pcm::Repository[dataTypes__Repository]
+	after element pcm::CompositeDataType inserted in pcm::Repository[dataTypes__Repository]
 	call createCompositeDataTypeImplementation(newValue)
 }
 
@@ -469,12 +468,12 @@ routine renameCompositeDataType(pcm::CompositeDataType compositeDataType) {
 }
 
 reaction DeletedCompositeDataType {
-	after element pcm::CompositeDataType deleted and removed from pcm::Repository[dataTypes__Repository]
-	call deleteJavaClassifier(oldValue)
+	after element pcm::CompositeDataType deleted
+	call deleteJavaClassifier(affectedEObject)
 }
 
 reaction CreatedCollectionDataType {
-	after element pcm::CollectionDataType created and inserted in pcm::Repository[dataTypes__Repository]
+	after element pcm::CollectionDataType inserted in pcm::Repository[dataTypes__Repository]
 	call createCollectionDataTypeImplementation(newValue)
 }
 
@@ -547,14 +546,14 @@ routine renameCollectionDataType(pcm::CollectionDataType collectionDataType) {
 }
 
 reaction DeletedCollectionDataType {
-	after element pcm::CollectionDataType deleted and removed from pcm::Repository[dataTypes__Repository]
-	call deleteJavaClassifier(oldValue)
+	after element pcm::CollectionDataType deleted
+	call deleteJavaClassifier(affectedEObject)
 }
 
 // ################ DATA TYPES - INNER DECLARATION REACTIONS ################
 
 reaction CreatedInnerDeclaration {
-	after element pcm::InnerDeclaration created and inserted in pcm::CompositeDataType[innerDeclaration_CompositeDataType]
+	after element pcm::InnerDeclaration inserted in pcm::CompositeDataType[innerDeclaration_CompositeDataType]
 	call createInnerDeclarationImplementation(newValue)
 }
 
@@ -855,8 +854,8 @@ routine deleteJavaClassifier(pcm::NamedElement sourceElement) {
 // ################ PROVIDED ROLES ####################
 
 reaction CreatedProvidedRole {
-	after element pcm::OperationProvidedRole created and inserted in pcm::InterfaceProvidingEntity[providedRoles_InterfaceProvidingEntity]
-	call addProvidedRole(newValue)
+	after element pcm::OperationProvidedRole inserted in pcm::InterfaceProvidingEntity[providedRoles_InterfaceProvidingEntity]
+	call findOrAddProvidedRole(newValue)
 }
 
 routine findOrAddProvidedRole(pcm::OperationProvidedRole providedRole) {
@@ -922,13 +921,13 @@ reaction ChangedProvidingEntityOfProvidedRole {
 }
 
 reaction DeletedProvidedRoleFromSystem {
-	after element pcm::ProvidedRole deleted and removed from pcm::System[providedRoles_InterfaceProvidingEntity]
-	call removeProvidedRole(oldValue)
+	after element pcm::ProvidedRole deleted
+	call removeProvidedRole(affectedEObject)
 }
 
 reaction DeletedProvidedRoleFromComponent {
-	after element pcm::ProvidedRole deleted and removed from pcm::RepositoryComponent[providedRoles_InterfaceProvidingEntity]
-	call removeProvidedRole(oldValue)
+	after element pcm::ProvidedRole deleted
+	call removeProvidedRole(affectedEObject)
 }
 
 routine removeProvidedRole(pcm::ProvidedRole providedRole) {
@@ -1095,7 +1094,7 @@ reaction ChangeOperationRequiredRoleInterface {
 // TODO HK Implement changing the signature interface. All components with their SEFFs have to be updated.
 // Use more reasonable correspondences than Michael
 reaction CreatedOperationSignature {
-	after element pcm::OperationSignature created and inserted in pcm::OperationInterface[signatures__OperationInterface]
+	after element pcm::OperationSignature inserted in pcm::OperationInterface[signatures__OperationInterface]
 	call createMethodForOperationSignature(newValue)
 }
 
@@ -1174,8 +1173,8 @@ routine changeInterfaceMethodReturnType(java::InterfaceMethod interfaceMethod, p
 }
 
 reaction DeletedOperationSignature {
-	after element pcm::OperationSignature deleted and removed from pcm::OperationInterface[signatures__OperationInterface]
-	call deleteMethodForOperationSignature(oldValue)
+	after element pcm::OperationSignature deleted
+	call deleteMethodForOperationSignature(affectedEObject)
 }
 
 routine deleteMethodForOperationSignature(pcm::OperationSignature operationSignature) {
@@ -1191,7 +1190,7 @@ routine deleteMethodForOperationSignature(pcm::OperationSignature operationSigna
 // ################################## PARAMETERS ##################################
 
 reaction CreatedParameter {
-	after element pcm::Parameter created and inserted in pcm::OperationSignature[parameters__OperationSignature]
+	after element pcm::Parameter inserted in pcm::OperationSignature[parameters__OperationSignature]
 	call createParameter(newValue)
 }
 
@@ -1252,7 +1251,7 @@ routine changeParameterType(pcm::Parameter parameter) {
 }
 
 reaction DeletedParameter {
-	after element pcm::Parameter deleted and removed from pcm::OperationSignature[parameters__OperationSignature]
+	after element pcm::Parameter removed from pcm::OperationSignature[parameters__OperationSignature]
 	call deleteParameter(affectedEObject, oldValue)
 }
 
@@ -1268,63 +1267,10 @@ routine deleteParameter(pcm::OperationSignature signature, pcm::Parameter parame
 }
 
 // ################################################################################
-// ##################### RESOURCE DEMANDING INTERNAL BEHAVIOR #####################
-
-//reaction CreatedResourceDemandingInternalBehavior {
-//	after element pcm::ResourceDemandingInternalBehaviour created and inserted in pcm::BasicComponent[resourceDemandingInternalBehaviours__BasicComponent]
-//	call createMethodForResourceDemandingBehavior(newValue)
-//}
-//
-//routine createMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val componentClass = retrieve java::Class corresponding to behavior.basicComponent_ResourceDemandingInternalBehaviour
-//	}
-//	action {
-//		val javaMethod = create java::ClassMethod and initialize {
-//			javaMethod.name = behavior.entityName;
-//			javaMethod.typeReference = TypesFactory.eINSTANCE.createVoid;
-//		}
-//		update componentClass {
-//			componentClass.members += javaMethod;
-//		}
-//	}
-//}
-//
-//reaction RenameResourceDemandingInternalBehavior {
-//	after attribute replaced at pcm::ResourceDemandingInternalBehaviour[entityName]
-//	call renameMethodForResourceDemandingBehavior(affectedEObject)
-//}
-//
-//routine renameMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val javaMethod = retrieve java::ClassMethod corresponding to behavior
-//	}
-//	action {
-//		update javaMethod {
-//			javaMethod.name = behavior.entityName;
-//		}
-//	}
-//}
-//
-//reaction DeletedDemandingInternalBehavior {
-//	after element pcm::ResourceDemandingInternalBehaviour deleted and removed from pcm::BasicComponent[resourceDemandingInternalBehaviours__BasicComponent]
-//	call deleteMethodForResourceDemandingBehavior(oldValue)
-//}
-//
-//routine deleteMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val javaMethod = retrieve java::ClassMethod corresponding to behavior
-//	}
-//	action {
-//		delete javaMethod
-//	}
-//}
-
-// ################################################################################
 // #################################### SEFFS #####################################
 
 reaction CreatedSEFF {
-	after element pcm::ServiceEffectSpecification created and inserted in pcm::BasicComponent[serviceEffectSpecifications__BasicComponent]
+	after element pcm::ServiceEffectSpecification inserted in pcm::BasicComponent[serviceEffectSpecifications__BasicComponent]
 	call createSEFF(newValue)
 }
 
@@ -1376,8 +1322,8 @@ routine updateSEFFImplementingMethodName(pcm::ServiceEffectSpecification seff) {
 }
 
 reaction DeletedSeff {
-	after element pcm::ServiceEffectSpecification deleted and removed from pcm::BasicComponent[serviceEffectSpecifications__BasicComponent]
-	call deleteMethodForSeff(oldValue)
+	after element pcm::ServiceEffectSpecification deleted
+	call deleteMethodForSeff(affectedEObject)
 }
 
 routine deleteMethodForSeff(pcm::ServiceEffectSpecification seff) {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.common/src/tools/vitruv/applications/pcmjava/common/pcm2java/Pcm2JavaCommon.reactions
@@ -855,7 +855,7 @@ routine deleteJavaClassifier(pcm::NamedElement sourceElement) {
 
 reaction CreatedProvidedRole {
 	after element pcm::OperationProvidedRole inserted in pcm::InterfaceProvidingEntity[providedRoles_InterfaceProvidingEntity]
-	call findOrAddProvidedRole(newValue)
+	call addProvidedRole(newValue)
 }
 
 routine findOrAddProvidedRole(pcm::OperationProvidedRole providedRole) {
@@ -890,6 +890,7 @@ routine addProvidedRole(pcm::OperationProvidedRole providedRole) {
 	match {
 		val operationProvidingInterface = retrieve java::Interface corresponding to providedRole.providedInterface__OperationProvidedRole
 		val javaClass = retrieve java::Class corresponding to providedRole.providingEntity_ProvidedRole
+		require absence of java::NamespaceClassifierReference corresponding to providedRole
 	}
 	action { 
 		val namespaceClassifierReference = create java::NamespaceClassifierReference and initialize {

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.depinjecttransformations/src/tools/vitruv/applications/pcmjava/depinjecttransformations/pcm2java/Pcm2JavaDepInject.reactions
@@ -29,7 +29,7 @@ import pcm2javaCommon
 // ############################# COMPOSED STRUCTURES ##############################
 
 reaction pcm2javaCommon::AddedAssemblyContextToComposedStructure {
-	after element pcm::AssemblyContext created and inserted in pcm::ComposedStructure[assemblyContexts__ComposedStructure]
+	after element pcm::AssemblyContext inserted in pcm::ComposedStructure[assemblyContexts__ComposedStructure]
 		// depInject start
 		with {
 			// do not allow multiple assembly contexts for the same basic component
@@ -77,7 +77,7 @@ routine addAssemblyContextToComposedStructure(pcm::ComposedStructure composedStr
 
 // depInject: added
 reaction AddedConnector {
-	after element pcm::AssemblyConnector created and inserted in pcm::ComposedStructure[connectors__ComposedStructure]
+	after element pcm::AssemblyConnector inserted in pcm::ComposedStructure[connectors__ComposedStructure]
 	call addConnector(newValue)
 }
 
@@ -97,7 +97,7 @@ routine addConnector(pcm::AssemblyConnector assemblyConnector) {
 
 // depInject: added
 reaction AddedProvidedDelegationConnector {
-	after element pcm::ProvidedDelegationConnector created and inserted in pcm::ComposedStructure[connectors__ComposedStructure]
+	after element pcm::ProvidedDelegationConnector inserted in pcm::ComposedStructure[connectors__ComposedStructure]
 	call addedProvidedDelegationConnector(newValue, affectedEObject)
 }
 
@@ -158,7 +158,7 @@ routine pcm2javaCommon::createJavaClass(pcm::NamedElement sourceElementMappedToC
 
 reaction pcm2javaCommon::CreatedRequiredRole {
 	// depInject: slightly different trigger
-	after element pcm::OperationRequiredRole created and inserted in pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
+	after element pcm::OperationRequiredRole inserted in pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
 	call addRequiredRole(newValue)
 }
 
@@ -191,9 +191,9 @@ routine pcm2javaCommon::addRequiredRole(pcm::OperationRequiredRole requiredRole)
 
 reaction pcm2javaCommon::DeletedRequiredRole {
 	// depInject: slightly different trigger
-	after element pcm::OperationRequiredRole deleted and removed from pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
+	after element pcm::OperationRequiredRole deleted
 	call {
-		removeRequiredRole(oldValue);
+		removeRequiredRole(affectedEObject);
 	}
 }
 
@@ -228,57 +228,3 @@ routine pcm2javaCommon::createParameter(pcm::Parameter parameter) {
 		}
 	}
 }
-
-// ################################################################################
-// ##################### RESOURCE DEMANDING INTERNAL BEHAVIOR #####################
-
-//reaction CreatedResourceDemandingInternalBehavior {
-//	after element pcm::ResourceDemandingInternalBehaviour created and inserted in pcm::BasicComponent[resourceDemandingInternalBehaviours__BasicComponent]
-//	call createMethodForResourceDemandingBehavior(newValue)
-//}
-//
-//routine createMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val componentClass = retrieve java::Class corresponding to behavior.basicComponent_ResourceDemandingInternalBehaviour
-//	}
-//	action {
-//		val javaMethod = create java::ClassMethod and initialize {
-//			javaMethod.name = behavior.entityName;
-//			javaMethod.typeReference = TypesFactory.eINSTANCE.createVoid;
-//		}
-//		add correspondence between javaMethod and behavior // depInject
-//		update componentClass {
-//			componentClass.members += javaMethod;
-//		}
-//	}
-//}
-//
-//reaction RenameResourceDemandingInternalBehavior {
-//	after attribute replaced at pcm::ResourceDemandingInternalBehaviour[entityName]
-//	call renameMethodForResourceDemandingBehavior(affectedEObject)
-//}
-//
-//routine renameMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val javaMethod = retrieve java::ClassMethod corresponding to behavior
-//	}
-//	action {
-//		update javaMethod {
-//			javaMethod.name = behavior.entityName;
-//		}
-//	}
-//}
-//
-//reaction DeletedDemandingInternalBehavior {
-//	after element pcm::ResourceDemandingInternalBehaviour deleted and removed from pcm::BasicComponent[resourceDemandingInternalBehaviours__BasicComponent]
-//	call deleteMethodForResourceDemandingBehavior(oldValue)
-//}
-//
-//routine deleteMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val javaMethod = retrieve java::ClassMethod corresponding to behavior
-//	}
-//	action {
-//		delete javaMethod
-//	}
-//}

--- a/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/src/tools/vitruv/applications/pcmjava/ejbtransformations/pcm2java/Pcm2EjbJava.reactions
+++ b/bundles/pcmjava/tools.vitruv.applications.pcmjava.ejbtransformations/src/tools/vitruv/applications/pcmjava/ejbtransformations/pcm2java/Pcm2EjbJava.reactions
@@ -23,14 +23,14 @@ import pcm2javaCommon
 
 // ejb: cleared
 reaction pcm2javaCommon::CreatedSystem {
-	after element pcm::System created and inserted as root
+	after element pcm::System inserted as root
 	call { 
 	}
 }
 
 // ejb: cleared
 reaction pcm2javaCommon::DeletedSystem {
-	after element pcm::System deleted and removed as root
+	after element pcm::System deleted
 	call {
 	}
 }
@@ -44,7 +44,7 @@ reaction pcm2javaCommon::ChangedSystemName {
 
 // ejb: cleared
 reaction pcm2javaCommon::AddedAssemblyContextToComposedStructure {
-	after element pcm::AssemblyContext created and inserted in pcm::ComposedStructure[assemblyContexts__ComposedStructure]
+	after element pcm::AssemblyContext inserted in pcm::ComposedStructure[assemblyContexts__ComposedStructure]
 	call {
 	}
 }
@@ -54,7 +54,7 @@ reaction pcm2javaCommon::AddedAssemblyContextToComposedStructure {
 
 reaction pcm2javaCommon::CreatedComponent {
 	// ejb: slightly different trigger
-	after element pcm::BasicComponent created and inserted in pcm::Repository[components__Repository]
+	after element pcm::BasicComponent inserted in pcm::Repository[components__Repository]
 	call createComponentImplementation(newValue)
 }
 
@@ -107,7 +107,7 @@ routine pcm2javaCommon::createJavaInterface(pcm::Interface pcmInterface, java::P
 
 // ejb: cleared
 reaction pcm2javaCommon::DeletedProvidedRoleFromSystem {
-	after element pcm::ProvidedRole deleted and removed from pcm::System[providedRoles_InterfaceProvidingEntity]
+	after element pcm::ProvidedRole removed from pcm::System[providedRoles_InterfaceProvidingEntity]
 	call {
 	}
 }
@@ -117,7 +117,7 @@ reaction pcm2javaCommon::DeletedProvidedRoleFromSystem {
 
 reaction pcm2javaCommon::CreatedRequiredRole {
 	// ejb: slightly different trigger
-	after element pcm::OperationRequiredRole created and inserted in pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
+	after element pcm::OperationRequiredRole inserted in pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
 	call addRequiredRole(newValue)
 }
 
@@ -149,7 +149,7 @@ routine pcm2javaCommon::addRequiredRole(pcm::OperationRequiredRole requiredRole)
 
 reaction pcm2javaCommon::DeletedRequiredRole {
 	// ejb: slightly different trigger
-	after element pcm::OperationRequiredRole deleted and removed from pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
+	after element pcm::OperationRequiredRole removed from pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
 	call {
 		removeRequiredRole(oldValue);
 	}
@@ -210,57 +210,3 @@ routine pcm2javaCommon::createParameter(pcm::Parameter parameter) {
 		}
 	}
 }
-
-// ################################################################################
-// ##################### RESOURCE DEMANDING INTERNAL BEHAVIOR #####################
-
-//reaction CreatedResourceDemandingInternalBehavior {
-//	after element pcm::ResourceDemandingInternalBehaviour created and inserted in pcm::BasicComponent[resourceDemandingInternalBehaviours__BasicComponent]
-//	call createMethodForResourceDemandingBehavior(newValue)
-//}
-//
-//routine createMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val componentClass = retrieve java::Class corresponding to behavior.basicComponent_ResourceDemandingInternalBehaviour
-//	}
-//	action {
-//		val javaMethod = create java::ClassMethod and initialize {
-//			javaMethod.name = behavior.entityName;
-//			javaMethod.typeReference = TypesFactory.eINSTANCE.createVoid;
-//		}
-//		add correspondence between javaMethod and behavior // ejb
-//		update componentClass {
-//			componentClass.members += javaMethod;
-//		}
-//	}
-//}
-//
-//reaction RenameResourceDemandingInternalBehavior {
-//	after attribute replaced at pcm::ResourceDemandingInternalBehaviour[entityName]
-//	call renameMethodForResourceDemandingBehavior(affectedEObject)
-//}
-//
-//routine renameMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val javaMethod = retrieve java::ClassMethod corresponding to behavior
-//	}
-//	action {
-//		update javaMethod {
-//			javaMethod.name = behavior.entityName;
-//		}
-//	}
-//}
-//
-//reaction DeletedDemandingInternalBehavior {
-//	after element pcm::ResourceDemandingInternalBehaviour deleted and removed from pcm::BasicComponent[resourceDemandingInternalBehaviours__BasicComponent]
-//	call deleteMethodForResourceDemandingBehavior(oldValue)
-//}
-//
-//routine deleteMethodForResourceDemandingBehavior(pcm::ResourceDemandingInternalBehaviour behavior) {
-//	match {
-//		val javaMethod = retrieve java::ClassMethod corresponding to behavior
-//	}
-//	action {
-//		delete javaMethod
-//	}
-//}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -31,7 +31,7 @@ in reaction to changes in uml
 execute actions in pcm
 
 reaction UmlModelCreated {
-    after element uml::Model created and inserted as root
+    after element uml::Model inserted as root
     call ensureModelCorrespondenceExists(newValue)
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/pcm2uml/PcmToUml.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/pcm2uml/PcmToUml.reactions
@@ -53,7 +53,7 @@ routine deleteElement(pcm::NamedElement pcmElement) {
 // ############### CONTAINER REACTIONS ###############
 
 reaction CreatedPcmRepository {
-	after element pcm::Repository created and inserted as root
+	after element pcm::Repository inserted as root
 	call createUmlModel(newValue)
 }
 
@@ -80,7 +80,7 @@ routine createUmlModel(pcm::Repository pcmRepository) {
 // ############## DATA TYPES REACTIONS ###############
 
 reaction CreatedPrimitiveDataType {
-	after element pcm::PrimitiveDataType created and inserted in pcm::Repository[dataTypes__Repository]
+	after element pcm::PrimitiveDataType inserted in pcm::Repository[dataTypes__Repository]
 	call createPrimitiveDataType(newValue)
 }
 
@@ -100,8 +100,8 @@ routine createPrimitiveDataType(pcm::PrimitiveDataType dataType) {
 }
 
 reaction DeletedDataType {
-	after element pcm::DataType deleted and removed from pcm::Repository[dataTypes__Repository]
-	call deleteDataType(oldValue)
+	after element pcm::DataType deleted
+	call deleteDataType(affectedEObject)
 }
 
 routine deleteDataType(pcm::DataType dataType) {
@@ -114,7 +114,7 @@ routine deleteDataType(pcm::DataType dataType) {
 }
 
 reaction CreatedCompositeDataType {
-	after element pcm::CompositeDataType created and inserted in pcm::Repository[dataTypes__Repository]
+	after element pcm::CompositeDataType inserted in pcm::Repository[dataTypes__Repository]
 	call createCompositeDataType(newValue)
 }
 
@@ -134,7 +134,7 @@ routine createCompositeDataType(pcm::CompositeDataType dataType) {
 }
 
 reaction CreatedInnerDeclaration {
-	after element pcm::InnerDeclaration created and inserted in pcm::CompositeDataType[innerDeclaration_CompositeDataType]
+	after element pcm::InnerDeclaration inserted in pcm::CompositeDataType[innerDeclaration_CompositeDataType]
 	call createInnerDeclaration(newValue)
 }
 
@@ -309,7 +309,7 @@ routine createUmlPropertyForDatatype(uml::DataType type, pcm::InnerDeclaration c
 // ############## INTERFACE REACTIONS ################
 
 reaction CreatedPcmInterface {
-	after element created and inserted in pcm::Repository[interfaces__Repository]
+	after element inserted in pcm::Repository[interfaces__Repository]
 	call createUmlInterface(newValue)
 }
 
@@ -334,7 +334,7 @@ reaction DeletedPcmInterface {
 }
 
 reaction CreatedOperationInterfaceSignature {
-	after element created and inserted in pcm::OperationInterface[signatures__OperationInterface]
+	after element inserted in pcm::OperationInterface[signatures__OperationInterface]
 	call createOperationInterfaceSignature(newValue)
 }
 
@@ -489,11 +489,11 @@ routine removeOperationSignatureParameter(pcm::Parameter pcmParameter) {
 // ############### COMPONENT REACTIONS ###############
 
 reaction CreatedBasicPcmComponent {
-	after element pcm::BasicComponent created and inserted in pcm::Repository[components__Repository]
+	after element pcm::BasicComponent inserted in pcm::Repository[components__Repository]
 	call createUmlComponent(newValue, "basic")
 }
 reaction CreatedCompositePcmComponent {
-	after element pcm::CompositeComponent created and inserted in pcm::Repository[components__Repository]
+	after element pcm::CompositeComponent inserted in pcm::Repository[components__Repository]
 	call createUmlComponent(newValue, "composite")
 }
 routine createUmlComponent(pcm::RepositoryComponent pcmComponent, String correspondenceTag) {
@@ -516,7 +516,7 @@ reaction DeletedComponent {
 }
 
 reaction CreatedProvidedRole {
-	after element created and inserted in pcm::InterfaceProvidingEntity[providedRoles_InterfaceProvidingEntity]
+	after element inserted in pcm::InterfaceProvidingEntity[providedRoles_InterfaceProvidingEntity]
 	call createProvidedRole(affectedEObject, newValue)
 }
 routine createProvidedRole(pcm::InterfaceProvidingEntity pcmComponent, pcm::ProvidedRole pcmProvidedRole) {

--- a/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/UmlToPcm.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlcomponents/src/tools/vitruv/applications/pcmumlcomponents/uml2pcm/UmlToPcm.reactions
@@ -106,7 +106,7 @@ routine updateMultiplicityType(uml::MultiplicityElement umlElement) {
 // ############### CONTAINER REACTIONS ###############
 
 reaction CreatedUmlModel {
-	after element uml::Model created and inserted as root
+	after element uml::Model inserted as root
 	call{
 		createPcmRepository(newValue)
 		ensureUmlModelCorrespondenceExists(newValue)
@@ -137,7 +137,7 @@ routine ensureUmlModelCorrespondenceExists(uml::Model newModel) {
 // ############## DATA TYPES REACTIONS ###############
 
 reaction CreatedPrimitiveDataType {
-	after element uml::PrimitiveType created and inserted in uml::Model[packagedElement]
+	after element uml::PrimitiveType inserted in uml::Model[packagedElement]
 	call createPrimitiveDataType(newValue)
 }
 
@@ -151,7 +151,7 @@ routine createPrimitiveDataType(uml::PrimitiveType umlType) {
 }
 
 reaction CreatedDataType {
-	after element uml::DataType created and inserted in uml::Model[packagedElement] with
+	after element uml::DataType inserted in uml::Model[packagedElement] with
 		!(newValue instanceof PrimitiveType)
 	call createDataType(newValue)
 }
@@ -193,7 +193,7 @@ routine createCollectionDataType(uml::DataType umlType) {
 }
 
 reaction CreatedPropertyForDataType {
-	after element uml::Property created and inserted in uml::DataType[ownedAttribute]
+	after element uml::Property inserted in uml::DataType[ownedAttribute]
 	call createInnerDeclarationOffProperty(newValue)
 }
 
@@ -269,7 +269,7 @@ routine deleteDataType(uml::DataType umlDataType) {
 // ############### INTERFACE REACTIONS ###############
 
 reaction CreatedInterface {
-	after element uml::Interface created and inserted in uml::Model[packagedElement]
+	after element uml::Interface inserted in uml::Model[packagedElement]
 	call createInterface(newValue)
 }
 
@@ -289,7 +289,7 @@ routine createInterface(uml::Interface umlInterface) {
 }
 
 reaction CreatedInterfaceOperation {
-	after element uml::Operation created and inserted in uml::Interface[ownedOperation]
+	after element uml::Operation inserted in uml::Interface[ownedOperation]
 	call createInterfaceOperation(newValue)
 }
 

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/class2comp/class2comp.reactions
@@ -25,7 +25,7 @@ execute actions in umlcomp
 ********/
 
 reaction CreatedClassModel {
-	after element umlclass::Model created and inserted as root 
+	after element umlclass::Model inserted as root 
 	call createModelSelfCorrespondence(newValue)
 	//call createComponentModel(newValue) //TODO This is currently not needed, as we are using one singular meta model
 }
@@ -93,7 +93,7 @@ routine renameElement(umlclass::NamedElement classElement) {
 ********/
 
 reaction CreatedUmlClass {
-	after element umlclass::Class created and inserted in umlclass::Package[packagedElement]
+	after element umlclass::Class inserted in umlclass::Package[packagedElement]
 	call {
 		routineCreatedUmlClass(newValue, affectedEObject)
 	}
@@ -191,8 +191,8 @@ routine renameDataType(umlclass::Class umlClass) {
 }
 
 reaction DeletedClass{
-	after element umlclass::Class deleted and removed from umlclass::Package[packagedElement]
-	call deleteComponent(oldValue)
+	after element umlclass::Class deleted
+	call deleteComponent(affectedEObject)
 }
 
 routine deleteComponent(umlclass::Class umlClass) { 
@@ -210,7 +210,7 @@ routine deleteComponent(umlclass::Class umlClass) {
 ************/
 
 reaction CreatedPrimitiveDataType {
-	after element umlclass::PrimitiveType created and inserted in umlclass::Package[packagedElement]
+	after element umlclass::PrimitiveType inserted in umlclass::Package[packagedElement]
 	//call createPrimitiveDataType(newValue) //TODO This is currently not needed, as we are using one singular meta model
 	call createPrimitiveDataTypeSelfCorrespondence(newValue)
 }
@@ -234,7 +234,7 @@ routine createPrimitiveDataType(umlclass::PrimitiveType classType) {
 }
 
 reaction CreatedDataType {
-	after element umlclass::DataType created and inserted in umlclass::Package[packagedElement] 
+	after element umlclass::DataType inserted in umlclass::Package[packagedElement] 
 		with !(newValue instanceof PrimitiveType)
 	//call createDataType(newValue) //TODO This is currently not needed, as we are using one singular meta model
 	call createDataTypeSelfCorrespondence(newValue)
@@ -260,7 +260,7 @@ routine createDataType(umlclass::DataType classType) {
 }
 
 reaction AddedDataClassTypeProperty {
-    after element umlclass::Property created and inserted in umlclass::Class[ownedAttribute]
+    after element umlclass::Property inserted in umlclass::Class[ownedAttribute]
     call {
         addDataTypeProperty(affectedEObject, newValue)
     }
@@ -302,8 +302,8 @@ routine changeDataTypeProperty(umlclass::Property classProperty) {
 
 
 reaction DeletedDataTypeClassProperty {
-    after element umlclass::Property deleted and removed from umlclass::Class[ownedAttribute]
-    call deleteCompDataTypeProperty(oldValue)
+    after element umlclass::Property deleted
+    call deleteCompDataTypeProperty(affectedEObject)
 }
 
 routine deleteCompDataTypeProperty(umlclass::Property classProperty) {
@@ -337,7 +337,7 @@ routine changeDataTypeAttributeType(umlclass::Property classProperty, umlclass::
 
 
 reaction AddedDataClassTypeOperation {
-    after element umlclass::Operation created and inserted in umlclass::Class[ownedOperation]
+    after element umlclass::Operation inserted in umlclass::Class[ownedOperation]
     call {
         addDataTypeOperation(affectedEObject, newValue)
     }
@@ -379,8 +379,8 @@ routine changeDataTypeOperation(umlclass::Operation classOperation) {
 
 
 reaction DeletedDataTypeClassOperation {
-    after element umlclass::Property deleted and removed from umlclass::Class[ownedAttribute]
-    call deleteCompDataTypeProperty(oldValue)
+    after element umlclass::Property deleted
+    call deleteCompDataTypeProperty(affectedEObject)
 }
 
 routine deleteCompDataTypeOperation(umlclass::Operation classOperation) {
@@ -398,7 +398,7 @@ routine deleteCompDataTypeOperation(umlclass::Operation classOperation) {
 ***********/
 
 reaction CreatePackage {
-	after element created and inserted in umlclass::Model[packagedElement]
+	after element inserted in umlclass::Model[packagedElement]
 		with (newValue instanceof Package)
 	call createdPackage(newValue as Package)
 }
@@ -526,11 +526,11 @@ routine updateCorrespondingComponent(umlclass::Package classPackage, String oldN
 }
 
 reaction PackageDeleted {
-	after element umlclass::Package deleted and removed from umlclass::Model[packagedElement]
-	call routinePackageDeleted(oldValue, affectedEObject)
+	after element umlclass::Package deleted
+	call routinePackageDeleted(affectedEObject)
 }
 
-routine routinePackageDeleted(umlclass::Package classPackage, umlclass::Model classModel) {
+routine routinePackageDeleted(umlclass::Package classPackage) {
 	action {
 		call {
 			//Check if Package removal is illegal
@@ -698,12 +698,12 @@ routine createUsage(umlclass::InterfaceRealization classIFRealization, umlcomp::
 }
 
 
-reaction RemovedInterface {
-	after element umlclass::Interface deleted and removed from umlclass::Package[packagedElement]
-	call removeInterface(oldValue)
+reaction DeletedInterface {
+	after element umlclass::Interface deleted
+	call deleteInterface(affectedEObject)
 }
 
-routine removeInterface(umlclass::Interface classInterface) {
+routine deleteInterface(umlclass::Interface classInterface) {
 	match {
 		val compInterface = retrieve umlcomp::Interface corresponding to classInterface
 	}
@@ -735,7 +735,7 @@ routine removeInterface(umlclass::Interface classInterface) {
 
 
 reaction RemovedInterfaceRealization {
-	after element umlclass::InterfaceRealization deleted and removed from umlclass::Class[interfaceRealization]
+	after element umlclass::InterfaceRealization removed from umlclass::Class[interfaceRealization]
 	call {
 		removeInterfaceRealization(oldValue)
 		removeUsage(oldValue)

--- a/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/comp2class/comp2class.reactions
+++ b/bundles/tools.vitruv.applications.umlclassumlcomponents/src/tools/vitruv/applications/umlclassumlcomponents/comp2class/comp2class.reactions
@@ -22,7 +22,7 @@ execute actions in umlclass
 ********/
 
 reaction CreatedCompModel {
-	after element umlcomp::Model created and inserted as root
+	after element umlcomp::Model inserted as root
 	call { 
 		createModelSelfCorrespondence(newValue) 
 		//createClassModel(newValue) //TODO This is currently not needed, as we are using one singular meta model  
@@ -123,7 +123,7 @@ routine changeCorrespondingVisibility(umlcomp::NamedElement compElement) {
 ************/
 
 reaction CreatedUmlComponent {
-	after element umlcomp::Component created and inserted in umlcomp::Model[packagedElement]
+	after element umlcomp::Component inserted in umlcomp::Model[packagedElement]
 	call {
 		createClassWithPackage(newValue)
 		}
@@ -178,8 +178,8 @@ routine renameClassAndPackage(umlcomp::Component umlComp, String newName) {
 
 
 reaction DeletedComp{
-	after element umlcomp::Component deleted and removed from umlcomp::Model[packagedElement]
-	call deleteClass(oldValue)
+	after element umlcomp::Component deleted
+	call deleteClass(affectedEObject)
 }
 
 routine deleteClass(umlcomp::Component umlComp) { 
@@ -215,7 +215,7 @@ routine deleteClass(umlcomp::Component umlComp) {
 ***********/
 
 reaction CreatedDatatype {
-	after element umlcomp::DataType created and inserted in umlcomp::Model[packagedElement]
+	after element umlcomp::DataType inserted in umlcomp::Model[packagedElement]
 	call {
 		val question = "Is '" + newValue.name + "' a generic/library DataType? If not a class representation will be created."
 		if ((newValue instanceof PrimitiveType) || userInteractor.modalTextYesNoUserInteractor(question))
@@ -265,7 +265,7 @@ routine createClassForDataType(umlcomp::DataType compType){
 
 
 reaction AddedDataTypeProperty{
-	after element umlcomp::Property created and inserted in umlcomp::DataType[ownedAttribute]
+	after element umlcomp::Property inserted in umlcomp::DataType[ownedAttribute]
 	call addClassDataTypeProperty(newValue, affectedEObject)
 }
 
@@ -306,8 +306,8 @@ routine changeClassDataTypeProperty(umlcomp::Property compProperty) {
 
 
 reaction AddedDataTypeOperation{
-	after element umlcomp::Operation created and inserted in umlcomp::DataType[ownedOperation]
-	call addDataTypeOperation(newValue, affectedEObject)		
+	after element umlcomp::Operation inserted in umlcomp::DataType[ownedOperation]
+	call addDataTypeOperation(newValue, affectedEObject)
 }
 
 routine addDataTypeOperation(umlcomp::Operation compOperation, umlcomp::DataType compDataType) {
@@ -445,9 +445,9 @@ reaction AddedRequiredRole {
 }
 
 reaction RemovedInterfaceRealization {
-	after element umlcomp::InterfaceRealization deleted and removed from umlcomp::Component[interfaceRealization]
+	after element umlcomp::InterfaceRealization deleted
 	call {
-		removeInterfaceRealizationForInterfaceRealization(oldValue)
+		removeInterfaceRealizationForInterfaceRealization(affectedEObject)
 	}
 }
 
@@ -464,9 +464,9 @@ routine removeInterfaceRealizationForInterfaceRealization(umlcomp::InterfaceReal
 }
 
 reaction RemovedUsage {
-	after element umlcomp::Usage deleted and removed from umlcomp::Component[packagedElement]
+	after element umlcomp::Usage deleted
 	call {
-		removeInterfaceRealizationForUsage(oldValue)
+		removeInterfaceRealizationForUsage(affectedEObject)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
@@ -11,12 +11,12 @@ execute actions in uml
 import routines javaToUmlTypePropagation using qualified names
 
 reaction JavaAttributeCreatedInClass {
-    after element java::Field created and inserted in java::Class[members]
+    after element java::Field inserted in java::Class[members]
     call createOrFindUmlAttributeInClass(affectedEObject, newValue)
 }
 
 reaction JavaAttributeCreatedInEnum {
-    after element java::Field created and inserted in java::Enumeration[members]
+    after element java::Field inserted in java::Enumeration[members]
     call createOrFindUmlAttributeInEnum(affectedEObject, newValue)
 }
 
@@ -138,6 +138,6 @@ routine setUmlAttributeFinal(java::Field jAttr, Boolean isFinal) {
 //===========================================
 
 reaction JavaAttributeCreatedInInterface {
-    after element java::Field created and inserted in java::Interface[members]
+    after element java::Field inserted in java::Interface[members]
     call showMessage(userInteractor, "Adding fields to " + affectedEObject.class.simpleName +" is not supported. Please remove " + newValue)
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -163,11 +163,11 @@ routine insertUmlMethod(java::Member javaMethod, java::ConcreteClassifier javaCl
 }
 
 reaction JavaMemberDeleted {
-    after element java::Member deleted and removed from java::ConcreteClassifier[members]
+    after element java::Member deleted
     call {
-        deleteUmlMethod(oldValue)
-        deleteAccessorCorrespondence(oldValue, UmlJavaCorrespondenceTag.GETTER)
-        deleteAccessorCorrespondence(oldValue, UmlJavaCorrespondenceTag.SETTER)
+        deleteUmlMethod(affectedEObject)
+        deleteAccessorCorrespondence(affectedEObject, UmlJavaCorrespondenceTag.GETTER)
+        deleteAccessorCorrespondence(affectedEObject, UmlJavaCorrespondenceTag.SETTER)
     }
 }
 
@@ -259,7 +259,7 @@ routine setUmlFeatureStatic(java::AnnotableAndModifiable jElem, Boolean isStatic
 //===========================================
 
 reaction JavaVariableLengthParameterCreated {
-    after element java::VariableLengthParameter created and inserted in java::Parametrizable[parameters]
+    after element java::VariableLengthParameter inserted in java::Parametrizable[parameters]
     call {
         createUmlParameter(affectedEObject, newValue)
         setMultiplicityOfCorrespondingParameterToUnlimited(newValue)
@@ -267,7 +267,7 @@ reaction JavaVariableLengthParameterCreated {
 }
 
 reaction JavaOrdinaryParameterCreated {
-    after element java::OrdinaryParameter created and inserted in java::Parametrizable[parameters]
+    after element java::OrdinaryParameter inserted in java::Parametrizable[parameters]
     call createUmlParameter(affectedEObject, newValue)
 }
 
@@ -302,7 +302,7 @@ routine setMultiplicityOfCorrespondingParameterToUnlimited(java::Parameter param
 }
 
 reaction JavaParameterDeleted {
-    after element java::Parameter deleted and removed from java::Parametrizable[parameters]
+    after element java::Parameter removed from java::Parametrizable[parameters]
     call deleteJavaParameter(oldValue)
 }
 
@@ -403,11 +403,11 @@ routine renameUmlNamedElement(java::NamedElement jElement) {
 
 //An interface can theoretically have static, non-abstract methods
 reaction JavaClassMethodCreatedInInterface {
-    after element java::ClassMethod created and inserted in java::Interface[members]
+    after element java::ClassMethod inserted in java::Interface[members]
     call showMessage(userInteractor, "ClassMethods are currently not supported in Interfaces. Please delete " + newValue)
 }
 
 reaction JavaParameterMadeFinal {
-    after element java::Final created and inserted in java::Parameter[annotationsAndModifiers]
+    after element java::Final inserted in java::Parameter[annotationsAndModifiers]
     call showMessage(userInteractor, "Final parameters are not supported. Please remove the modifier from " + affectedEObject)
 }


### PR DESCRIPTION
Removes compound change triggers from all application tests in preparation to removing compound triggers from the language at all. The rationale behind this in discussed in [Vitruv-DSLs#32](https://github.com/vitruv-tools/Vitruv-DSLs/issues/32).

There are only two supported compound triggers: `created and inserted in <container>` and `deleted and removed from <container>`. Those were refactored as follows:
- `created and inserted` was changed to `inserted` for all occurrences
- `deleted and removed` was changed to `deleted` if the element has an identity that is not bound to its container and thus no context information is needed (like `PCM:RepositoryComponent`) and `removed` otherwise (like `PCM:Parameter`)