### PR TITLE
Preparation for renaming all Vitruv default branches to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   release:
     types: [created]
   workflow_dispatch:
@@ -41,7 +41,7 @@ jobs:
         env: 
           MAVEN_OPTS: -Djansi.force=true
       - name: Publish Nightly Update Site
-        if: github.ref == 'refs/heads/master' && github.repository_owner == 'vitruv-tools'
+        if: github.ref == 'refs/heads/main' && github.repository_owner == 'vitruv-tools'
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.UPDATE_SITE_DEPLOY_KEY }}


### PR DESCRIPTION
Adapts the GitHub actions to renaming the default branch to `main`.