### PR TITLE
Adapt to introduced internal DSL for actions in Reactions

### DIFF
--- a/bundles/tools.vitruv.applications.cbs.testutils/META-INF/MANIFEST.MF
+++ b/bundles/tools.vitruv.applications.cbs.testutils/META-INF/MANIFEST.MF
@@ -2,8 +2,9 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Component-Based Systems Application Test Utilities
 Bundle-SymbolicName: tools.vitruv.applications.cbs.testutils
-Bundle-Version: 0.1.0.qualifier
 Automatic-Module-Name: tools.vitruv.applications.cbs.testutils
+Bundle-Vendor: vitruv.tools
+Bundle-Version: 0.1.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: tools.vitruv.testutils.vsum,
  org.eclipse.uml2.uml,

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
@@ -257,7 +257,7 @@ routine removeRepository(java::Package javaPackage) {
 		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged with "package_root"
 	}
 	update {
-		deleteObject(pcmRepository)
+		removeObject(pcmRepository)
 		removeCorrespondenceBetween(javaPackage, pcmRepository)
 	}
 }
@@ -267,7 +267,7 @@ routine removeSystem(java::Package javaPackage) {
 		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged with "root_system"
 	}
 	update {
-		deleteObject(pcmSystem)
+		removeObject(pcmSystem)
 		removeCorrespondenceBetween(javaPackage, pcmSystem)
 	}
 }
@@ -277,7 +277,7 @@ routine removeComponent(java::Package javaPackage) {
 		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaPackage
 	}
 	update {
-		deleteObject(pcmComponent)
+		removeObject(pcmComponent)
 		removeCorrespondenceBetween(javaPackage, pcmComponent)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
@@ -47,8 +47,8 @@ routine createPackageEClassCorrespondence(java::Package jPackage) {
 		val allPackages = retrieve many java::Package corresponding to jPackage.eClass
 		check !allPackages.contains(jPackage)
 	}
-	action {
-		add correspondence between jPackage and jPackage.eClass
+	update {
+		addCorrespondenceBetween(jPackage, jPackage.eClass)
 	}
 }
 
@@ -60,14 +60,12 @@ routine createOrFindArchitecturalElement(java::Package javaPackage, String conta
 		// ensure that we are not the root package (happens when the root package is being moved)
 		require absence of pcm::Repository corresponding to javaPackage tagged with "package_root"
 	}
-	action {
-		call {
-			val rootPackageName = getRootPackageName(javaPackage.name)
-			if (containerPackage.isPresent) { // can actually be located if it exists:
-				createOrFindArchitecturalElementInPackage(javaPackage, containerPackage.get, rootPackageName)
-			} else { // cannot be located if it already exists, so just create it anyways:
-				createArchitecturalElement(javaPackage, containerName, rootPackageName)
-			}
+	update {
+		val rootPackageName = getRootPackageName(javaPackage.name)
+		if (containerPackage.isPresent) { // can actually be located if it exists:
+			createOrFindArchitecturalElementInPackage(javaPackage, containerPackage.get, rootPackageName)
+		} else { // cannot be located if it already exists, so just create it anyways:
+			createArchitecturalElement(javaPackage, containerName, rootPackageName)
 		}
 	}
 }
@@ -77,14 +75,12 @@ routine createOrFindArchitecturalElementInPackage(java::Package javaPackage, jav
 		val pcmRepository = retrieve pcm::Repository corresponding to containingPackage tagged with "package_root"
 		require absence of pcm::RepositoryComponent corresponding to javaPackage
 	}
-	action {
-		call {
-			val pcmComponentCandidate = pcmRepository.components__Repository.findFirst[entityName == javaPackage.name.toFirstUpper]
-			if (pcmComponentCandidate === null) {
-				createArchitecturalElement(javaPackage, containingPackage.name, rootPackageName)
-			} else {
-				addCorrespondenceAndUpdateRepository(pcmComponentCandidate, javaPackage)
-			}
+	update {
+		val pcmComponentCandidate = pcmRepository.components__Repository.findFirst[entityName == javaPackage.name.toFirstUpper]
+		if (pcmComponentCandidate === null) {
+			createArchitecturalElement(javaPackage, containingPackage.name, rootPackageName)
+		} else {
+			addCorrespondenceAndUpdateRepository(pcmComponentCandidate, javaPackage)
 		}
 	}
 }
@@ -96,24 +92,22 @@ routine createArchitecturalElement(java::Package javaPackage, String name, Strin
 	match {
 		retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 	}
-	action {
-		call {
-			val String userMsg = "A package has been created. Please decide whether and which corresponding architectural element should be created"
-			val String[] selections = #[Java2PcmUserSelection.SELECT_BASIC_COMPONENT.message,
-				Java2PcmUserSelection.SELECT_COMPOSITE_COMPONENT.message,
-				Java2PcmUserSelection.SELECT_SYSTEM.message,
-				Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
-			]
-			val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-				.windowModality(WindowModality.MODAL).startInteraction()
-			switch(selected) {
-				case Java2PcmUserSelection.SELECT_BASIC_COMPONENT.selection: 
-					createBasicComponent(javaPackage, name, rootPackageName) 
-				case Java2PcmUserSelection.SELECT_COMPOSITE_COMPONENT.selection: 
-					createCompositeComponent(javaPackage, name, rootPackageName)
-				case Java2PcmUserSelection.SELECT_SYSTEM.selection: 
-					createOrFindSystem(javaPackage, name)
-			}
+	update {
+		val String userMsg = "A package has been created. Please decide whether and which corresponding architectural element should be created"
+		val String[] selections = #[Java2PcmUserSelection.SELECT_BASIC_COMPONENT.message,
+			Java2PcmUserSelection.SELECT_COMPOSITE_COMPONENT.message,
+			Java2PcmUserSelection.SELECT_SYSTEM.message,
+			Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
+		]
+		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
+			.windowModality(WindowModality.MODAL).startInteraction()
+		switch(selected) {
+			case Java2PcmUserSelection.SELECT_BASIC_COMPONENT.selection: 
+				createBasicComponent(javaPackage, name, rootPackageName) 
+			case Java2PcmUserSelection.SELECT_COMPOSITE_COMPONENT.selection: 
+				createCompositeComponent(javaPackage, name, rootPackageName)
+			case Java2PcmUserSelection.SELECT_SYSTEM.selection: 
+				createOrFindSystem(javaPackage, name)
 		}
 	}
 }
@@ -125,14 +119,12 @@ routine createOrFindRepository(java::Package javaPackage, String packageName, St
 		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
 			with javaPackage.isPackageFor(foundRepository)
 	}
-	action {
-		call {
-			if (foundRepository.isPresent) {
-				ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, javaPackage)
-				addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
-			} else {
-				createRepository(javaPackage, packageName, newTag)
-			}
+	update {
+		if (foundRepository.isPresent) {
+			ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, javaPackage)
+			addRepositoryCorrespondence(foundRepository.get, javaPackage, newTag)
+		} else {
+			createRepository(javaPackage, packageName, newTag)
 		}
 	}
 }
@@ -141,41 +133,36 @@ routine ensureFirstCaseUpperCaseRepositoryNaming(pcm::Repository pcmRepository, 
 	match {
 		check pcmRepository.entityName == javaPackage.name
 	}
-	action {
-		update pcmRepository {
-			pcmRepository.entityName = javaPackage.name.toFirstUpper
-		}
+	update {
+		pcmRepository.entityName = javaPackage.name.toFirstUpper
 	}
 }
 
 routine addRepositoryCorrespondence(pcm::Repository pcmRepository, java::Package javaPackage, String newTag) {
-	action {
-		add correspondence between pcmRepository and ContainersPackage.Literals.PACKAGE
-		add correspondence between pcmRepository and javaPackage tagged with newTag
+	update {
+		addCorrespondenceBetween(pcmRepository, ContainersPackage.Literals.PACKAGE)
+		addCorrespondenceBetween(pcmRepository, javaPackage, newTag)
 	}
 }
 
 routine createRepository(java::Package javaPackage, String packageName, String newTag) {
-	action {
-		update javaPackage {
-			// If the package-info.java is not persisted, do it
-			val packageUri = javaPackage.eResource.URI;
-			if (!URIUtil.existsResourceAtUri(packageUri)) {
-				val projectRelativeResourcePath = packageUri.segmentsList.tail.fold("", [a, b | a + "/" + b])
-				persistProjectRelative(javaPackage, javaPackage, projectRelativeResourcePath)
-			}
+	create {
+		val pcmRepository = new pcm::Repository
+	}
+	update {
+		// If the package-info.java is not persisted, do it
+		val packageUri = javaPackage.eResource.URI;
+		if (!URIUtil.existsResourceAtUri(packageUri)) {
+			val projectRelativeResourcePath = packageUri.segmentsList.tail.fold("", [a, b | a + "/" + b])
+			persistProjectRelative(javaPackage, javaPackage, projectRelativeResourcePath)
 		}
-		val pcmRepository = create pcm::Repository and initialize {
-			pcmRepository.entityName = packageName.toFirstUpper
-			persistProjectRelative(javaPackage, pcmRepository, "model/" + pcmRepository.entityName + ".repository")
-		}
+		pcmRepository.entityName = packageName.toFirstUpper
+		persistProjectRelative(javaPackage, pcmRepository, "model/" + pcmRepository.entityName + ".repository")
 		
-		add correspondence between pcmRepository and javaPackage 
-			tagged with newTag
-			
-		call createJavaSubPackages(javaPackage)
-		add correspondence between pcmRepository and ContainersPackage.Literals.PACKAGE
-		add correspondence between pcmRepository and RepositoryPackage.Literals.REPOSITORY
+		addCorrespondenceBetween(pcmRepository, javaPackage, newTag)
+		createJavaSubPackages(javaPackage)
+		addCorrespondenceBetween(pcmRepository, ContainersPackage.Literals.PACKAGE)
+		addCorrespondenceBetween(pcmRepository, RepositoryPackage.Literals.REPOSITORY)
 	}
 }
 
@@ -185,49 +172,50 @@ routine createOrFindSystem(java::Package javaPackage, String name) {
 		val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM
 			with javaPackage.isPackageFor(foundSystem)
 	}
-	action {
-		call {
-			if (foundSystem.isPresent) {
-				addSystemCorrespondence(foundSystem.get, javaPackage)
-			} else {
-				createSystem(javaPackage, name)
-			}
+	update {
+		if (foundSystem.isPresent) {
+			addSystemCorrespondence(foundSystem.get, javaPackage)
+		} else {
+			createSystem(javaPackage, name)
 		}
 	}
 }
 
 routine addSystemCorrespondence(pcm::System pcmSystem, java::Package javaPackage) {
-	action {
-		add correspondence between pcmSystem and javaPackage tagged with "root_system"
+	update {
+		addCorrespondenceBetween(pcmSystem, javaPackage, "root_system")
 	}
 }
 
 routine createSystem(java::Package javaPackage, String name) {
-	action {
-		val pcmSystem = create pcm::System and initialize {
-			pcmSystem.entityName = name
-			persistProjectRelative(javaPackage, pcmSystem, "model/" + pcmSystem.entityName + ".system")
-		}
-		add correspondence between pcmSystem and javaPackage
-		add correspondence between pcmSystem and SystemPackage.Literals.SYSTEM tagged with "root_system"
+	create {
+		val pcmSystem = new pcm::System
+	}
+	update {
+		pcmSystem.entityName = name
+		persistProjectRelative(javaPackage, pcmSystem, "model/" + pcmSystem.entityName + ".system")
+		addCorrespondenceBetween(pcmSystem, javaPackage)
+		addCorrespondenceBetween(pcmSystem, SystemPackage.Literals.SYSTEM, "root_system")
 	}
 }
 
 routine createBasicComponent(java::Package javaPackage, String name, String rootPackageName) {
-	action {
-		val pcmBasicComponent = create pcm::BasicComponent and initialize {
-			pcmBasicComponent.entityName = name
-		}
-		call addCorrespondenceAndUpdateRepository(pcmBasicComponent, javaPackage)
+	create {
+		val pcmBasicComponent = new pcm::BasicComponent
+	}
+	update {
+		pcmBasicComponent.entityName = name
+		addCorrespondenceAndUpdateRepository(pcmBasicComponent, javaPackage)
 	}
 }
 
 routine createCompositeComponent(java::Package javaPackage, String name, String rootPackageName) {
-	action {
-		val pcmCompositeComponent = create pcm::CompositeComponent and initialize {
-			pcmCompositeComponent.entityName = name
-		}		
-		call addCorrespondenceAndUpdateRepository(pcmCompositeComponent, javaPackage)
+	create {
+		val pcmCompositeComponent = new pcm::CompositeComponent
+	}
+	update {
+		pcmCompositeComponent.entityName = name
+		addCorrespondenceAndUpdateRepository(pcmCompositeComponent, javaPackage)
 	}
 }
 
@@ -237,14 +225,11 @@ routine createCompositeComponent(java::Package javaPackage, String name, String 
 routine addCorrespondenceAndUpdateRepository(pcm::RepositoryComponent pcmComponent, java::Package javaPackage) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-		
 	}
-	action {
-		add correspondence between pcmComponent and javaPackage
-		update pcmRepository {
-			if(!pcmRepository.components__Repository.contains(pcmComponent)) {
-				pcmRepository.components__Repository += pcmComponent
-			}
+	update {
+		addCorrespondenceBetween(pcmComponent, javaPackage)
+		if(!pcmRepository.components__Repository.contains(pcmComponent)) {
+			pcmRepository.components__Repository += pcmComponent
 		}
 	}
 }
@@ -271,8 +256,9 @@ routine removeRepository(java::Package javaPackage) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged with "package_root"
 	}
-	action {
-		delete pcmRepository
+	update {
+		deleteObject(pcmRepository)
+		removeCorrespondenceBetween(javaPackage, pcmRepository)
 	}
 }
 
@@ -280,8 +266,9 @@ routine removeSystem(java::Package javaPackage) {
 	match {
 		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged with "root_system"
 	}
-	action {
-		delete pcmSystem
+	update {
+		deleteObject(pcmSystem)
+		removeCorrespondenceBetween(javaPackage, pcmSystem)
 	}
 }
 
@@ -289,8 +276,9 @@ routine removeComponent(java::Package javaPackage) {
 	match {
 		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaPackage
 	}
-	action {
-		delete pcmComponent
+	update {
+		deleteObject(pcmComponent)
+		removeCorrespondenceBetween(javaPackage, pcmComponent)
 	}
 }
 
@@ -298,10 +286,8 @@ routine renameRepository(java::Package javaPackage) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged with "package_root"
 	}
-	action {
-		update pcmRepository {
-			pcmRepository.entityName = javaPackage.name.toFirstUpper
-		}
+	update {
+		pcmRepository.entityName = javaPackage.name.toFirstUpper
 	}
 }
 
@@ -309,10 +295,8 @@ routine renameSystem(java::Package javaPackage) {
 	match {
 		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged with "root_system"
 	}
-	action {
-		update pcmSystem {
-			pcmSystem.entityName = javaPackage.name.toFirstUpper
-		}
+	update {
+		pcmSystem.entityName = javaPackage.name.toFirstUpper
 	}
 }
 
@@ -320,10 +304,8 @@ routine renameComponent(java::Package javaPackage) {
 	match {
 		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaPackage
 	}
-	action {
-		update pcmComponent {
-			pcmComponent.entityName = javaPackage.name.toFirstUpper;
-		}
+	update {
+		pcmComponent.entityName = javaPackage.name.toFirstUpper;
 	}
 }
 
@@ -340,26 +322,22 @@ routine createOrFindPCMInterface(java::Interface javaInterface, java::Compilatio
 		val pcmRepository = retrieve optional pcm::Repository corresponding to containingPackage tagged with "contracts"
 		require absence of pcm::OperationInterface corresponding to javaInterface
 	}
-	action {
-		call {
-			if(pcmRepository.isPresent) {
-				createOrFindContractsInterface(javaInterface, compilationUnit, containingPackage, pcmRepository.get)
-			} else {
-				createNonContractsInterface(javaInterface, compilationUnit, containingPackage)
-			}
+	update {
+		if(pcmRepository.isPresent) {
+			createOrFindContractsInterface(javaInterface, compilationUnit, containingPackage, pcmRepository.get)
+		} else {
+			createNonContractsInterface(javaInterface, compilationUnit, containingPackage)
 		}
 	}
 }
 
 routine createOrFindContractsInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package contractsPackage, pcm::Repository pcmRepository) {
-	action {
-		call {
-			val pcmInterface = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[entityName == javaInterface.name]
-			if (pcmInterface === null) {
-				createInterface(javaInterface, compilationUnit, contractsPackage)
-			} else {
-				addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
-			}
+	update {
+		val pcmInterface = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[entityName == javaInterface.name]
+		if (pcmInterface === null) {
+			createInterface(javaInterface, compilationUnit, contractsPackage)
+		} else {
+			addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
 		}
 	}
 }
@@ -372,10 +350,8 @@ reaction JavaInterfaceRenamed {
 routine renameInterface(java::Interface javaInterface) {
 	match {
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to javaInterface}
-	action {
-		update pcmInterface {
-			pcmInterface.entityName = javaInterface.name
-		}
+	update {
+		pcmInterface.entityName = javaInterface.name
 	}
 }
 
@@ -383,31 +359,28 @@ routine renameInterface(java::Interface javaInterface) {
  * User selects if interface should be created if interface was not created into contract package.
  */
 routine createNonContractsInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package javaPackage) {
-	action {
-		call {
-			val String userMsg = "The created interface is not in the contracts packages. Should an architectural interface be created for the interface " +
-					javaInterface.name + " ?"
-			val String[] selections = #[Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.message,
-				Java2PcmUserSelection.SELECT_DONT_CREATE_INTERFACE_NOT_IN_CONTRACTS.message
-			]
-			val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-				.windowModality(WindowModality.MODAL).startInteraction()
-			if (selected == Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.selection) {
-				createInterface(javaInterface, compilationUnit, javaPackage)
-			}
+	update {
+		val String userMsg = "The created interface is not in the contracts packages. Should an architectural interface be created for the interface " +
+				javaInterface.name + " ?"
+		val String[] selections = #[Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.message,
+			Java2PcmUserSelection.SELECT_DONT_CREATE_INTERFACE_NOT_IN_CONTRACTS.message
+		]
+		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
+			.windowModality(WindowModality.MODAL).startInteraction()
+		if (selected == Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.selection) {
+			createInterface(javaInterface, compilationUnit, javaPackage)
 		}
 	}
 }
 
 routine createInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package javaPackage) {
-	action {
-		val pcmInterface = create pcm::OperationInterface and initialize {
-			pcmInterface.entityName = javaInterface.name
-		}
-		call {
-			addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
-			updateRepositoryInterfaces(pcmInterface)
-		}
+	create {
+		val pcmInterface = new pcm::OperationInterface
+	}
+	update {
+		pcmInterface.entityName = javaInterface.name
+		addInterfaceCorrespondence(pcmInterface, javaInterface, compilationUnit)
+		updateRepositoryInterfaces(pcmInterface)
 	}
 }
 
@@ -415,8 +388,8 @@ routine addInterfaceCorrespondence(pcm::OperationInterface pcmInterface, java::I
 	match {
 		require absence of pcm::Interface corresponding to javaInterface
 	}
-	action {
-		add correspondence between pcmInterface and javaInterface 
+	update {
+		addCorrespondenceBetween(pcmInterface, javaInterface) 
 	}
 }
 
@@ -424,10 +397,8 @@ routine updateRepositoryInterfaces(pcm::OperationInterface pcmInterface) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 	}
-	action {
-		update pcmRepository {
-			pcmRepository.interfaces__Repository += pcmInterface
-		}
+	update {
+		pcmRepository.interfaces__Repository += pcmInterface
 	}
 }
 
@@ -444,12 +415,10 @@ routine renameComponentFromClass(java::Class javaClass) {
 	match {
 		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to javaClass
 	}
-	action {
-		update pcmComponent {
-			var newName = javaClass.name.toFirstUpper
-			if (newName.endsWith("Impl")) newName = newName.substring(0, newName.length - "Impl".length)
-			pcmComponent.entityName = newName
-		}
+	update {
+		var newName = javaClass.name.toFirstUpper
+		if (newName.endsWith("Impl")) newName = newName.substring(0, newName.length - "Impl".length)
+		pcmComponent.entityName = newName
 	}
 }
 
@@ -457,11 +426,9 @@ routine renameDataTypeFromClass(java::Class javaClass) {
 	match {
 		val dataType = retrieve pcm::DataType corresponding to javaClass
 	}
-	action {
-		update dataType {
-			if(dataType instanceof Entity) { // primitive data types don't have names
-				dataType.entityName = javaClass.name.toFirstUpper
-			}
+	update {
+		if(dataType instanceof Entity) { // primitive data types don't have names
+			dataType.entityName = javaClass.name.toFirstUpper
 		}
 	}
 }
@@ -484,15 +451,12 @@ routine classMapping(java::Class javaClass, java::CompilationUnit compilationUni
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 		val datatypesPackage = retrieve java::Package corresponding to pcmRepository tagged with "datatypes" 
 	}
-	action {
-		call {
-			if (javaPackage !== null && javaPackage.name == datatypesPackage.name) {
-				createDataType(javaClass, compilationUnit)
-			} else {
-				checkSystemAndComponent(javaPackage, javaClass)
-				createElement(javaClass, javaPackage, compilationUnit)
-			}
-			
+	update {
+		if (javaPackage !== null && javaPackage.name == datatypesPackage.name) {
+			createDataType(javaClass, compilationUnit)
+		} else {
+			checkSystemAndComponent(javaPackage, javaClass)
+			createElement(javaClass, javaPackage, compilationUnit)
 		}
 	}
 }
@@ -501,22 +465,20 @@ routine classMapping(java::Class javaClass, java::CompilationUnit compilationUni
  * User can choose if a composite or collection data type should be created.
  */
 routine createDataType(java::Class javaClass, java::CompilationUnit compilationUnit) {
-	action {
-		call {
-			val String userMsg = "Class " + javaClass.name +
-						" has been created in the datatypes package. Please decide which kind of data type should be created."
-			val String[] selections = #[Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.message,
-				Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.message,
-				Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
-			]
-			val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-				.windowModality(WindowModality.MODAL).startInteraction()
-			switch(selected) {
-				case Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.selection: 
-					createOrFindCompositeDataType(javaClass, compilationUnit)
-				case Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.selection: 
-					createOrFindCollectionDataType(javaClass, compilationUnit)
-			}
+	update {
+		val String userMsg = "Class " + javaClass.name +
+					" has been created in the datatypes package. Please decide which kind of data type should be created."
+		val String[] selections = #[Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.message,
+			Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.message,
+			Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
+		]
+		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
+			.windowModality(WindowModality.MODAL).startInteraction()
+		switch(selected) {
+			case Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.selection: 
+				createOrFindCompositeDataType(javaClass, compilationUnit)
+			case Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.selection: 
+				createOrFindCollectionDataType(javaClass, compilationUnit)
 		}
 	}
 }
@@ -531,11 +493,9 @@ routine createElement(java::Class javaClass, java::Package javaPackage, java::Co
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 		val javaRootPackage = retrieve java::Package corresponding to pcmRepository tagged with "package_root" 
 	}
-	action {
-		call {
-			createArchitecturalElement(javaRootPackage, javaClass.name, compilationUnit.namespaces.head)			
-			checkSystemAndComponent(javaRootPackage, javaClass)
-		}
+	update {
+		createArchitecturalElement(javaRootPackage, javaClass.name, compilationUnit.namespaces.head)			
+		checkSystemAndComponent(javaRootPackage, javaClass)
 	}
 }
 
@@ -547,8 +507,8 @@ routine checkSystemAndComponent(java::Package javaPackage, java::Class javaClass
 	match {
 		val componentOrSystem = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to javaPackage 
 	}
-	action {
-		add correspondence between javaClass and componentOrSystem
+	update {
+		addCorrespondenceBetween(javaClass, componentOrSystem)
 	}
 }
 
@@ -556,29 +516,26 @@ routine createOrFindCompositeDataType(java::Class javaClass, java::CompilationUn
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 	}
-	action {
-		call {
-			val foundCompositeDataType = pcmRepository.dataTypes__Repository.filter(CompositeDataType)
-				.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"].claimNotMany
-			if (foundCompositeDataType === null) {
-				createCompositeDataType(javaClass, compilationUnit)
-			} else {
-				addDataTypeCorrespondence(javaClass, compilationUnit, foundCompositeDataType)
-			}
+	update {
+		val foundCompositeDataType = pcmRepository.dataTypes__Repository.filter(CompositeDataType)
+			.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"].claimNotMany
+		if (foundCompositeDataType === null) {
+			createCompositeDataType(javaClass, compilationUnit)
+		} else {
+			addDataTypeCorrespondence(javaClass, compilationUnit, foundCompositeDataType)
 		}
 	}
 }
 
 routine createCompositeDataType(java::Class javaClass, java::CompilationUnit compilationUnit) {
-	action {
-		val pcmCompositeDataType = create pcm::CompositeDataType and initialize {
-			pcmCompositeDataType.entityName = javaClass.name
-		}
-		add correspondence between pcmCompositeDataType and javaClass
-		call {
-			addDataTypeCorrespondence(javaClass, compilationUnit, pcmCompositeDataType)
-			addDataTypeInRepository(pcmCompositeDataType)
-		}
+	create {
+		val pcmCompositeDataType = new pcm::CompositeDataType
+	}
+	update {
+		pcmCompositeDataType.entityName = javaClass.name
+		addCorrespondenceBetween(pcmCompositeDataType, javaClass)
+		addDataTypeCorrespondence(javaClass, compilationUnit, pcmCompositeDataType)
+		addDataTypeInRepository(pcmCompositeDataType)
 	}
 }
 
@@ -586,34 +543,31 @@ routine createOrFindCollectionDataType(java::Class javaClass, java::CompilationU
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 	}
-	action {
-		call {
-			val foundCollectionDataType = pcmRepository.dataTypes__Repository.filter(CollectionDataType)
-				.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"].claimNotMany
-			if (foundCollectionDataType === null) {
-				createCollectionDataType(javaClass, compilationUnit)
-			} else {
-				addDataTypeCorrespondence(javaClass, compilationUnit, foundCollectionDataType)
-			}
+	update {
+		val foundCollectionDataType = pcmRepository.dataTypes__Repository.filter(CollectionDataType)
+			.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"].claimNotMany
+		if (foundCollectionDataType === null) {
+			createCollectionDataType(javaClass, compilationUnit)
+		} else {
+			addDataTypeCorrespondence(javaClass, compilationUnit, foundCollectionDataType)
 		}
 	}
 }
 
 routine createCollectionDataType(java::Class javaClass, java::CompilationUnit compilationUnit) {
-	action {
-		val pcmCollectionDataType = create pcm::CollectionDataType and initialize {
-			pcmCollectionDataType.entityName = javaClass.name
-		}
-		call {
-			addDataTypeCorrespondence(javaClass, compilationUnit, pcmCollectionDataType)
-			addDataTypeInRepository(pcmCollectionDataType)
-		}
+	create {
+		val pcmCollectionDataType = new pcm::CollectionDataType
+	}
+	update {
+		pcmCollectionDataType.entityName = javaClass.name
+		addDataTypeCorrespondence(javaClass, compilationUnit, pcmCollectionDataType)
+		addDataTypeInRepository(pcmCollectionDataType)
 	}
 }
 
 routine addDataTypeCorrespondence(java::Class javaClass, java::CompilationUnit compilationUnit, pcm::DataType dataType) {
-	action {
-		add correspondence between dataType and javaClass
+	update {
+		addCorrespondenceBetween(dataType, javaClass)
 	}
 }
 
@@ -621,13 +575,9 @@ routine addDataTypeInRepository(pcm::DataType pcmDataType) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 	}
-	action {
-		update pcmDataType {
-			pcmDataType.repository__DataType = pcmRepository
-		}
-		update pcmRepository {
-			pcmRepository.dataTypes__Repository += pcmDataType
-		}
+	update {
+		pcmDataType.repository__DataType = pcmRepository
+		pcmRepository.dataTypes__Repository += pcmDataType
 	}
 }
 
@@ -641,12 +591,10 @@ reaction TypeReferenceCreated {
 }
 
 routine createOperationProvidedRole(java::TypeReference typeReference) {
-	action {
-		call {
-			val javaClass = typeReference.eContainer as Class
-			var javaInterfaceClassifier = getNormalizedClassifierFromTypeReference(typeReference)
-			createOperationProvidedRoleFromTypeReference(javaInterfaceClassifier, javaClass, typeReference)
-		}
+	update {
+		val javaClass = typeReference.eContainer as Class
+		var javaInterfaceClassifier = getNormalizedClassifierFromTypeReference(typeReference)
+		createOperationProvidedRoleFromTypeReference(javaInterfaceClassifier, javaClass, typeReference)
 	}
 }
 
@@ -655,13 +603,14 @@ routine createOperationProvidedRoleFromTypeReference(java::Classifier classifier
 		val opInterface = retrieve pcm::OperationInterface corresponding to classifierInterface
 		val basicComponent = retrieve pcm::BasicComponent corresponding to javaClass
 	}
-	action {
-		val operationProvidedRole = create pcm::OperationProvidedRole and initialize {
-			operationProvidedRole.providedInterface__OperationProvidedRole = opInterface
-			operationProvidedRole.providingEntity_ProvidedRole = basicComponent
-			operationProvidedRole.entityName = basicComponent.entityName + "_provides_" + opInterface.entityName
-		}
-		add correspondence between operationProvidedRole and reference
+	create {
+		val operationProvidedRole = new pcm::OperationProvidedRole
+	}
+	update {
+		operationProvidedRole.providedInterface__OperationProvidedRole = opInterface
+		operationProvidedRole.providingEntity_ProvidedRole = basicComponent
+		operationProvidedRole.entityName = basicComponent.entityName + "_provides_" + opInterface.entityName
+		addCorrespondenceBetween(operationProvidedRole, reference)
 	}
 }
 
@@ -673,11 +622,9 @@ routine createJavaSubPackages(java::Package javaPackage) {
 	match {
 		val repository = retrieve pcm::Repository corresponding to javaPackage
 	}
-	action {
-		call {
-			createJavaPackage(repository, javaPackage, "datatypes", "datatypes");
-			createJavaPackage(repository, javaPackage, "contracts", "contracts");
-		}
+	update {
+		createJavaPackage(repository, javaPackage, "datatypes", "datatypes");
+		createJavaPackage(repository, javaPackage, "contracts", "contracts");
 	}
 }	
 
@@ -688,17 +635,17 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
 	} 
-	action { // TODO FIXME find or create pattern
-		val javaPackage = create java::Package and initialize {
-			if (parentPackage !== null) {
-				javaPackage.namespaces += parentPackage.namespaces;
-				javaPackage.namespaces += parentPackage.name; 
-			}
-			javaPackage.name = packageName;
-			persistProjectRelative(parentPackage, javaPackage, buildJavaFilePath(javaPackage));
+	create {
+		val javaPackage = new java::Package
+	}
+	update { // TODO FIXME find or create pattern
+		if (parentPackage !== null) {
+			javaPackage.namespaces += parentPackage.namespaces;
+			javaPackage.namespaces += parentPackage.name; 
 		}
-		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE
-		add correspondence between javaPackage and sourceElementMappedToPackage
-			tagged with newTag
+		javaPackage.name = packageName;
+		persistProjectRelative(parentPackage, javaPackage, buildJavaFilePath(javaPackage));
+		addCorrespondenceBetween(javaPackage, ContainersPackage.Literals.PACKAGE)
+		addCorrespondenceBetween(javaPackage, sourceElementMappedToPackage, newTag)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmMethod.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmMethod.reactions
@@ -69,7 +69,7 @@ routine deleteParameter(java::OrdinaryParameter javaParameter) {
 		val pcmParameter = retrieve pcm::Parameter corresponding to javaParameter
 	}
 	update {
-		deleteObject(pcmParameter)
+		removeObject(pcmParameter)
 		removeCorrespondenceBetween(javaParameter, pcmParameter)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmMethod.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmMethod.reactions
@@ -26,10 +26,8 @@ reaction MemberRenamed {
 routine renameMember(java::Member javaMember) {
 	match {
 		val pcmElement = retrieve pcm::NamedElement corresponding to javaMember}
-	action {
-		update pcmElement {
-			pcmElement.entityName = javaMember.name
-		}
+	update {
+		pcmElement.entityName = javaMember.name
 	}
 }
 
@@ -45,14 +43,14 @@ routine createParameter(java::OrdinaryParameter javaParameter, java::Parametriza
 	match {
 		val operationSignature = retrieve pcm::OperationSignature corresponding to javaMethod
 	}
-	action {
-		val pcmParameter = create pcm::Parameter
-		call changeParameterName(javaParameter.name, javaParameter)
-		call changeParameterType(javaParameter.typeReference, javaParameter)
-		add correspondence between javaParameter and pcmParameter
-		update operationSignature {
-			operationSignature.parameters__OperationSignature += pcmParameter
-		}
+	create {
+		val pcmParameter = new pcm::Parameter
+	}
+	update {
+		changeParameterName(javaParameter.name, javaParameter)
+		changeParameterType(javaParameter.typeReference, javaParameter)
+		addCorrespondenceBetween(javaParameter, pcmParameter)
+		operationSignature.parameters__OperationSignature += pcmParameter
 	}
 }
 
@@ -70,8 +68,9 @@ routine deleteParameter(java::OrdinaryParameter javaParameter) {
 	match {
 		val pcmParameter = retrieve pcm::Parameter corresponding to javaParameter
 	}
-	action{
-		delete pcmParameter
+	update {
+		deleteObject(pcmParameter)
+		removeCorrespondenceBetween(javaParameter, pcmParameter)
 	}
 }
 
@@ -87,10 +86,8 @@ routine changeParameterName(String newName, java::Parameter javaParameter) {
 	match {
 		val pcmParameter = retrieve pcm::Parameter corresponding to javaParameter
 	}
-	action {
-		update pcmParameter {
-			pcmParameter.name = newName
-		}
+	update {
+		pcmParameter.name = newName
 	}
 }
 
@@ -103,14 +100,12 @@ routine changeParameterType(java::TypeReference newType, java::Parameter javaPar
 	match {
 		val pcmParameter = retrieve pcm::Parameter corresponding to javaParameter
 	}
-	action {
-		update pcmParameter {
-			pcmParameter.dataType__Parameter = if (javaParameter.typeReference !== null) {
-					javaParameter.typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
-				} else {
-					null
-				}
-		}
+	update {
+		pcmParameter.dataType__Parameter = if (javaParameter.typeReference !== null) {
+				javaParameter.typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
+			} else {
+				null
+			}
 	}
 }
 
@@ -134,17 +129,18 @@ routine createInnerDeclaration(java::ConcreteClassifier classifier, java::Field 
 	match {
 		val compositeDataType = retrieve pcm::CompositeDataType corresponding to classifier
 	}
-	action {
-		val innerDeclaration = create pcm::InnerDeclaration and initialize {
-			innerDeclaration.entityName = javaField.name
-			innerDeclaration.datatype_InnerDeclaration = if (javaField.typeReference !== null) {
-					javaField.typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
-				} else {
-					null
-				}
+	create {
+		val innerDeclaration = new pcm::InnerDeclaration
+	}
+	update {
+		innerDeclaration.entityName = javaField.name
+		innerDeclaration.datatype_InnerDeclaration = if (javaField.typeReference !== null) {
+				javaField.typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
+			} else {
+				null
+			}
 			innerDeclaration.compositeDataType_InnerDeclaration = compositeDataType
-		}
-		add correspondence between innerDeclaration and javaField
+		addCorrespondenceBetween(innerDeclaration, javaField)
 	}
 }
 
@@ -154,14 +150,12 @@ routine createOrFindAssemblyContext(java::ConcreteClassifier classifier, java::F
         val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to getClassifierFromTypeReference(javaField.typeReference)
         require absence of pcm::AssemblyContext corresponding to javaField
     }
-    action {
-        call {
-            val pcmAssemblyContextCandidate = composedProvidingRequiringEntity.assemblyContexts__ComposedStructure.findFirst[entityName === javaField.name]
-            if (pcmAssemblyContextCandidate === null) {
-                createAssemblyContext(classifier, javaField)
-            } else {
-                addAssemblyContextCorrespondence(pcmAssemblyContextCandidate, javaField)
-            }
+    update {
+        val pcmAssemblyContextCandidate = composedProvidingRequiringEntity.assemblyContexts__ComposedStructure.findFirst[entityName === javaField.name]
+        if (pcmAssemblyContextCandidate === null) {
+            createAssemblyContext(classifier, javaField)
+        } else {
+            addAssemblyContextCorrespondence(pcmAssemblyContextCandidate, javaField)
         }
     }
 }
@@ -171,19 +165,20 @@ routine createAssemblyContext(java::ConcreteClassifier classifier, java::Field j
 		val composedProvidingRequiringEntity = retrieve pcm::ComposedProvidingRequiringEntity corresponding to classifier
 		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to getClassifierFromTypeReference(javaField.typeReference)
 	}
-	action {
-		val assemblyContext = create pcm::AssemblyContext and initialize {
-			assemblyContext.entityName = javaField.name
-			assemblyContext.encapsulatedComponent__AssemblyContext = repositoryComponent
-			assemblyContext.parentStructure__AssemblyContext = composedProvidingRequiringEntity	
-		}
-		add correspondence between assemblyContext and javaField
+	create {
+		val assemblyContext = new pcm::AssemblyContext
+	}
+	update {
+		assemblyContext.entityName = javaField.name
+		assemblyContext.encapsulatedComponent__AssemblyContext = repositoryComponent
+		assemblyContext.parentStructure__AssemblyContext = composedProvidingRequiringEntity	
+		addCorrespondenceBetween(assemblyContext, javaField)
 	}
 }
 
 routine addAssemblyContextCorrespondence(pcm::AssemblyContext assemblyContext, java::Field javaField) {
-    action {
-        add correspondence between assemblyContext and javaField
+    update {
+        addCorrespondenceBetween(assemblyContext, javaField)
     }
 }
 
@@ -192,10 +187,8 @@ routine fieldCreatedCorrespondingToOperationInterface(java::Classifier classifie
 		val correspondingInterface = retrieve pcm::OperationInterface corresponding to classifier
 		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to javaField.containingConcreteClassifier
 	}
-	action {
-		call {
-			createOperationRequiredRoleCorrespondingToField(javaField, correspondingInterface, repositoryComponent)
-		}
+	update {
+		createOperationRequiredRoleCorrespondingToField(javaField, correspondingInterface, repositoryComponent)
 	}
 }
 routine fieldCreatedCorrespondingToRepositoryComponent(java::Classifier classifier, java::Field javaField) {
@@ -203,25 +196,24 @@ routine fieldCreatedCorrespondingToRepositoryComponent(java::Classifier classifi
 		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to classifier
 		val concreteRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to javaField.containingConcreteClassifier
 	}
-	action {
-		call {
-			var operationProvidedRoles = repositoryComponent.providedRoles_InterfaceProvidingEntity.filter(OperationProvidedRole)
-			for (providedRole : operationProvidedRoles) {
-				createOperationRequiredRoleCorrespondingToField(javaField, providedRole.providedInterface__OperationProvidedRole, concreteRepositoryComponent)
-			}
+	update {
+		var operationProvidedRoles = repositoryComponent.providedRoles_InterfaceProvidingEntity.filter(OperationProvidedRole)
+		for (providedRole : operationProvidedRoles) {
+			createOperationRequiredRoleCorrespondingToField(javaField, providedRole.providedInterface__OperationProvidedRole, concreteRepositoryComponent)
 		}
 	}
 }
 
 routine createOperationRequiredRoleCorrespondingToField(java::Field javaField, pcm::OperationInterface operationInterface, pcm::RepositoryComponent repoComponent) {
-	action {
-		val operationRequiredRole = create pcm::OperationRequiredRole and initialize {
-			operationRequiredRole.requiredInterface__OperationRequiredRole = operationInterface
-			operationRequiredRole.requiringEntity_RequiredRole = repoComponent
-			operationRequiredRole.entityName = "Component_" + repoComponent.entityName + "_requires_" +
-				operationInterface.entityName
-		}
-		add correspondence between operationRequiredRole and javaField
+	create {
+		val operationRequiredRole = new pcm::OperationRequiredRole
+	}
+	update {
+		operationRequiredRole.requiredInterface__OperationRequiredRole = operationInterface
+		operationRequiredRole.requiringEntity_RequiredRole = repoComponent
+		operationRequiredRole.entityName = "Component_" + repoComponent.entityName + "_requires_" +
+			operationInterface.entityName
+		addCorrespondenceBetween(operationRequiredRole, javaField)
 	}
 }
 
@@ -234,14 +226,12 @@ routine changeInnerDeclarationType(java::TypeReference typeReference, java::Fiel
 	match {
 		val innerDeclaration = retrieve pcm::InnerDeclaration corresponding to javaField
 	}
-	action {
-		update innerDeclaration {
-			innerDeclaration.datatype_InnerDeclaration = if (typeReference !== null) {
-					typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
-				} else {
-					null
-				}
-		}
+	update {
+		innerDeclaration.datatype_InnerDeclaration = if (typeReference !== null) {
+				typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
+			} else {
+				null
+			}
 	}
 }
 
@@ -252,12 +242,10 @@ reaction ClassMethodCreated {
 }
 
 routine createSeffFromImplementingInterfaces(java::ClassMethod classMethod, java::Class javaClass) {
-	action {
-		call {
-			val implementingInterfaces = findImplementingInterfacesFromTypeRefs(javaClass.implements)
-			for (implementingInterface : implementingInterfaces) {
-				createSeffFromImplementingInterface(classMethod, javaClass, implementingInterface)
-			}
+	update {
+		val implementingInterfaces = findImplementingInterfacesFromTypeRefs(javaClass.implements)
+		for (implementingInterface : implementingInterfaces) {
+			createSeffFromImplementingInterface(classMethod, javaClass, implementingInterface)
 		}
 	}
 }
@@ -266,12 +254,10 @@ routine createSeffFromImplementingInterface(java::ClassMethod classMethod, java:
 	match {
 		val operationInterface = retrieve pcm::OperationInterface corresponding to javaInterface
 	} 
-	action {
-		call {
-			val methods = javaInterface.methods.filter[hasSameSignature(classMethod)]
-			for (method : methods) {
-				createSEFF(method, javaClass, classMethod)
-			}
+	update {
+		val methods = javaInterface.methods.filter[hasSameSignature(classMethod)]
+		for (method : methods) {
+			createSEFF(method, javaClass, classMethod)
 		}
 	}
 }
@@ -281,16 +267,14 @@ routine createSEFF(java::Method javaMethod, java::Class javaClass, java::ClassMe
 		val operationSignature = retrieve pcm::OperationSignature corresponding to javaMethod
 		val basicComponent = retrieve pcm::BasicComponent corresponding to javaClass
 	}
-	action {
-		val rdseff = create pcm::ResourceDemandingSEFF and initialize {
-			rdseff.describedService__SEFF = operationSignature
-			rdseff.basicComponent_ServiceEffectSpecification = basicComponent
-		}
-		add correspondence between classMethod and rdseff
-		
-		update basicComponent {
-			basicComponent.serviceEffectSpecifications__BasicComponent += rdseff
-		}
+	create {
+		val rdseff = new pcm::ResourceDemandingSEFF
+	}
+	update {
+		rdseff.describedService__SEFF = operationSignature
+		rdseff.basicComponent_ServiceEffectSpecification = basicComponent
+		addCorrespondenceBetween(classMethod, rdseff)
+		basicComponent.serviceEffectSpecifications__BasicComponent += rdseff
 	}
 }
 
@@ -304,17 +288,14 @@ routine createPCMSignature(java::InterfaceMethod interfaceMethod) {
 	match {
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to interfaceMethod.containingConcreteClassifier
 	}
-	action {
-		val operationSignature = create pcm::OperationSignature and initialize {
-			operationSignature.entityName = interfaceMethod.name
-			operationSignature.interface__OperationSignature = pcmInterface
-		}
-		
-		update pcmInterface {
-			pcmInterface.signatures__OperationInterface += operationSignature
-		}
-		
-		add correspondence between operationSignature and interfaceMethod
+	create {
+		val operationSignature = new pcm::OperationSignature
+	}
+	update {
+		operationSignature.entityName = interfaceMethod.name
+		operationSignature.interface__OperationSignature = pcmInterface
+		pcmInterface.signatures__OperationInterface += operationSignature
+		addCorrespondenceBetween(operationSignature, interfaceMethod)
 	}
 }
 
@@ -327,14 +308,12 @@ routine changeReturnType(java::Method javaMethod, java::TypeReference typeRefere
 	match {
 		val operationSignature = retrieve pcm::OperationSignature corresponding to javaMethod
 	}
-	 action {
-		 update operationSignature {
-			val repository = operationSignature.interface__OperationSignature.repository__Interface
-			operationSignature.returnType__OperationSignature = if (typeReference !== null) {
-					typeReference.getCorrespondingPCMDataTypeForTypeReference(correspondenceModel, userInteractor, repository, javaMethod.arrayDimension)
-				} else {
-					null
-				}
-		 }
+	 update {
+		val repository = operationSignature.interface__OperationSignature.repository__Interface
+		operationSignature.returnType__OperationSignature = if (typeReference !== null) {
+				typeReference.getCorrespondingPCMDataTypeForTypeReference(correspondenceModel, userInteractor, repository, javaMethod.arrayDimension)
+			} else {
+				null
+			}
 	 }
 }

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
@@ -687,7 +687,7 @@ routine deleteJavaPackage(pcm::NamedElement sourceElementMappedToPackage, String
 		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage tagged with expectedTag
 	}
 	update {
-		deleteObject(javaPackage)
+		removeObject(javaPackage)
 		removeCorrespondenceBetween(sourceElementMappedToPackage, javaPackage)
 	}
 }
@@ -794,7 +794,7 @@ routine deleteJavaClassifier(pcm::NamedElement sourceElement) {
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to sourceElement
 	}
 	update {
-		deleteObject(javaClassifier.containingCompilationUnit)
+		removeObject(javaClassifier.containingCompilationUnit)
 		removeCorrespondenceBetween(sourceElement, javaClassifier.containingCompilationUnit)
 	}
 }
@@ -882,9 +882,9 @@ routine removeProvidedRole(pcm::ProvidedRole providedRole) {
 		val typeReference = retrieve java::TypeReference corresponding to providedRole
 	}
 	update {
-		deleteObject(typeReference.pureClassifierReference) // seems to be necessary to properly delete reference if it is a NamespaceClassifierReference
+		removeObject(typeReference.pureClassifierReference) // seems to be necessary to properly delete reference if it is a NamespaceClassifierReference
 		removeCorrespondenceBetween(typeReference.pureClassifierReference, providedRole)
-		deleteObject(typeReference)
+		removeObject(typeReference)
 		removeCorrespondenceBetween(typeReference, providedRole)
 	}
 }
@@ -960,9 +960,9 @@ routine removeRequiredRole(pcm::RequiredRole requiredRole) {
 		val javaClass = retrieve java::Class corresponding to requiredRole
 	}
 	update {
-		deleteObject(requiredInterfaceImport)
+		removeObject(requiredInterfaceImport)
 		removeCorrespondenceBetween(requiredInterfaceImport, requiredRole)
-		deleteObject(requiredInterfaceField)
+		removeObject(requiredInterfaceField)
 		removeCorrespondenceBetween(requiredInterfaceField, requiredRole)
 		removeCorrespondenceBetween(javaClass, requiredRole)
 		for (ctor : javaClass.members.filter(typeof(Constructor))) {
@@ -1003,7 +1003,7 @@ routine removeCorrespondingParameterFromConstructor(java::Constructor ctor, pcm:
 			with ctor.parameters.contains(param)
 	}
 	update {
-		deleteObject(param)
+		removeObject(param)
 		removeCorrespondenceBetween(correspondenceSource, param)
 	}
 }
@@ -1113,7 +1113,7 @@ routine deleteMethodForOperationSignature(pcm::OperationSignature operationSigna
 		val interfaceMethod = retrieve java::InterfaceMethod corresponding to operationSignature
 	}
 	update {
-		deleteObject(interfaceMethod)
+		removeObject(interfaceMethod)
 		removeCorrespondenceBetween(interfaceMethod, operationSignature)
 	}
 }
@@ -1189,7 +1189,7 @@ routine deleteParameter(pcm::OperationSignature signature, pcm::Parameter parame
 		val javaParameter = retrieve java::OrdinaryParameter corresponding to parameter
 	}
 	update {
-		deleteObject(javaParameter)
+		removeObject(javaParameter)
 		removeCorrespondenceBetween(javaParameter, parameter)
 	}
 }
@@ -1255,7 +1255,7 @@ routine deleteMethodForSeff(pcm::ServiceEffectSpecification seff) {
 		val classMethod = retrieve java::ClassMethod corresponding to seff
 	}
 	update {
-		deleteObject(classMethod)
+		removeObject(classMethod)
 		removeCorrespondenceBetween(seff, classMethod)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
@@ -57,8 +57,8 @@ reaction RepositoryCreated {
 }
 
 routine addRepositoryCorrespondence(pcm::Repository pcmRepository) {
-	action {
-		add correspondence between pcmRepository and RepositoryPackage.Literals.REPOSITORY
+	update {
+		addCorrespondenceBetween(pcmRepository, RepositoryPackage.Literals.REPOSITORY)
 	}
 }
 
@@ -74,11 +74,9 @@ routine createRepositoryPackages(pcm::Repository repository) {
 	match {
 		require absence of java::Package corresponding to repository
 	}
-	action {
-		call {
-			createOrFindJavaPackage(repository, null, repository.entityName, "repository_root");
-			createRepositorySubPackages(repository);
-		}
+	update {
+		createOrFindJavaPackage(repository, null, repository.entityName, "repository_root");
+		createRepositorySubPackages(repository);
 	}
 }
 
@@ -86,11 +84,9 @@ routine createRepositorySubPackages(pcm::Repository repository) {
 	match {
 		val repositoryPackage = retrieve java::Package corresponding to repository
 	}
-	action {
-		call {
-			createOrFindJavaPackage(repository, repositoryPackage, "datatypes", "datatypes");
-			createOrFindJavaPackage(repository, repositoryPackage, "contracts", "contracts");
-		}
+	update {
+		createOrFindJavaPackage(repository, repositoryPackage, "datatypes", "datatypes");
+		createOrFindJavaPackage(repository, repositoryPackage, "contracts", "contracts");
 	}
 }
 
@@ -99,27 +95,23 @@ routine renamePackageForRepository(pcm::Repository repository) {
 		val rootPackage = retrieve java::Package corresponding to repository
 			tagged with "repository_root"
 	}
-	action {
-		update rootPackage {
-			rootPackage.name = repository.correspondingPackageName
+	update {
+		rootPackage.name = repository.correspondingPackageName
+		renameJavaPackage(repository, rootPackage, "contracts", "contracts");
+		renameJavaPackage(repository, rootPackage, "datatypes", "datatypes");
+		for (component : repository.components__Repository.filter(BasicComponent)) {
+			renameComponentPackageAndClass(component);
 		}
-		call {
-			renameJavaPackage(repository, rootPackage, "contracts", "contracts");
-			renameJavaPackage(repository, rootPackage, "datatypes", "datatypes");
-			for (component : repository.components__Repository.filter(BasicComponent)) {
-				renameComponentPackageAndClass(component);
-			}
-			for (interface : repository.interfaces__Repository.filter(OperationInterface)) {
-				renameInterface(interface);
-			}
-			for (dataType : repository.dataTypes__Repository.filter(CompositeDataType)) {
-				renameCompositeDataType(dataType);
-			}
-			for (dataType : repository.dataTypes__Repository.filter(CollectionDataType)) {
-				renameCollectionDataType(dataType);
-			}
-			persistProjectRelative(repository, rootPackage, buildJavaFilePath(rootPackage));
+		for (interface : repository.interfaces__Repository.filter(OperationInterface)) {
+			renameInterface(interface);
 		}
+		for (dataType : repository.dataTypes__Repository.filter(CompositeDataType)) {
+			renameCompositeDataType(dataType);
+		}
+		for (dataType : repository.dataTypes__Repository.filter(CollectionDataType)) {
+			renameCollectionDataType(dataType);
+		}
+		persistProjectRelative(repository, rootPackage, buildJavaFilePath(rootPackage));
 	}
 }
 
@@ -159,8 +151,8 @@ reaction CreatedSystem {
 }
 
 routine addSystemCorrespondence(pcm::System pcmSystem) {
-	action { // required to enable find-or-create-pattern:
-		add correspondence between pcmSystem and SystemPackage.Literals.SYSTEM
+	update { // required to enable find-or-create-pattern:
+		addCorrespondenceBetween(pcmSystem, SystemPackage.Literals.SYSTEM)
 	}
 }
 
@@ -168,8 +160,8 @@ routine createImplementationForSystem(pcm::System system) {
 	match {
 		val systemPackage = retrieve java::Package corresponding to system
 	}
-	action {
-		call createOrFindJavaClass(system, systemPackage, system.entityName + "Impl")
+	update {
+		createOrFindJavaClass(system, systemPackage, system.entityName + "Impl")
 	}
 }
 
@@ -190,11 +182,9 @@ routine changeSystemImplementationName(pcm::System system) {
 	match {
 		val systemPackage = retrieve java::Package corresponding to system
 	}
-	action {
-		call {
-			renameJavaPackage(system, null, system.correspondingPackageName, null);
-			renameJavaClassifier(system, systemPackage, system.entityName + "Impl");
-		}
+	update {
+		renameJavaPackage(system, null, system.correspondingPackageName, null);
+		renameJavaClassifier(system, systemPackage, system.entityName + "Impl");
 	}
 }
 
@@ -213,31 +203,30 @@ routine createOrFindAssemblyContextField(pcm::AssemblyContext assemblyContext, p
 		 val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
 		 require absence of java::Field corresponding to assemblyContext
 	 }
-	 action {
-		call {
-			val foundField = compositeComponentJavaClass.members.filter(Field).findFirst[name == assemblyContext.entityName]
-			if (foundField === null) {
-				createAssemblyContextField(assemblyContext, compositeComponentJavaClass, encapsulatedComponentJavaClass)
-			} else {
-				addAssemblyContextFieldCorrespondence(assemblyContext, foundField)
-			}
+	 update {
+		val foundField = compositeComponentJavaClass.members.filter(Field).findFirst[name == assemblyContext.entityName]
+		if (foundField === null) {
+			createAssemblyContextField(assemblyContext, compositeComponentJavaClass, encapsulatedComponentJavaClass)
+		} else {
+			addAssemblyContextFieldCorrespondence(assemblyContext, foundField)
 		}
 	 }
 }
 
 routine createAssemblyContextField(pcm::AssemblyContext assemblyContext, java::Class compositeComponentJavaClass, java::Class encapsulatedComponentJavaClass) {
-	action {
-		val assemblyContextField = create java::Field and initialize {
-			createPrivateField(assemblyContextField, createNamespaceClassifierReference(encapsulatedComponentJavaClass), assemblyContext.entityName)
-			compositeComponentJavaClass.members += assemblyContextField
-		}
-		add correspondence between assemblyContextField and assemblyContext
+	create {
+		val assemblyContextField = new java::Field
+	}
+	update {
+		createPrivateField(assemblyContextField, createNamespaceClassifierReference(encapsulatedComponentJavaClass), assemblyContext.entityName)
+		compositeComponentJavaClass.members += assemblyContextField
+		addCorrespondenceBetween(assemblyContextField, assemblyContext)
 	}
 }
 
 routine addAssemblyContextFieldCorrespondence(pcm::AssemblyContext assemblyContext, java::Field javaField) {
-	action {
-		add correspondence between javaField and assemblyContext
+	update {
+		addCorrespondenceBetween(javaField, assemblyContext)
 	}
 }
 
@@ -247,18 +236,16 @@ routine createOrFindAssemblyContextConstructor(pcm::AssemblyContext assemblyCont
 		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
 		require absence of java::Constructor corresponding to assemblyContext
 	}
-	action {
-		call {
-			val foundConstructor = compositeComponentJavaClass.members.filter(Constructor).findFirst[name == compositeComponentJavaClass.name]
-			if (foundConstructor === null) {
-				createAssemblyContextConstructor(assemblyContext, compositeComponentJavaClass)
-			} else {
-				val foundCall = foundConstructor.statements.filter(ExpressionStatement).map[expression].filter(AssignmentExpression).map[value].filter(NewConstructorCall).head
-				if (foundCall === null) {
-					createAssemblyContextStatement(assemblyContext, foundConstructor, compositeComponentJavaClass)
-				} else{
-					addAssemblyContextConstructorCorrespondence(assemblyContext, foundConstructor, foundCall)
-				}
+	update {
+		val foundConstructor = compositeComponentJavaClass.members.filter(Constructor).findFirst[name == compositeComponentJavaClass.name]
+		if (foundConstructor === null) {
+			createAssemblyContextConstructor(assemblyContext, compositeComponentJavaClass)
+		} else {
+			val foundCall = foundConstructor.statements.filter(ExpressionStatement).map[expression].filter(AssignmentExpression).map[value].filter(NewConstructorCall).head
+			if (foundCall === null) {
+				createAssemblyContextStatement(assemblyContext, foundConstructor, compositeComponentJavaClass)
+			} else{
+				addAssemblyContextConstructorCorrespondence(assemblyContext, foundConstructor, foundCall)
 			}
 		}
 	}
@@ -268,12 +255,12 @@ routine createAssemblyContextConstructor(pcm::AssemblyContext assemblyContext, j
 	match {
 		val assemblyContextField = retrieve java::Field corresponding to assemblyContext
 	}
-	action {
-		val constructor = create java::Constructor
-		call {
-			createAssemblyContextStatement(assemblyContext, constructor, compositeComponentJavaClass)
-			addConstructorToClass(constructor, compositeComponentJavaClass)
-		}
+	create {
+		val constructor = new java::Constructor
+	}
+	update {
+		createAssemblyContextStatement(assemblyContext, constructor, compositeComponentJavaClass)
+		addConstructorToClass(constructor, compositeComponentJavaClass)
 	}
 }
 
@@ -281,20 +268,20 @@ routine createAssemblyContextStatement(pcm::AssemblyContext assemblyContext, jav
 	match {
 		val assemblyContextField = retrieve java::Field corresponding to assemblyContext
 	}
-	action {
-		val newConstructorCall = create java::NewConstructorCall
-		update constructor {
-			createNewForFieldInConstructor(newConstructorCall, constructor, assemblyContextField)
-		}
-		add correspondence between newConstructorCall and assemblyContext
-		add correspondence between constructor and assemblyContext
+	create {
+		val newConstructorCall = new java::NewConstructorCall
+	}
+	update {
+		createNewForFieldInConstructor(newConstructorCall, constructor, assemblyContextField)
+		addCorrespondenceBetween(newConstructorCall, assemblyContext)
+		addCorrespondenceBetween(constructor, assemblyContext)
 	}
 }
 
 routine addAssemblyContextConstructorCorrespondence(pcm::AssemblyContext assemblyContext, java::Constructor constructor, java::NewConstructorCall constructorCall) {
-	action {
-		add correspondence between constructorCall and assemblyContext
-		add correspondence between constructor and assemblyContext
+	update {
+		addCorrespondenceBetween(constructorCall, assemblyContext)
+		addCorrespondenceBetween(constructor, assemblyContext)
 	}
 }
 
@@ -304,31 +291,30 @@ routine createOrFindAssemblyContextImport(pcm::AssemblyContext assemblyContext, 
 		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
 		require absence of java::ClassifierImport corresponding to assemblyContext
 	}
-	action {
-		call {
-			val foundImport = compositeComponentJavaClass.containingCompilationUnit.imports.filter(ClassifierImport).findFirst[it.classifier == encapsulatedComponentJavaClass]
-			if(foundImport === null) {
-				createAssemblyContextImport(assemblyContext, compositeComponentJavaClass, encapsulatedComponentJavaClass)
-			} else {
-				addAssemblyContextImportCorrespondence(assemblyContext, foundImport)
-			}
+	update {
+		val foundImport = compositeComponentJavaClass.containingCompilationUnit.imports.filter(ClassifierImport).findFirst[it.classifier == encapsulatedComponentJavaClass]
+		if(foundImport === null) {
+			createAssemblyContextImport(assemblyContext, compositeComponentJavaClass, encapsulatedComponentJavaClass)
+		} else {
+			addAssemblyContextImportCorrespondence(assemblyContext, foundImport)
 		}
 	}
 }
 
 routine createAssemblyContextImport(pcm::AssemblyContext assemblyContext, java::Class compositeComponentJavaClass, java::Class encapsulatedComponentJavaClass) {
-	action {
-		val contextClassImport = create java::ClassifierImport and initialize {
-			addImportToCompilationUnitOfClassifier(contextClassImport, compositeComponentJavaClass, encapsulatedComponentJavaClass)
-		}
-		add correspondence between contextClassImport and assemblyContext
+	create {
+		val contextClassImport = new java::ClassifierImport
+	}
+	update {
+		addImportToCompilationUnitOfClassifier(contextClassImport, compositeComponentJavaClass, encapsulatedComponentJavaClass)
+		addCorrespondenceBetween(contextClassImport, assemblyContext)
 	}
 }
 
 
 routine addAssemblyContextImportCorrespondence(pcm::AssemblyContext assemblyContext, java::ClassifierImport contextClassImport) {
-	action {
-		add correspondence between contextClassImport and assemblyContext
+	update {
+		addCorrespondenceBetween(contextClassImport, assemblyContext)
 	}
 }
 
@@ -345,11 +331,9 @@ routine createComponentImplementation(pcm::RepositoryComponent component) {
 		val repositoryPackage = retrieve java::Package corresponding to component.repository__RepositoryComponent
 			tagged with "repository_root"
 	}
-	action {
-		call {
-			createOrFindJavaPackage(component, repositoryPackage, component.entityName, null);
-			createImplementationForComponent(component);
-		}
+	update {
+		createOrFindJavaPackage(component, repositoryPackage, component.entityName, null);
+		createImplementationForComponent(component);
 	}
 }
 
@@ -357,8 +341,8 @@ routine createImplementationForComponent(pcm::RepositoryComponent component) {
 	match {
 		val componentPackage = retrieve java::Package corresponding to component
 	}
-	action {
-		call createOrFindJavaClass(component, componentPackage, component.entityName + "Impl")
+	update {
+		createOrFindJavaClass(component, componentPackage, component.entityName + "Impl")
 	}
 }
 
@@ -375,11 +359,9 @@ routine renameComponentPackageAndClass(pcm::RepositoryComponent component) {
 		val repositoryPackage = retrieve java::Package corresponding to component.repository__RepositoryComponent
 			with repositoryPackage.name == component.repository__RepositoryComponent.entityName
 	}
-	action {
-		call {
-			renameJavaPackage(component, repositoryPackage, component.entityName, null);
-			renameComponentClass(component);
-		}
+	update {
+		renameJavaPackage(component, repositoryPackage, component.entityName, null);
+		renameComponentClass(component);
 	}
 }
 
@@ -387,8 +369,8 @@ routine renameComponentClass(pcm::RepositoryComponent component) {
 	match {
 		val componentPackage = retrieve java::Package corresponding to component
 	}
-	action {
-		call renameJavaClassifier(component, componentPackage, component.entityName + "Impl")
+	update {
+		renameJavaClassifier(component, componentPackage, component.entityName + "Impl")
 	}
 }
 
@@ -418,8 +400,8 @@ routine renameInterface(pcm::OperationInterface interf) {
 		val contractsPackage = retrieve java::Package corresponding to interf.repository__Interface
 			with contractsPackage.name == "contracts"
 	}
-	action {
-		call renameJavaClassifier(interf, contractsPackage, interf.entityName)
+	update {
+		renameJavaClassifier(interf, contractsPackage, interf.entityName)
 	}
 }
 
@@ -436,19 +418,17 @@ routine createCompositeDataTypeImplementation(pcm::CompositeDataType compositeDa
 		val datatypesPackage = retrieve java::Package corresponding to compositeDataType.repository__DataType
 			with datatypesPackage.name == "datatypes"
 	}
-	action {
-		call createOrFindDataTypeClass(compositeDataType, datatypesPackage)
+	update {
+		createOrFindDataTypeClass(compositeDataType, datatypesPackage)
 	}
 }
 
 routine createOrFindDataTypeClass(pcm::NamedElement dataType, java::Package datatypesPackage) {
-	action {
-		call {
-			if (dataType.entityName == "aName") {
-				createOrFindJavaClass(dataType, datatypesPackage, null)
-			} else {
-				createOrFindJavaClass(dataType, datatypesPackage, dataType.entityName)
-			}
+	update {
+		if (dataType.entityName == "aName") {
+			createOrFindJavaClass(dataType, datatypesPackage, null)
+		} else {
+			createOrFindJavaClass(dataType, datatypesPackage, dataType.entityName)
 		}
 	}
 }
@@ -462,8 +442,8 @@ routine renameCompositeDataType(pcm::CompositeDataType compositeDataType) {
 	match {
 		val datatypesPackage = retrieve java::Package corresponding to compositeDataType.repository__DataType with datatypesPackage.name == "datatypes"
 	}
-	action {
-		call renameJavaClassifier(compositeDataType, datatypesPackage, compositeDataType.entityName)
+	update {
+		renameJavaClassifier(compositeDataType, datatypesPackage, compositeDataType.entityName)
 	}
 }
 
@@ -482,30 +462,28 @@ routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType)
 		val innerTypeClass = retrieve optional java::Class corresponding to dataType.innerType_CollectionDataType
 		val datatypesPackage = retrieve java::Package corresponding to dataType.repository__DataType with datatypesPackage.name == "datatypes"
 	}
-	action {
-		call {
-			// create correct (and in case of primitive types wrapped) type reference for the inner type
-			val innerTypeRef = createTypeReference(dataType.innerType_CollectionDataType, innerTypeClass);
-			var innerTypeClassOrWrapper = innerTypeRef;
-			if (innerTypeRef instanceof PrimitiveType) {
-				innerTypeClassOrWrapper = getWrapperTypeReferenceForPrimitiveType(innerTypeRef);
-			}
-
-			// Let user select the class to map the collection type to
-			var Set<Class<?>> collectionDataTypes = new HashSet;
-			collectionDataTypes += #[ArrayList, LinkedList, Vector, Stack, HashSet];
-			val List<String> collectionDataTypeNames = new ArrayList<String>(collectionDataTypes.size);
-			for (collectionDataType : collectionDataTypes) {
-				collectionDataTypeNames += collectionDataType.name;
-			}
-			val String selectTypeMsg = "Please select type (or interface) that should be used for the type";
-			val int selectedType = userInteractor.singleSelectionDialogBuilder.message(selectTypeMsg)
-				.choices(collectionDataTypeNames).windowModality(WindowModality.MODAL).startInteraction();
-			val Class<?> selectedClass = collectionDataTypes.get(selectedType);
-
-			createOrFindDataTypeClass(dataType, datatypesPackage)
-			addSuperTypeToDataType(dataType, innerTypeClassOrWrapper, selectedClass.name);
+	update {
+		// create correct (and in case of primitive types wrapped) type reference for the inner type
+		val innerTypeRef = createTypeReference(dataType.innerType_CollectionDataType, innerTypeClass);
+		var innerTypeClassOrWrapper = innerTypeRef;
+		if (innerTypeRef instanceof PrimitiveType) {
+			innerTypeClassOrWrapper = getWrapperTypeReferenceForPrimitiveType(innerTypeRef);
 		}
+
+		// Let user select the class to map the collection type to
+		var Set<Class<?>> collectionDataTypes = new HashSet;
+		collectionDataTypes += #[ArrayList, LinkedList, Vector, Stack, HashSet];
+		val List<String> collectionDataTypeNames = new ArrayList<String>(collectionDataTypes.size);
+		for (collectionDataType : collectionDataTypes) {
+			collectionDataTypeNames += collectionDataType.name;
+		}
+		val String selectTypeMsg = "Please select type (or interface) that should be used for the type";
+		val int selectedType = userInteractor.singleSelectionDialogBuilder.message(selectTypeMsg)
+			.choices(collectionDataTypeNames).windowModality(WindowModality.MODAL).startInteraction();
+		val Class<?> selectedClass = collectionDataTypes.get(selectedType);
+
+		createOrFindDataTypeClass(dataType, datatypesPackage)
+		addSuperTypeToDataType(dataType, innerTypeClassOrWrapper, selectedClass.name);
 	}
 }
 
@@ -513,21 +491,18 @@ routine addSuperTypeToDataType(pcm::DataType dataType, java::TypeReference inner
 	match {
 		val dataTypeImplementation = retrieve java::Class corresponding to dataType
 	}
-	action {
-		update dataTypeImplementation.containingCompilationUnit {
-			val collectionTypeClassImport = createJavaClassImport(superTypeQualifiedName);
-			dataTypeImplementation.containingCompilationUnit.imports += collectionTypeClassImport;
-		}
-		val namespaceClassifier = create java::NamespaceClassifierReference and initialize {
-			createNamespaceClassifierReference(namespaceClassifier, dataTypeImplementation.containingCompilationUnit.imports.filter(ClassifierImport).last.classifier);
-			val qualifiedTypeArgument = GenericsFactory.eINSTANCE.createQualifiedTypeArgument();
-			qualifiedTypeArgument.typeReference = innerTypeReference;
-			namespaceClassifier.classifierReferences.get(0).typeArguments += qualifiedTypeArgument;
-		}
-		add correspondence between namespaceClassifier and dataType
-		update dataTypeImplementation {
-			dataTypeImplementation.extends = namespaceClassifier;
-		}
+	create {
+		val namespaceClassifier = new java::NamespaceClassifierReference
+	}
+	update {
+		val collectionTypeClassImport = createJavaClassImport(superTypeQualifiedName);
+		dataTypeImplementation.containingCompilationUnit.imports += collectionTypeClassImport;
+		createNamespaceClassifierReference(namespaceClassifier, dataTypeImplementation.containingCompilationUnit.imports.filter(ClassifierImport).last.classifier);
+		val qualifiedTypeArgument = GenericsFactory.eINSTANCE.createQualifiedTypeArgument();
+		qualifiedTypeArgument.typeReference = innerTypeReference;
+		namespaceClassifier.classifierReferences.get(0).typeArguments += qualifiedTypeArgument;
+		addCorrespondenceBetween(namespaceClassifier, dataType)
+		dataTypeImplementation.extends = namespaceClassifier;
 	}
 }
 
@@ -540,8 +515,8 @@ routine renameCollectionDataType(pcm::CollectionDataType collectionDataType) {
 	match {
 		val datatypesPackage = retrieve java::Package corresponding to collectionDataType.repository__DataType with datatypesPackage.name == "datatypes"
 	}
-	action {
-		call renameJavaClassifier(collectionDataType, datatypesPackage, collectionDataType.entityName)
+	update {
+		renameJavaClassifier(collectionDataType, datatypesPackage, collectionDataType.entityName)
 	}
 }
 
@@ -561,11 +536,9 @@ routine createInnerDeclarationImplementation(pcm::InnerDeclaration innerDeclarat
 	match {
 		val nonPrimitiveInnerDataTypeClass = retrieve optional java::Class corresponding to innerDeclaration.datatype_InnerDeclaration
 	}
-	action {
-		call {
-			val innerDataTypeReference = createTypeReference(innerDeclaration.datatype_InnerDeclaration, nonPrimitiveInnerDataTypeClass);
-			addInnerDeclarationToCompositeDataType(innerDeclaration.compositeDataType_InnerDeclaration, innerDeclaration, innerDataTypeReference);
-		}
+	update {
+		val innerDataTypeReference = createTypeReference(innerDeclaration.datatype_InnerDeclaration, nonPrimitiveInnerDataTypeClass);
+		addInnerDeclarationToCompositeDataType(innerDeclaration.compositeDataType_InnerDeclaration, innerDeclaration, innerDataTypeReference);
 	}
 }
 
@@ -573,25 +546,22 @@ routine addInnerDeclarationToCompositeDataType(pcm::CompositeDataType dataType, 
 	match {
 		val dataTypeClass = retrieve java::Class corresponding to dataType
 	}
-	action {
-		val innerDataTypeField = create java::Field and initialize {
-			createPrivateField(innerDataTypeField, EcoreUtil.copy(dataTypeReference), innerDeclaration.entityName);
-		}
-		add correspondence between innerDataTypeField and innerDeclaration
-		val getterMethod = create java::ClassMethod and initialize {
-			createGetter(innerDataTypeField, getterMethod);
-		}
-		add correspondence between getterMethod and innerDeclaration tagged with "getter"
-		val setterMethod = create java::ClassMethod and initialize {
-			createSetter(innerDataTypeField, setterMethod);
-		}
-		add correspondence between setterMethod and innerDeclaration tagged with "setter"
-		update dataTypeClass {
-			dataTypeClass.members += innerDataTypeField;
-			dataTypeClass.members += getterMethod;
-			dataTypeClass.members += setterMethod;
-			sortMembers(dataTypeClass.members);
-		}
+	create {
+		val innerDataTypeField = new java::Field
+		val getterMethod = new java::ClassMethod
+		val setterMethod = new java::ClassMethod
+	}
+	update {
+		createPrivateField(innerDataTypeField, EcoreUtil.copy(dataTypeReference), innerDeclaration.entityName);
+		addCorrespondenceBetween(innerDataTypeField, innerDeclaration)
+		createGetter(innerDataTypeField, getterMethod);
+		addCorrespondenceBetween(getterMethod, innerDeclaration, "getter")
+		createSetter(innerDataTypeField, setterMethod);
+		addCorrespondenceBetween(setterMethod, innerDeclaration, "setter")
+		dataTypeClass.members += innerDataTypeField;
+		dataTypeClass.members += getterMethod;
+		dataTypeClass.members += setterMethod;
+		sortMembers(dataTypeClass.members);
 	}
 }
 
@@ -606,18 +576,12 @@ routine renameInnerDeclarationImplementation(pcm::InnerDeclaration innerDeclarat
 		val compositeTypeGetterMethod = retrieve java::ClassMethod corresponding to innerDeclaration tagged with "getter"
 		val compositeTypeSetterMethod = retrieve java::ClassMethod corresponding to innerDeclaration tagged with "setter"
 	}
-	action {
-		update compositeTypeField {
-			compositeTypeField.name = innerDeclaration.entityName;
-		}
-		update compositeTypeGetterMethod {
-			compositeTypeGetterMethod.name = "get" + innerDeclaration.entityName.toFirstUpper;
-		}
-		update compositeTypeSetterMethod {
-			if (!compositeTypeSetterMethod.parameters.nullOrEmpty) {
-				val parameter = compositeTypeSetterMethod.parameters.get(0);
-				parameter.name = "set" + innerDeclaration.entityName.toFirstUpper;
-			}
+	update {
+		compositeTypeField.name = innerDeclaration.entityName;
+		compositeTypeGetterMethod.name = "get" + innerDeclaration.entityName.toFirstUpper;
+		if (!compositeTypeSetterMethod.parameters.nullOrEmpty) {
+			val parameter = compositeTypeSetterMethod.parameters.get(0);
+			parameter.name = "set" + innerDeclaration.entityName.toFirstUpper;
 		}
 	}
 }
@@ -631,11 +595,9 @@ routine changeTypeOfInnerDeclarationImplementation(pcm::InnerDeclaration innerDe
 	match {
 		val newJavaDataType = retrieve optional java::Class corresponding to innerDeclaration.datatype_InnerDeclaration
 	}
-	action {
-		call {
-			val newDataTypeReference = createTypeReference(innerDeclaration.datatype_InnerDeclaration, newJavaDataType);
-			changeInnerDeclarationType(innerDeclaration, newDataTypeReference);
-		}
+	update {
+		val newDataTypeReference = createTypeReference(innerDeclaration.datatype_InnerDeclaration, newJavaDataType);
+		changeInnerDeclarationType(innerDeclaration, newDataTypeReference);
 	}
 }
 
@@ -645,18 +607,12 @@ routine changeInnerDeclarationType(pcm::InnerDeclaration innerDeclaration, java:
 		val compositeTypeGetterMethod = retrieve java::Method corresponding to innerDeclaration tagged with "getter"
 		val compositeTypeSetterMethod = retrieve java::Method corresponding to innerDeclaration tagged with "setter"
 	}
-	action {
-		update compositeTypeField {
-			compositeTypeField.typeReference = EcoreUtil.copy(newTypeReference);
-		}
-		update compositeTypeGetterMethod {
-			compositeTypeGetterMethod.typeReference = EcoreUtil.copy(newTypeReference);
-		}
-		update compositeTypeSetterMethod {
-			if (!compositeTypeSetterMethod.parameters.nullOrEmpty) {
-				val parameter = compositeTypeSetterMethod.parameters.get(0);
-				parameter.typeReference = EcoreUtil.copy(newTypeReference);
-			}
+	update {
+		compositeTypeField.typeReference = EcoreUtil.copy(newTypeReference);
+		compositeTypeGetterMethod.typeReference = EcoreUtil.copy(newTypeReference);
+		if (!compositeTypeSetterMethod.parameters.nullOrEmpty) {
+			val parameter = compositeTypeSetterMethod.parameters.get(0);
+			parameter.typeReference = EcoreUtil.copy(newTypeReference);
 		}
 	}
 }
@@ -671,21 +627,18 @@ routine createOrFindJavaPackage(EObject sourceElementMappedToPackage, java::Pack
 		with matchingPackages.name.toLowerCase == packageName.toLowerCase && (parentPackage === null ||
 			matchingPackages.namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + ".")
 	}
-	action {
-		call {
-			if(matchingPackages.empty) {
-				createJavaPackage(sourceElementMappedToPackage, parentPackage, packageName, newTag)
-			} else {
-				addPackageCorrespondence(sourceElementMappedToPackage, matchingPackages.head, newTag)
-			}
+	update {
+		if(matchingPackages.empty) {
+			createJavaPackage(sourceElementMappedToPackage, parentPackage, packageName, newTag)
+		} else {
+			addPackageCorrespondence(sourceElementMappedToPackage, matchingPackages.head, newTag)
 		}
 	}
 }
 
 routine addPackageCorrespondence(EObject sourceElementMappedToPackage, java::Package javaPackage, String newTag) {
-	action {
-		add correspondence between javaPackage and sourceElementMappedToPackage
-			tagged with newTag
+	update {
+		addCorrespondenceBetween(javaPackage, sourceElementMappedToPackage, newTag)
 	}
 }
 
@@ -693,19 +646,20 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
 	}
-	action {
-		val javaPackage = create java::Package and initialize {
-			if (parentPackage !== null) {
-				val newNamespaces = new ArrayList(parentPackage.namespaces)
-				newNamespaces += parentPackage.name
-				javaPackage.namespaces += newNamespaces;
-			}
-			javaPackage.name = packageName.toFirstLower;
-			persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage));
+	create {
+		val javaPackage = new java::Package
+	}
+	update {
+		if (parentPackage !== null) {
+			val newNamespaces = new ArrayList(parentPackage.namespaces)
+			newNamespaces += parentPackage.name
+			javaPackage.namespaces += newNamespaces;
 		}
-		add correspondence between javaPackage and sourceElementMappedToPackage tagged with newTag
+		javaPackage.name = packageName.toFirstLower;
+		persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage));
+		addCorrespondenceBetween(javaPackage, sourceElementMappedToPackage, newTag)
 		// Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
-		add correspondence between javaPackage and ContainersPackage.Literals.PACKAGE
+		addCorrespondenceBetween(javaPackage, ContainersPackage.Literals.PACKAGE)
 	}
 }
 
@@ -714,18 +668,16 @@ routine renameJavaPackage(pcm::NamedElement sourceElementMappedToPackage, java::
 		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage
 			tagged with expectedTag	//move containing model to project-relative location: buildJavaFilePath(javaPackage)
 	}
-	action {
-		update javaPackage {
-			val newNamespaces = newArrayList 
-			if (parentPackage !== null) {
-				newNamespaces += parentPackage.namespaces
-				newNamespaces += parentPackage.name
-			}
-			var modified = javaPackage.updateNamespaces(newNamespaces)
-			modified = javaPackage.updateName(packageName) || modified
-			if (modified) {
-				persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage))
-			}
+	update {
+		val newNamespaces = newArrayList 
+		if (parentPackage !== null) {
+			newNamespaces += parentPackage.namespaces
+			newNamespaces += parentPackage.name
+		}
+		var modified = javaPackage.updateNamespaces(newNamespaces)
+		modified = javaPackage.updateName(packageName) || modified
+		if (modified) {
+			persistProjectRelative(sourceElementMappedToPackage, javaPackage, buildJavaFilePath(javaPackage))
 		}
 	}
 }
@@ -734,8 +686,9 @@ routine deleteJavaPackage(pcm::NamedElement sourceElementMappedToPackage, String
 	match {
 		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage tagged with expectedTag
 	}
-	action {
-		delete javaPackage
+	update {
+		deleteObject(javaPackage)
+		removeCorrespondenceBetween(sourceElementMappedToPackage, javaPackage)
 	}
 }
 
@@ -747,26 +700,25 @@ routine createOrFindJavaClass(pcm::NamedElement pcmElement, java::Package contai
 	match {
 		require absence of java::Class corresponding to pcmElement
 	}
-	action {
-		call {
-			val foundClass = findClassifier(className, containingPackage, org.emftext.language.java.classifiers.Class)
-			if(foundClass === null) {
-				createJavaClass(pcmElement, containingPackage, className)
-			} else {
-				addMissingClassifierCorrespondence(pcmElement, foundClass)
-			}
+	update {
+		val foundClass = findClassifier(className, containingPackage, org.emftext.language.java.classifiers.Class)
+		if(foundClass === null) {
+			createJavaClass(pcmElement, containingPackage, className)
+		} else {
+			addMissingClassifierCorrespondence(pcmElement, foundClass)
 		}
 	}
 }
 
 routine createJavaClass(pcm::NamedElement sourceElementMappedToClass, java::Package containingPackage, String className) {
-	action {
-		val javaClass = create java::Class and initialize {
-			javaClass.name = className.toFirstUpper
-			javaClass.addModifier(ModifiersFactory.eINSTANCE.createPublic())
-		}
-		add correspondence between javaClass and sourceElementMappedToClass
-		call createCompilationUnit(sourceElementMappedToClass, javaClass, containingPackage)
+	create {
+		val javaClass = new java::Class
+	}
+	update {
+		javaClass.name = className.toFirstUpper
+		javaClass.addModifier(ModifiersFactory.eINSTANCE.createPublic())
+		addCorrespondenceBetween(javaClass, sourceElementMappedToClass)
+		createCompilationUnit(sourceElementMappedToClass, javaClass, containingPackage)
 	}
 }
 
@@ -775,46 +727,46 @@ routine createOrFindJavaInterface(pcm::Interface pcmInterface) {
 		val contractsPackage = retrieve java::Package corresponding to pcmInterface.repository__Interface tagged with "contracts"
 		require absence of java::Interface corresponding to pcmInterface
 	}
-	action {
-		call {
-			val foundInterface = findClassifier(pcmInterface.entityName, contractsPackage, Interface)
-			if(foundInterface === null) {
-				createJavaInterface(pcmInterface, contractsPackage)
-			} else {
-				addMissingClassifierCorrespondence(pcmInterface, foundInterface)
-			}
+	update {
+		val foundInterface = findClassifier(pcmInterface.entityName, contractsPackage, Interface)
+		if(foundInterface === null) {
+			createJavaInterface(pcmInterface, contractsPackage)
+		} else {
+			addMissingClassifierCorrespondence(pcmInterface, foundInterface)
 		}
 	}
 }
 
 routine createJavaInterface(pcm::Interface pcmInterface, java::Package containingPackage) {
-	action {
-		val javaInterface = create java::Interface and initialize {
-			javaInterface.name = pcmInterface.entityName.toFirstUpper;
-			javaInterface.addModifier(ModifiersFactory.eINSTANCE.createPublic());
-		}
-		add correspondence between javaInterface and pcmInterface
-		call createCompilationUnit(pcmInterface, javaInterface, containingPackage)
+	create {
+		val javaInterface = new java::Interface
+	}
+	update {
+		javaInterface.name = pcmInterface.entityName.toFirstUpper;
+		javaInterface.addModifier(ModifiersFactory.eINSTANCE.createPublic());
+		addCorrespondenceBetween(javaInterface, pcmInterface)
+		createCompilationUnit(pcmInterface, javaInterface, containingPackage)
 	}
 }
 
 routine addMissingClassifierCorrespondence(pcm::NamedElement pcmElement, java::ConcreteClassifier javaClassifier) {
-	action {
-		add correspondence between javaClassifier and pcmElement
+	update {
+		addCorrespondenceBetween(javaClassifier, pcmElement)
 	}
 }
 
 routine createCompilationUnit(pcm::NamedElement sourceElementMappedToClass, java::ConcreteClassifier classifier, java::Package containingPackage) {
-	action {
-		val compilationUnit = create java::CompilationUnit and initialize {
-			val newNamespaces = new ArrayList(containingPackage.namespaces)
-			newNamespaces += containingPackage.name
-			compilationUnit.namespaces += newNamespaces
-			compilationUnit.name = containingPackage.namespacesAsString + containingPackage.name + "." + classifier.name.toFirstUpper + ".java"
-			compilationUnit.classifiers += classifier;
-			persistProjectRelative(sourceElementMappedToClass, compilationUnit, buildJavaFilePath(compilationUnit));
-		}
-		call containingPackage.compilationUnits += compilationUnit
+	create {
+		val compilationUnit = new java::CompilationUnit
+	}
+	update {
+		val newNamespaces = new ArrayList(containingPackage.namespaces)
+		newNamespaces += containingPackage.name
+		compilationUnit.namespaces += newNamespaces
+		compilationUnit.name = containingPackage.namespacesAsString + containingPackage.name + "." + classifier.name.toFirstUpper + ".java"
+		compilationUnit.classifiers += classifier;
+		persistProjectRelative(sourceElementMappedToClass, compilationUnit, buildJavaFilePath(compilationUnit));
+		containingPackage.compilationUnits += compilationUnit
 	}
 }
 
@@ -823,20 +775,16 @@ routine renameJavaClassifier(pcm::NamedElement classSourceElement, java::Package
 		// move containing model to project-relative location: buildJavaFilePath(compilationUnit)
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to classSourceElement
 	}
-	action {
-		update javaClassifier {
-			javaClassifier.updateName(className.toFirstUpper)
-		}
-		update javaClassifier.containingCompilationUnit {
-		    val compilationUnit = javaClassifier.containingCompilationUnit
-			val newNamespaces = new ArrayList(containingPackage.namespaces)
-			newNamespaces += containingPackage.name
-			var modified = compilationUnit.updateNamespaces(newNamespaces)
-			val newName = getCompilationUnitName(containingPackage, className.toFirstUpper)
-			modified = compilationUnit.updateName(newName) || modified
-			if (modified) {
-				persistProjectRelative(classSourceElement, compilationUnit, buildJavaFilePath(compilationUnit))
-			}
+	update {
+		javaClassifier.updateName(className.toFirstUpper)
+	    val compilationUnit = javaClassifier.containingCompilationUnit
+		val newNamespaces = new ArrayList(containingPackage.namespaces)
+		newNamespaces += containingPackage.name
+		var modified = compilationUnit.updateNamespaces(newNamespaces)
+		val newName = getCompilationUnitName(containingPackage, className.toFirstUpper)
+		modified = compilationUnit.updateName(newName) || modified
+		if (modified) {
+			persistProjectRelative(classSourceElement, compilationUnit, buildJavaFilePath(compilationUnit))
 		}
 	}
 }
@@ -845,8 +793,9 @@ routine deleteJavaClassifier(pcm::NamedElement sourceElement) {
 	match {
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to sourceElement
 	}
-	action {
-		delete javaClassifier.containingCompilationUnit
+	update {
+		deleteObject(javaClassifier.containingCompilationUnit)
+		removeCorrespondenceBetween(sourceElement, javaClassifier.containingCompilationUnit)
 	}
 }
 
@@ -864,15 +813,13 @@ routine findOrAddProvidedRole(pcm::OperationProvidedRole providedRole) {
 		val javaClass = retrieve java::Class corresponding to providedRole.providingEntity_ProvidedRole
 		require absence of java::NamespaceClassifierReference corresponding to providedRole
 	}
-	action {
-		execute {
-			val matchingReference = javaClass.implements.filter[target == operationProvidingInterface]
-			checkState(matchingReference.size <= 1, "There is more than one implementation of interface %s in Java class %s", operationProvidingInterface, javaClass)
-			if(matchingReference.size == 1) {
-				addProvidedRoleCorrespondence(providedRole, matchingReference.get(0))
-			} else {
-				addProvidedRole(providedRole)
-			}
+	update {
+		val matchingReference = javaClass.implements.filter[target == operationProvidingInterface]
+		checkState(matchingReference.size <= 1, "There is more than one implementation of interface %s in Java class %s", operationProvidingInterface, javaClass)
+		if(matchingReference.size == 1) {
+			addProvidedRoleCorrespondence(providedRole, matchingReference.get(0))
+		} else {
+			addProvidedRole(providedRole)
 		}
 	}
 }
@@ -881,8 +828,8 @@ routine addProvidedRoleCorrespondence(pcm::OperationProvidedRole providedRole, j
 	match {
 		require absence of java::TypeReference corresponding to providedRole
 	}
-	action {
-		add correspondence between reference and providedRole
+	update {
+		addCorrespondenceBetween(reference, providedRole)
 	}
 }
 
@@ -892,14 +839,13 @@ routine addProvidedRole(pcm::OperationProvidedRole providedRole) {
 		val javaClass = retrieve java::Class corresponding to providedRole.providingEntity_ProvidedRole
 		require absence of java::NamespaceClassifierReference corresponding to providedRole
 	}
-	action { 
-		val namespaceClassifierReference = create java::NamespaceClassifierReference and initialize {
-			createNamespaceClassifierReference(namespaceClassifierReference, operationProvidingInterface)
-		}
-		add correspondence between namespaceClassifierReference and providedRole
-		update javaClass {
-			javaClass.implements += namespaceClassifierReference
-		}
+	create {
+		val namespaceClassifierReference = new java::NamespaceClassifierReference
+	}
+	update { 
+		createNamespaceClassifierReference(namespaceClassifierReference, operationProvidingInterface)
+		addCorrespondenceBetween(namespaceClassifierReference, providedRole)
+		javaClass.implements += namespaceClassifierReference
 	}
 }
 
@@ -935,9 +881,11 @@ routine removeProvidedRole(pcm::ProvidedRole providedRole) {
 	match {
 		val typeReference = retrieve java::TypeReference corresponding to providedRole
 	}
-	action {
-		delete typeReference.getPureClassifierReference // seems to be necessary to properly delete reference if it is a NamespaceClassifierReference
-		delete typeReference
+	update {
+		deleteObject(typeReference.pureClassifierReference) // seems to be necessary to properly delete reference if it is a NamespaceClassifierReference
+		removeCorrespondenceBetween(typeReference.pureClassifierReference, providedRole)
+		deleteObject(typeReference)
+		removeCorrespondenceBetween(typeReference, providedRole)
 	}
 }
 
@@ -958,31 +906,25 @@ routine addRequiredRole(pcm::OperationRequiredRole requiredRole) {
 		val requiredInterface = retrieve java::Interface corresponding to requiredRole.requiredInterface__OperationRequiredRole
 		val javaClass = retrieve java::Class corresponding to requiredRole.requiringEntity_RequiredRole
 	}
-	action {
-		add correspondence between javaClass and requiredRole
+	create {
+		val requiredInterfaceImport = new java::ClassifierImport
+		val requiredInterfaceField = new java::Field
+	}
+	update {
+		addCorrespondenceBetween(javaClass, requiredRole)
 		// TODO HK this should be partly in the context of the compilation unit
-		val requiredInterfaceImport = create java::ClassifierImport and initialize {
-			addImportToCompilationUnitOfClassifier(requiredInterfaceImport, javaClass, requiredInterface);
+		addImportToCompilationUnitOfClassifier(requiredInterfaceImport, javaClass, requiredInterface);
+		addCorrespondenceBetween(requiredInterfaceImport, requiredRole)
+		val typeRef = createNamespaceClassifierReference(requiredInterface);
+		val requiredRoleName = requiredRole.entityName;
+		createPrivateField(requiredInterfaceField, EcoreUtil.copy(typeRef), requiredRoleName);
+		addCorrespondenceBetween(requiredInterfaceField, requiredRole)
+		javaClass.members += requiredInterfaceField;
+		if (javaClass.members.filter(typeof(Constructor)).nullOrEmpty) {
+			addConstructorToClass(javaClass);
 		}
-		add correspondence between requiredInterfaceImport and requiredRole
-		val requiredInterfaceField = create java::Field and initialize {
-			val typeRef = createNamespaceClassifierReference(requiredInterface);
-			val requiredRoleName = requiredRole.entityName;
-			createPrivateField(requiredInterfaceField, EcoreUtil.copy(typeRef), requiredRoleName);
-		}
-		add correspondence between requiredInterfaceField and requiredRole
-		update javaClass {
-			javaClass.members += requiredInterfaceField;
-			if (javaClass.members.filter(typeof(Constructor)).nullOrEmpty) {
-				addConstructorToClass(javaClass);
-			}
-		}
-		call {
-			val typeRef = createNamespaceClassifierReference(requiredInterface);
-			val requiredRoleName = requiredRole.entityName;
-			for (ctor : javaClass.members.filter(typeof(Constructor))) {
-				addParameterAndAssignmentToConstructor(requiredRole, ctor, typeRef, requiredInterfaceField, requiredRoleName);
-			}
+		for (ctor : javaClass.members.filter(typeof(Constructor))) {
+			addParameterAndAssignmentToConstructor(requiredRole, ctor, typeRef, requiredInterfaceField, requiredRoleName);
 		}
 	}
 }
@@ -993,25 +935,22 @@ routine addParameterAndAssignmentToConstructor(pcm::NamedElement parameterCorres
 		val existingParameters = retrieve many java::OrdinaryParameter corresponding to parameterCorrespondenceSource
 		check !existingParameters.exists [name == parameterName] 
 	}	
-	action {
-		val newParameter = create java::OrdinaryParameter and initialize {
-			newParameter.name = parameterName;
-			newParameter.typeReference = EcoreUtil.copy(typeReference);
-		}
-		add correspondence between newParameter and parameterCorrespondenceSource
-		update constructor {
-			constructor.parameters += newParameter;
-			val asssignment = createAssignmentFromParameterToField(fieldToBeAssigned, newParameter);
-			constructor.statements += asssignment;
-		}
+	create {
+		val newParameter = new java::OrdinaryParameter
+	}
+	update {
+		newParameter.name = parameterName;
+		newParameter.typeReference = EcoreUtil.copy(typeReference);
+		addCorrespondenceBetween(newParameter, parameterCorrespondenceSource)
+		constructor.parameters += newParameter;
+		val asssignment = createAssignmentFromParameterToField(fieldToBeAssigned, newParameter);
+		constructor.statements += asssignment;
 	}
 }
 
 reaction DeletedRequiredRole {
 	after element pcm::OperationRequiredRole removed from pcm::InterfaceRequiringEntity[requiredRoles_InterfaceRequiringEntity]
-	call {
-		removeRequiredRole(oldValue);
-	}
+	call removeRequiredRole(oldValue)
 }
 
 routine removeRequiredRole(pcm::RequiredRole requiredRole) {
@@ -1020,36 +959,34 @@ routine removeRequiredRole(pcm::RequiredRole requiredRole) {
 		val requiredInterfaceField = retrieve java::Field corresponding to requiredRole
 		val javaClass = retrieve java::Class corresponding to requiredRole
 	}
-	action {
-		delete requiredInterfaceImport
-		delete requiredInterfaceField
-		remove correspondence between javaClass and requiredRole
-		call {
-			for (ctor : javaClass.members.filter(typeof(Constructor))) {
-				removeParameterToFieldAssignmentFromConstructor(ctor, requiredRole.entityName);
-				removeCorrespondingParameterFromConstructor(ctor, requiredRole);
-			}
+	update {
+		deleteObject(requiredInterfaceImport)
+		removeCorrespondenceBetween(requiredInterfaceImport, requiredRole)
+		deleteObject(requiredInterfaceField)
+		removeCorrespondenceBetween(requiredInterfaceField, requiredRole)
+		removeCorrespondenceBetween(javaClass, requiredRole)
+		for (ctor : javaClass.members.filter(typeof(Constructor))) {
+			removeParameterToFieldAssignmentFromConstructor(ctor, requiredRole.entityName);
+			removeCorrespondingParameterFromConstructor(ctor, requiredRole);
 		}
 	}
 }
 
 routine removeParameterToFieldAssignmentFromConstructor(java::Constructor ctor, String fieldName) {
-	action {
-		update ctor {
-			for (statement : ctor.statements) {
-				if (statement instanceof ExpressionStatement) {
-					val assignmentExpression = statement.expression;
-					if (assignmentExpression instanceof AssignmentExpression) {
-						val selfReference = assignmentExpression.child;
-						if (selfReference instanceof SelfReference) {
-							val fieldReference = selfReference.next;
-							if (fieldReference instanceof IdentifierReference) {
-								val field = fieldReference.target;
-								if (field instanceof Field) {
-									if (field.name == fieldName) {
-										ctor.statements -= statement;
-										return;
-									}
+	update {
+		for (statement : ctor.statements) {
+			if (statement instanceof ExpressionStatement) {
+				val assignmentExpression = statement.expression;
+				if (assignmentExpression instanceof AssignmentExpression) {
+					val selfReference = assignmentExpression.child;
+					if (selfReference instanceof SelfReference) {
+						val fieldReference = selfReference.next;
+						if (fieldReference instanceof IdentifierReference) {
+							val field = fieldReference.target;
+							if (field instanceof Field) {
+								if (field.name == fieldName) {
+									ctor.statements -= statement;
+									return;
 								}
 							}
 						}
@@ -1065,17 +1002,16 @@ routine removeCorrespondingParameterFromConstructor(java::Constructor ctor, pcm:
 		val param = retrieve java::OrdinaryParameter corresponding to correspondenceSource
 			with ctor.parameters.contains(param)
 	}
-	action {
-		delete param
+	update {
+		deleteObject(param)
+		removeCorrespondenceBetween(correspondenceSource, param)
 	}
 }
 
 routine reinitializeOperationRequiredRole(pcm::OperationRequiredRole requiredRole) {
-	action {
-		call {
-			removeRequiredRole(requiredRole);
-			addRequiredRole(requiredRole);
-		}
+	update {
+		removeRequiredRole(requiredRole);
+		addRequiredRole(requiredRole);
 	}
 }
 
@@ -1103,14 +1039,14 @@ routine createMethodForOperationSignature(pcm::OperationSignature operationSigna
 	match {
 		val javaInterface = retrieve java::Interface corresponding to operationSignature.interface__OperationSignature
 	}
-	action {
-		val interfaceMethod = create java::InterfaceMethod
-		add correspondence between interfaceMethod and operationSignature
-		call {
-			interfaceMethod.name = operationSignature.entityName;
-			changeInterfaceMethodReturnType(interfaceMethod, operationSignature.returnType__OperationSignature);
-			javaInterface.members += interfaceMethod;
-		}
+	create {
+		val interfaceMethod = new java::InterfaceMethod
+	}
+	update {
+		addCorrespondenceBetween(interfaceMethod, operationSignature)
+		interfaceMethod.name = operationSignature.entityName;
+		changeInterfaceMethodReturnType(interfaceMethod, operationSignature.returnType__OperationSignature);
+		javaInterface.members += interfaceMethod;
 	}
 }
 
@@ -1123,27 +1059,23 @@ routine renameMethodForOperationSignature(pcm::OperationSignature operationSigna
 	match {
 		val interfaceMethod = retrieve java::InterfaceMethod corresponding to operationSignature
 	}
-	action {
-		update interfaceMethod {
-			interfaceMethod.name = operationSignature.entityName;
-		}
-		call {
-			val operationInterface = operationSignature.interface__OperationSignature;
-			// get implementing components
-			val implementingComponents = Sets.newHashSet;
-			operationInterface.repository__Interface.components__Repository.forEach [ comp |
-				val opProvRoles = comp.providedRoles_InterfaceProvidingEntity.filter(OperationProvidedRole);
-				opProvRoles.filter[it.providedInterface__OperationProvidedRole.id == operationInterface.id].forEach [ opProRole |
-					implementingComponents += opProRole.providingEntity_ProvidedRole;
-				]
+	update {
+		interfaceMethod.name = operationSignature.entityName;
+		val operationInterface = operationSignature.interface__OperationSignature;
+		// get implementing components
+		val implementingComponents = Sets.newHashSet;
+		operationInterface.repository__Interface.components__Repository.forEach [ comp |
+			val opProvRoles = comp.providedRoles_InterfaceProvidingEntity.filter(OperationProvidedRole);
+			opProvRoles.filter[it.providedInterface__OperationProvidedRole.id == operationInterface.id].forEach [ opProRole |
+				implementingComponents += opProRole.providingEntity_ProvidedRole;
 			]
-			val basicComponents = implementingComponents.filter(BasicComponent);
-			basicComponents.forEach[
-				it.serviceEffectSpecifications__BasicComponent.forEach[
-					updateSEFFImplementingMethodName(it);
-				]
+		]
+		val basicComponents = implementingComponents.filter(BasicComponent);
+		basicComponents.forEach[
+			it.serviceEffectSpecifications__BasicComponent.forEach[
+				updateSEFFImplementingMethodName(it);
 			]
-		}
+		]
 	}
 }
 
@@ -1156,8 +1088,8 @@ routine changeReturnTypeOfMethodForOperationSignature(pcm::OperationSignature op
 	match {
 		val interfaceMethod = retrieve java::InterfaceMethod corresponding to operationSignature
 	}
-	action {
-		call changeInterfaceMethodReturnType(interfaceMethod, operationSignature.returnType__OperationSignature)
+	update {
+		changeInterfaceMethodReturnType(interfaceMethod, operationSignature.returnType__OperationSignature)
 	}
 }
 
@@ -1165,11 +1097,9 @@ routine changeInterfaceMethodReturnType(java::InterfaceMethod interfaceMethod, p
 	match {
 		val returnTypeClass = retrieve optional java::Class corresponding to returnType
 	}
-	action {
-		update interfaceMethod {
-			val returnTypeReference = createTypeReference(returnType, returnTypeClass);
-			interfaceMethod.typeReference = returnTypeReference;
-		}
+	update {
+		val returnTypeReference = createTypeReference(returnType, returnTypeClass);
+		interfaceMethod.typeReference = returnTypeReference;
 	}
 }
 
@@ -1182,8 +1112,9 @@ routine deleteMethodForOperationSignature(pcm::OperationSignature operationSigna
 	match {
 		val interfaceMethod = retrieve java::InterfaceMethod corresponding to operationSignature
 	}
-	action {
-		delete interfaceMethod
+	update {
+		deleteObject(interfaceMethod)
+		removeCorrespondenceBetween(interfaceMethod, operationSignature)
 	}
 }
 
@@ -1202,16 +1133,15 @@ routine createParameter(pcm::Parameter parameter) {
 		require absence of java::OrdinaryParameter corresponding to parameter
 		val javaParameterTypeClass = retrieve optional java::Class corresponding to parameter.dataType__Parameter
 	}
-	action {
-		val javaParameter = create java::OrdinaryParameter and initialize {
-			javaParameter.name = parameter.parameterName;
-			val parameterTypeReference = createTypeReference(parameter.dataType__Parameter, javaParameterTypeClass);
-			javaParameter.typeReference = parameterTypeReference;
-		}
-		add correspondence between javaParameter and parameter
-		update interfaceMethod {
-			interfaceMethod.parameters += javaParameter;
-		}
+	create {
+		val javaParameter = new java::OrdinaryParameter
+	}
+	update {
+		javaParameter.name = parameter.parameterName;
+		val parameterTypeReference = createTypeReference(parameter.dataType__Parameter, javaParameterTypeClass);
+		javaParameter.typeReference = parameterTypeReference;
+		addCorrespondenceBetween(javaParameter, parameter)
+		interfaceMethod.parameters += javaParameter;
 	}
 }
 
@@ -1224,10 +1154,8 @@ routine renameParameter(pcm::Parameter parameter) {
 	match {
 		val javaParameter = retrieve java::OrdinaryParameter corresponding to parameter
 	}
-	action {
-		update javaParameter {
-			javaParameter.name = parameter.parameterName;
-		}
+	update {
+		javaParameter.name = parameter.parameterName;
 	}
 }
 
@@ -1243,11 +1171,9 @@ routine changeParameterType(pcm::Parameter parameter) {
 		val javaParameter = retrieve java::OrdinaryParameter corresponding to parameter
 		val javaParameterTypeClass = retrieve optional java::Class corresponding to parameter.dataType__Parameter
 	}
-	action {
-		update parameter {
-			val parameterTypeReference = createTypeReference(parameter.dataType__Parameter, javaParameterTypeClass);
-			javaParameter.typeReference = parameterTypeReference;
-		}
+	update {
+		val parameterTypeReference = createTypeReference(parameter.dataType__Parameter, javaParameterTypeClass);
+		javaParameter.typeReference = parameterTypeReference;
 	}
 }
 
@@ -1262,8 +1188,9 @@ routine deleteParameter(pcm::OperationSignature signature, pcm::Parameter parame
 		val interfaceMethod = retrieve java::InterfaceMethod corresponding to signature
 		val javaParameter = retrieve java::OrdinaryParameter corresponding to parameter
 	}
-	action {
-		delete javaParameter
+	update {
+		deleteObject(javaParameter)
+		removeCorrespondenceBetween(javaParameter, parameter)
 	}
 }
 
@@ -1281,20 +1208,18 @@ routine createSEFF(pcm::ServiceEffectSpecification seff) {
 		val interfaceMethod = retrieve java::InterfaceMethod corresponding to seff.describedService__SEFF
 		check seff.describedService__SEFF instanceof OperationSignature
 	}
-	action {
-		val classMethod = create java::ClassMethod and initialize {
-			initializeClassMethod(classMethod, interfaceMethod, true);
-		}
-		add correspondence between classMethod and seff
-		// TODO HK This is not completely in the context of the component class, but in contained elements...
-		update componentClass {
-			var correspondingClassMethod = componentClass.findMethodInClass(classMethod);
-			if (null === correspondingClassMethod) {
-				componentClass.members += classMethod;
-				correspondingClassMethod = classMethod;
-			} else {
-				correspondingClassMethod.name = interfaceMethod.name;
-			}
+	create {
+		val classMethod = new java::ClassMethod
+	}
+	update {
+		initializeClassMethod(classMethod, interfaceMethod, true);
+		addCorrespondenceBetween(classMethod, seff)
+		var correspondingClassMethod = componentClass.findMethodInClass(classMethod);
+		if (null === correspondingClassMethod) {
+			componentClass.members += classMethod;
+			correspondingClassMethod = classMethod;
+		} else {
+			correspondingClassMethod.name = interfaceMethod.name;
 		}
 	}
 }
@@ -1305,9 +1230,9 @@ reaction ChangeOperationSignatureOfSeff {
 }
 
 routine changeMethodForSeff(pcm::ResourceDemandingSEFF seff) {
-	action {
-		call deleteMethodForSeff(seff)
-		call createSEFF(seff)
+	update {
+		deleteMethodForSeff(seff)
+		createSEFF(seff)
 	}
 }
 
@@ -1315,10 +1240,8 @@ routine updateSEFFImplementingMethodName(pcm::ServiceEffectSpecification seff) {
 	match {
 		val classMethod = retrieve java::ClassMethod corresponding to seff
 	}
-	action {
-		update classMethod {
-			classMethod.name = seff.describedService__SEFF.entityName;
-		}
+	update {
+		classMethod.name = seff.describedService__SEFF.entityName;
 	}
 }
 
@@ -1331,7 +1254,8 @@ routine deleteMethodForSeff(pcm::ServiceEffectSpecification seff) {
 	match {
 		val classMethod = retrieve java::ClassMethod corresponding to seff
 	}
-	action {
-		delete classMethod
+	update {
+		deleteObject(classMethod)
+		removeCorrespondenceBetween(seff, classMethod)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
@@ -111,7 +111,7 @@ routine deleteCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
-		deleteObject(umlProperty)
+		removeObject(umlProperty)
 		removeCorrespondenceBetween(pcmAssembly, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
@@ -24,10 +24,10 @@ reaction AssemblyContextInserted {
 	call insertCorrespondingAssemblyContextProperty(newValue, affectedEObject)
 }
 
-routine insertCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite){
-	action {
-		call detectOrCreateCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
-		call moveCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
+routine insertCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
+	update {
+		detectOrCreateCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
+		moveCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
 	}
 }
 
@@ -38,14 +38,12 @@ routine detectOrCreateCorrespondingAssemblyContextProperty(pcm::AssemblyContext 
 		val umlComponentImplementation = retrieve optional uml::Class 
 			corresponding to pcmAssembly.encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action{
-		call {
-			val Property umlPropertyCandidate = umlCompositeImplementation.ownedAttributes.findFirst[name == pcmAssembly.entityName]
-			if (umlPropertyCandidate === null) {
-				createCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
-			} else {
-				addCorrespondenceForExistingAssemblyContextProperty(pcmAssembly, umlPropertyCandidate)
-			}
+	update {
+		val Property umlPropertyCandidate = umlCompositeImplementation.ownedAttributes.findFirst[name == pcmAssembly.entityName]
+		if (umlPropertyCandidate === null) {
+			createCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
+		} else {
+			addCorrespondenceForExistingAssemblyContextProperty(pcmAssembly, umlPropertyCandidate)
 		}
 	}
 }
@@ -55,8 +53,8 @@ routine addCorrespondenceForExistingAssemblyContextProperty(pcm::AssemblyContext
 		require absence of uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		add correspondence between pcmAssembly and umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+	update {
+		addCorrespondenceBetween(pcmAssembly, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
 	}
 }
 
@@ -67,12 +65,13 @@ routine createCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 		val umlInnerComponent = retrieve optional uml::Class 
 				corresponding to pcmAssembly.encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		val umlProperty = create uml::Property and initialize {
-			umlProperty.name = pcmAssembly.entityName
-		}
-		add correspondence between pcmAssembly and umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		call changeTypeOfCorrespondingAssemblyContextProperty(pcmAssembly, pcmAssembly.encapsulatedComponent__AssemblyContext)
+	create {
+		val umlProperty = new uml::Property
+	}
+	update {
+		umlProperty.name = pcmAssembly.entityName
+		addCorrespondenceBetween(pcmAssembly, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
+		changeTypeOfCorrespondingAssemblyContextProperty(pcmAssembly, pcmAssembly.encapsulatedComponent__AssemblyContext)
 	}
 }
 
@@ -81,10 +80,8 @@ routine moveCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembl
 		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		update umlCompositeImplementation {
-			umlCompositeImplementation.ownedAttributes += umlProperty
-		}
+	update {
+		umlCompositeImplementation.ownedAttributes += umlProperty
 	}
 }
 
@@ -99,10 +96,8 @@ routine removeCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action{
-		update umlCompositeImplementation {
-			umlCompositeImplementation.ownedAttributes -= umlProperty
-		}
+	update {
+		umlCompositeImplementation.ownedAttributes -= umlProperty
 	}
 }
 
@@ -115,9 +110,9 @@ routine deleteCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 	match {
 		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action{
-		remove correspondence between pcmAssembly and umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		delete umlProperty
+	update {
+		deleteObject(umlProperty)
+		removeCorrespondenceBetween(pcmAssembly, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
 	}
 }
 
@@ -131,10 +126,8 @@ routine changeNameOfCorrespondingAssemblyContextProperty(pcm::AssemblyContext pc
 	match {
 		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action{
-		update umlProperty {
-			umlProperty.name = newName
-		}
+	update {
+		umlProperty.name = newName
 	}
 }
 
@@ -149,10 +142,8 @@ routine changeTypeOfCorrespondingAssemblyContextProperty(pcm::AssemblyContext pc
 		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComonent tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action{
-		update umlProperty {
-			umlProperty.type = umlComponentImplementation.orElse(null)
-		}
+	update {
+		umlProperty.type = umlComponentImplementation.orElse(null)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
@@ -47,19 +47,17 @@ routine changeTypeOfCorrespondingPropertyOrParameter(pcm::CollectionDataType pcm
 		val umlPrimitiveType = retrieve many uml::Type corresponding to newInnerType tagged with TagLiterals.DATATYPE__TYPE
 		val umlCompositeType = retrieve optional uml::Type corresponding to newInnerType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		execute {
-			if (newInnerType instanceof CollectionDataType) logger.warn(DefaultLiterals.WARNING_NESTED_COLLECTION_DATA_TYPE)
-			
-			// if the newInnerType is null or a CollectionDataType, this synchronizes the corresponding element's type to null
-			val umlType = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
-			for (umlParameter : umlParameterList) {
-				umlParameter.type = umlType
-			}
-			for (umlProperty : umlPropertyList) {
-				umlProperty.type = umlType
-			}
+	update {
+		if (newInnerType instanceof CollectionDataType) logger.warn(DefaultLiterals.WARNING_NESTED_COLLECTION_DATA_TYPE)
+		
+		// if the newInnerType is null or a CollectionDataType, this synchronizes the corresponding element's type to null
+		val umlType = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
+		for (umlParameter : umlParameterList) {
+			umlParameter.type = umlType
 		}
+		for (umlProperty : umlPropertyList) {
+			umlProperty.type = umlType
+	}
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
@@ -25,9 +25,9 @@ reaction CompositeDataTypeInsertedInRepository {
 }
 
 routine insertCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
-	action {
-		call detectOrCreateCorrespondingCompositeTypeClass(pcmType, pcmRepo)
-		call moveCorrespondingCompositeTypeClass(pcmType, pcmRepo)
+	update {
+		detectOrCreateCorrespondingCompositeTypeClass(pcmType, pcmRepo)
+		moveCorrespondingCompositeTypeClass(pcmType, pcmRepo)
 	}
 }
 
@@ -36,16 +36,14 @@ routine detectOrCreateCorrespondingCompositeTypeClass(pcm::CompositeDataType pcm
 		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 		val umlCompositeClass = retrieve optional uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		call {
-			if (!umlCompositeClass.isPresent) {
-				val umlCompositeCandidate = umlDatatypesPackage.packagedElements
-					.filter(Class).findFirst[it.name == pcmType.entityName]
-				if (umlCompositeCandidate !== null) {
-					addCorrespondenceForExistingCompositeTypeClass(pcmType, umlCompositeCandidate)
-				} else {
-					createCorrespondingCompositetypeClass(pcmType, pcmRepo)
-				}
+	update {
+		if (!umlCompositeClass.isPresent) {
+			val umlCompositeCandidate = umlDatatypesPackage.packagedElements
+				.filter(Class).findFirst[it.name == pcmType.entityName]
+			if (umlCompositeCandidate !== null) {
+				addCorrespondenceForExistingCompositeTypeClass(pcmType, umlCompositeCandidate)
+			} else {
+				createCorrespondingCompositetypeClass(pcmType, pcmRepo)
 			}
 		}
 	}
@@ -56,8 +54,8 @@ routine addCorrespondenceForExistingCompositeTypeClass(pcm::CompositeDataType pc
 		require absence of pcm::CompositeDataType corresponding to umlCompositeClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		require absence of uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		add correspondence between pcmType and umlCompositeClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+	update {
+		addCorrespondenceBetween(pcmType, umlCompositeClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
 	}
 }
 
@@ -66,11 +64,12 @@ routine createCorrespondingCompositetypeClass(pcm::CompositeDataType pcmType, pc
 		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 		require absence of uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		val umlCompositeClass = create uml::Class and initialize {
-			umlCompositeClass.name = pcmType.entityName	
-		}
-		add correspondence between pcmType and umlCompositeClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS 
+	create {
+		val umlCompositeClass = new uml::Class
+	}
+	update {
+		umlCompositeClass.name = pcmType.entityName	
+		addCorrespondenceBetween(pcmType, umlCompositeClass, TagLiterals.COMPOSITE_DATATYPE__CLASS) 
 	}
 }
 
@@ -79,10 +78,8 @@ routine moveCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm:
 		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		update umlDatatypesPackage {
-			umlDatatypesPackage.packagedElements += umlCompositeClass
-		}
+	update {
+		umlDatatypesPackage.packagedElements += umlCompositeClass
 	}
 }
 
@@ -97,10 +94,8 @@ routine removeCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pc
 		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		update umlDatatypesPackage {
-			umlDatatypesPackage.packagedElements -= umlCompositeClass
-		}
+	update {
+		umlDatatypesPackage.packagedElements -= umlCompositeClass
 	}
 }
 
@@ -113,9 +108,9 @@ routine deleteCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType) {
 	match {
 		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		remove correspondence between pcmType and umlCompositeClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		delete umlCompositeClass
+	update {
+		deleteObject(umlCompositeClass)
+		removeCorrespondenceBetween(pcmType, umlCompositeClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
 	}
 }
 
@@ -129,10 +124,8 @@ routine changeNameOfCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmTy
 	match {
 		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		update umlCompositeClass {
-			umlCompositeClass.name = newName
-		}
+	update {
+		umlCompositeClass.name = newName
 	}
 }
 
@@ -148,11 +141,12 @@ routine addParentTypeToCorrespondingCompositeTypeClass(pcm::CompositeDataType pc
 		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		check {!umlCompositeClass.generalizations.exists[it.general === umlParentCompositeClass]}
 	}
-	action {
-		val generalization = create uml::Generalization and initialize {
-			generalization.specific = umlCompositeClass
-			generalization.general = umlParentCompositeClass
-		}
+	create {
+		val generalization = new uml::Generalization
+	}
+	update {
+		generalization.specific = umlCompositeClass
+		generalization.general = umlParentCompositeClass
 	}
 }
 
@@ -167,13 +161,11 @@ routine removeParentTypeFromCorrespondingCompositeTypeClass(pcm::CompositeDataTy
 		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		execute {
-			val generalization = umlCompositeClass.generalizations.findFirst[it.general == umlParentCompositeClass]
-			generalization.general = null
-			generalization.specific = null
-			generalization.destroy
-		}
+	update {
+		val generalization = umlCompositeClass.generalizations.findFirst[it.general == umlParentCompositeClass]
+		generalization.general = null
+		generalization.specific = null
+		generalization.destroy
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
@@ -109,7 +109,7 @@ routine deleteCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType) {
 		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
-		deleteObject(umlCompositeClass)
+		removeObject(umlCompositeClass)
 		removeCorrespondenceBetween(pcmType, umlCompositeClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmDataTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmDataTypePropagation.reactions
@@ -24,20 +24,16 @@ execute actions in uml
 routine setUmlParameterType(
 		pcm::DataType pcmType, 
 		uml::Parameter umlParameter) {
-	action {
-		call {
-			setTypeOfUmlParameterOrProperty(pcmType, umlParameter, umlParameter, TagLiterals.COLLECTION_DATATYPE__PARAMETER)
-		}
+	update {
+		setTypeOfUmlParameterOrProperty(pcmType, umlParameter, umlParameter, TagLiterals.COLLECTION_DATATYPE__PARAMETER)
 	}
 }
 
 routine setUmlPropertyType(
 		pcm::DataType pcmType, 
 		uml::Property umlProperty) {
-	action {
-		call {
-			setTypeOfUmlParameterOrProperty(pcmType, umlProperty, umlProperty, TagLiterals.COLLECTION_DATATYPE__PROPERTY)
-		}
+	update {
+		setTypeOfUmlParameterOrProperty(pcmType, umlProperty, umlProperty, TagLiterals.COLLECTION_DATATYPE__PROPERTY)
 	}
 }
 
@@ -48,19 +44,17 @@ routine setTypeOfUmlParameterOrProperty(
 		pcm::DataType pcmType, 
 		uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, // same element; Parameter or Property
 		String tag) {
-	action {
-		call {
-			if(umlElement !== umlMultiplicity) {
-				throw new IllegalStateException("uml::TypedElement umlElement and uml::MultiplicityElement uMultiplicity"
-					+ "have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
-				)
-			}
-			
-			if (pcmType !== null && pcmType instanceof CollectionDataType) {
-				setTypeOfUmlParameterOrProperty_Collection(pcmType as CollectionDataType, umlElement, umlMultiplicity, tag)
-			} else {
-				setTypeOfUmlParameterOrProperty_NonCollection(pcmType, umlElement, umlMultiplicity, tag)
-			}
+	update {
+		if(umlElement !== umlMultiplicity) {
+			throw new IllegalStateException("uml::TypedElement umlElement, uml::MultiplicityElement uMultiplicity"
+				+ "have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
+			)
+		}
+		
+		if (pcmType !== null && pcmType instanceof CollectionDataType) {
+			setTypeOfUmlParameterOrProperty_Collection(pcmType as CollectionDataType, umlElement, umlMultiplicity, tag)
+		} else {
+			setTypeOfUmlParameterOrProperty_NonCollection(pcmType, umlElement, umlMultiplicity, tag)
 		}
 	}
 }
@@ -73,15 +67,11 @@ routine setTypeOfUmlParameterOrProperty_NonCollection(
 		val umlPrimitiveType = retrieve many uml::Type corresponding to pcmType tagged with TagLiterals.DATATYPE__TYPE
 		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		update umlElement {
-			umlElement.type = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
-		}
-		update umlMultiplicity {
-			umlMultiplicity.lower = 1
-			umlMultiplicity.upper = 1
-		}
-		call removeOldCollectionDataTypeCorrespondence(umlElement, tag)
+	update {
+		umlElement.type = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
+		umlMultiplicity.lower = 1
+		umlMultiplicity.upper = 1
+		removeOldCollectionDataTypeCorrespondence(umlElement, tag)
 	}
 }
 
@@ -93,16 +83,12 @@ routine setTypeOfUmlParameterOrProperty_Collection(
 		val umlPrimitiveType = retrieve many uml::Type corresponding to pcmType.innerType_CollectionDataType tagged with TagLiterals.DATATYPE__TYPE
 		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType.innerType_CollectionDataType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		update umlElement {
-			umlElement.type = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
-		}
-		update umlMultiplicity {
-			umlMultiplicity.lower = 0
-			umlMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
-		}
-		call removeOldCollectionDataTypeCorrespondence(umlElement, tag)
-		call addCollectionDataTypeCorrespondence(pcmType, umlElement, tag)
+	update {
+		umlElement.type = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
+		umlMultiplicity.lower = 0
+		umlMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
+		removeOldCollectionDataTypeCorrespondence(umlElement, tag)
+		addCollectionDataTypeCorrespondence(pcmType, umlElement, tag)
 	}
 }
 
@@ -113,8 +99,8 @@ routine removeOldCollectionDataTypeCorrespondence(
 	match {
 		val oldCollectionType = retrieve pcm::CollectionDataType corresponding to umlElement tagged with tag
 	}
-	action {
-		remove correspondence between oldCollectionType and umlElement tagged with tag
+	update {
+		removeCorrespondenceBetween(oldCollectionType, umlElement, tag)
 	}
 }
 
@@ -125,8 +111,8 @@ routine addCollectionDataTypeCorrespondence(
 	match {
 		require absence of pcm::CollectionDataType corresponding to umlElement tagged with tag
 	}
-	action {
-		add correspondence between pcmType and umlElement tagged with tag
+	update {
+		addCorrespondenceBetween(pcmType, umlElement, tag)
 	}
 }
 
@@ -153,15 +139,13 @@ reaction UnsupportedPrimitiveTypeSetAtSignature {
 }
 
 routine unsupportedPrimitiveTypeSetWarning(pcm::PrimitiveDataType primitive, EObject entity) {
-	action {
-		execute {
-			userInteractor.notificationDialogBuilder
-				.message("The pcm::PrimitiveDataType " + primitive + " set at the pcm element " + entity 
-					+ " has no good match in the predefined set of uml::PrimitiveTypes "
-					+ " used by these transformations and is therefore not supported.")
-				.notificationType(NotificationType.WARNING)
-				.startInteraction
-		}
+	update {
+		userInteractor.notificationDialogBuilder
+			.message("The pcm::PrimitiveDataType " + primitive + " set at the pcm element " + entity 
+				+ " has no good match in the predefined set of uml::PrimitiveTypes "
+				+ " used by these transformations, is therefore not supported.")
+			.notificationType(NotificationType.WARNING)
+			.startInteraction
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
@@ -23,9 +23,9 @@ reaction InnerDeclarationInserted {
 }
 
 routine insertCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
-	action {
-		call detectOrCreateCorrespondingAttribute(pcmAttribute, pcmComposite)
-		call moveCorrespondingAttribute(pcmAttribute, pcmComposite)
+	update {
+		detectOrCreateCorrespondingAttribute(pcmAttribute, pcmComposite)
+		moveCorrespondingAttribute(pcmAttribute, pcmComposite)
 	}
 }
 
@@ -34,15 +34,13 @@ routine detectOrCreateCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute,
 		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val umlAttribute = retrieve optional uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		call {
-			if (!umlAttribute.isPresent) {
-				val umlAttributeCandidate = umlComposite.ownedAttributes.findFirst[it.name == pcmAttribute.entityName]
-				if (umlAttributeCandidate !== null) {
-					addCorrespondenceForExistingAttribute(pcmAttribute, umlAttributeCandidate)
-				} else {
-					createCorrespondingAttribute(pcmAttribute, pcmComposite)
-				}
+	update {
+		if (!umlAttribute.isPresent) {
+			val umlAttributeCandidate = umlComposite.ownedAttributes.findFirst[it.name == pcmAttribute.entityName]
+			if (umlAttributeCandidate !== null) {
+				addCorrespondenceForExistingAttribute(pcmAttribute, umlAttributeCandidate)
+			} else {
+				createCorrespondingAttribute(pcmAttribute, pcmComposite)
 			}
 		}
 	}
@@ -53,8 +51,8 @@ routine addCorrespondenceForExistingAttribute(pcm::InnerDeclaration pcmAttribute
 		require absence of uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 		require absence of pcm::InnerDeclaration corresponding to umlAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		add correspondence between pcmAttribute and umlAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+	update {
+		addCorrespondenceBetween(pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY)
 	}
 }
 
@@ -63,12 +61,13 @@ routine createCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::Co
 		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		require absence of uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		val umlAttribute = create uml::Property and initialize {
-			umlAttribute.name = pcmAttribute.entityName
-		}
-		add correspondence between pcmAttribute and umlAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
-		call changeTypeOfCorrespondingAttribute(pcmAttribute, pcmAttribute.datatype_InnerDeclaration)
+	create {
+		val umlAttribute = new uml::Property
+	}
+	update {
+		umlAttribute.name = pcmAttribute.entityName
+		addCorrespondenceBetween(pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY)
+		changeTypeOfCorrespondingAttribute(pcmAttribute, pcmAttribute.datatype_InnerDeclaration)
 	}
 }
 
@@ -77,10 +76,8 @@ routine moveCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::Comp
 		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		update umlComposite {
-			umlComposite.ownedAttributes += umlAttribute
-		}
+	update {
+		umlComposite.ownedAttributes += umlAttribute
 	}
 }
 
@@ -95,10 +92,8 @@ routine removeCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::Co
 		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		update umlComposite {
-			umlComposite.ownedAttributes -= umlAttribute
-		}
+	update {
+		umlComposite.ownedAttributes -= umlAttribute
 	}
 }
 
@@ -111,9 +106,9 @@ routine deleteCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute) {
 	match {
 		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		remove correspondence between pcmAttribute and umlAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
-		delete umlAttribute
+	update {
+		deleteObject(umlAttribute)
+		removeCorrespondenceBetween(pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY)
 	}
 }
 
@@ -127,10 +122,8 @@ routine changeNameOfCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, S
 	match {
 		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		update umlAttribute {
-			umlAttribute.name = newName
-		}
+	update {
+		umlAttribute.name = newName
 	}
 }
 
@@ -145,8 +138,8 @@ routine changeTypeOfCorrespondingAttribute(pcm::InnerDeclaration pcmInnerDeclara
 	match {
 		val umlProperty = retrieve uml::Property corresponding to pcmInnerDeclaration tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		call pcmDataTypePropagationReactions.setUmlPropertyType(pcmDataType, umlProperty)
+	update {
+		pcmDataTypePropagationReactions.setUmlPropertyType(pcmDataType, umlProperty)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
@@ -107,7 +107,7 @@ routine deleteCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute) {
 		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
 	update {
-		deleteObject(umlAttribute)
+		removeObject(umlAttribute)
 		removeCorrespondenceBetween(pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
@@ -110,7 +110,7 @@ routine deleteCorrespondingInterface(pcm::OperationInterface pcmInterface) {
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
 	update {
-		deleteObject(umlInterface)
+		removeObject(umlInterface)
 		removeCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
@@ -23,9 +23,9 @@ reaction InterfaceInsertedInRepository {
 }
 
 routine insertCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
-	action {
-		call detectOrCreateInterfaceCandidate(pcmInterface, pcmRepository)
-		call moveCorrespondingInterface(pcmInterface, pcmRepository)
+	update {
+		detectOrCreateInterfaceCandidate(pcmInterface, pcmRepository)
+		moveCorrespondingInterface(pcmInterface, pcmRepository)
 	}
 }
 
@@ -34,15 +34,13 @@ routine detectOrCreateInterfaceCandidate(pcm::OperationInterface pcmInterface, p
 		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
-	action {
-		call {
-			if (!umlInterface.isPresent) {
-				val umlInterfaceCandidate = umlContractsPackage.packagedElements.filter(Interface).findFirst[it.name == pcmInterface.entityName]
-				if (umlInterfaceCandidate !== null) {
-					attemptAddingCorrespondenceForExistingInterfaceCandidate(pcmInterface, pcmRepository, umlInterfaceCandidate)
-				} else {
-					createInterfaceCorrespondence(pcmInterface, pcmRepository)
-				}
+	update {
+		if (!umlInterface.isPresent) {
+			val umlInterfaceCandidate = umlContractsPackage.packagedElements.filter(Interface).findFirst[it.name == pcmInterface.entityName]
+			if (umlInterfaceCandidate !== null) {
+				attemptAddingCorrespondenceForExistingInterfaceCandidate(pcmInterface, pcmRepository, umlInterfaceCandidate)
+			} else {
+				createInterfaceCorrespondence(pcmInterface, pcmRepository)
 			}
 		}
 	}
@@ -55,8 +53,8 @@ routine attemptAddingCorrespondenceForExistingInterfaceCandidate(
 	match {  
 		require absence of pcm::OperationInterface corresponding to umlInterfaceCandidate tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		add correspondence between pcmInterface and umlInterfaceCandidate tagged with TagLiterals.INTERFACE_TO_INTERFACE
+	update {
+		addCorrespondenceBetween(pcmInterface, umlInterfaceCandidate, TagLiterals.INTERFACE_TO_INTERFACE)
 	}
 }
 
@@ -66,12 +64,12 @@ routine createInterfaceCorrespondence(pcm::OperationInterface pcmInterface, pcm:
 		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		require absence of uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
-	action {
-		val umlInterface = create uml::Interface and initialize {
-			umlInterface.name = pcmInterface.entityName
-//			umlContractsPackage.packagedElements += umlInterface // done in move-routine
-		}
-		add correspondence between pcmInterface and umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+	create {
+		val umlInterface = new uml::Interface
+	}
+	update {
+		umlInterface.name = pcmInterface.entityName
+		addCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
 	}
 }
 
@@ -80,10 +78,8 @@ routine moveCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::Re
 		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
-	action {
-		update umlContractsPackage {
-			umlContractsPackage.packagedElements += umlInterface
-		}
+	update {
+		umlContractsPackage.packagedElements += umlInterface
 	}
 }
 
@@ -99,10 +95,8 @@ routine removeCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::
 		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
-	action {
-		update umlContractsPackage {
-			umlContractsPackage.packagedElements -= umlInterface
-		}
+	update {
+		umlContractsPackage.packagedElements -= umlInterface
 	}
 }
 
@@ -115,9 +109,9 @@ routine deleteCorrespondingInterface(pcm::OperationInterface pcmInterface) {
 	match {
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
-	action {
-		remove correspondence between pcmInterface and umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		delete umlInterface
+	update {
+		deleteObject(umlInterface)
+		removeCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
 	}
 }
 
@@ -131,10 +125,8 @@ routine renameCorrespondingInterface(pcm::OperationInterface pcmInterface, Strin
 	match {
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
-	action {
-		update umlInterface {
-			umlInterface.name = newName
-		}
+	update {
+		umlInterface.name = newName
 	}
 }
 
@@ -149,11 +141,12 @@ routine addParentInterfaceToCorrespondingInterface(pcm::OperationInterface pcmIn
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
-	action {
-		val generalization = create uml::Generalization and initialize {
-			generalization.specific = umlInterface
-			generalization.general = umlParentInterface
-		}
+	create {
+		val generalization = new uml::Generalization
+	}
+	update {
+		generalization.specific = umlInterface
+		generalization.general = umlParentInterface
 	}
 }
 
@@ -168,10 +161,8 @@ routine removeParentInterfaceFromCorrespondingInterface(pcm::OperationInterface 
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
 	}
-	action{
-		execute{
-			umlInterface.generalizations.findFirst[it.general === umlParentInterface]?.destroy
-		}
+	update {
+		umlInterface.generalizations.findFirst[it.general === umlParentInterface]?.destroy
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
@@ -25,9 +25,9 @@ reaction ParameterInsertedInSignature {
 }
 
 routine insertCorrespondingRegularParameter(pcm::Parameter pcmParameter, pcm::OperationSignature pcmSignature) {
-	action {
-		call detectOrCreateRegularParameterCandidate(pcmParameter, pcmSignature)
-		call moveCorrespondingRegularParameter(pcmParameter, pcmSignature)
+	update {
+		detectOrCreateRegularParameterCandidate(pcmParameter, pcmSignature)
+		moveCorrespondingRegularParameter(pcmParameter, pcmSignature)
 		
 	}
 }
@@ -37,15 +37,13 @@ routine detectOrCreateRegularParameterCandidate(pcm::Parameter pcmParam, pcm::Op
 		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		val umlParam = retrieve optional uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		call {
-			if (!umlParam.isPresent) {
-				val umlParamCandidate = umlOperation.ownedParameters.findFirst[it.name == pcmParam.parameterName]
-				if (umlParamCandidate !== null) {
-					addCorrespondenceForExistingRegularParameter(pcmParam, umlParamCandidate)
-				} else {
-					createCorrespondingRegularParameter(pcmParam, pcmSignature)
-				}
+	update {
+		if (!umlParam.isPresent) {
+			val umlParamCandidate = umlOperation.ownedParameters.findFirst[it.name == pcmParam.parameterName]
+			if (umlParamCandidate !== null) {
+				addCorrespondenceForExistingRegularParameter(pcmParam, umlParamCandidate)
+			} else {
+				createCorrespondingRegularParameter(pcmParam, pcmSignature)
 			}
 		}
 	}
@@ -56,8 +54,8 @@ routine addCorrespondenceForExistingRegularParameter(pcm::Parameter pcmParam, um
 		require absence of uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 		require absence of pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		add correspondence between pcmParam and umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+	update {
+		addCorrespondenceBetween(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER)
 	}
 }
 
@@ -66,13 +64,14 @@ routine createCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::Operat
 		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		require absence of uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		val umlParam = create uml::Parameter and initialize{
-			umlParam.name = pcmParam.parameterName
-		}
-		add correspondence between pcmParam and umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
-		call changeDirectionOfCorrespondingRegularParameter(pcmParam)
-		call changeTypeOfCorrespondingRegularParameter(pcmParam, pcmParam.dataType__Parameter)
+	create {
+		val umlParam = new uml::Parameter
+	}
+	update {
+		umlParam.name = pcmParam.parameterName
+		addCorrespondenceBetween(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER)
+		changeDirectionOfCorrespondingRegularParameter(pcmParam)
+		changeTypeOfCorrespondingRegularParameter(pcmParam, pcmParam.dataType__Parameter)
 	}
 }
 
@@ -81,10 +80,8 @@ routine moveCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::Operatio
 		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		val umlParameter = retrieve asserted uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		update umlOperation {
-			umlOperation.ownedParameters += umlParameter
-		}
+	update {
+		umlOperation.ownedParameters += umlParameter
 	}
 }
 
@@ -99,10 +96,8 @@ routine removeCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::Operat
 		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		update umlOperation {
-			umlOperation.ownedParameters -= umlParameter
-		}
+	update {
+		umlOperation.ownedParameters -= umlParameter
 	}
 }
 
@@ -115,9 +110,9 @@ routine deleteCorrespondingRegularParameter(pcm::Parameter pcmParam) {
 	match {
 		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		remove correspondence between pcmParam and umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
-		delete umlParameter
+	update {
+		deleteObject(umlParameter)
+		removeCorrespondenceBetween(pcmParam, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
 	}
 }
 
@@ -131,10 +126,8 @@ routine renameCorrespondingRegularParameter(pcm::Parameter pcmParam, String newN
 	match {
 		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		update umlParam {
-			umlParam.name = newName
-		}
+	update {
+		umlParam.name = newName
 	}
 }
 
@@ -149,10 +142,8 @@ routine changeDirectionOfCorrespondingRegularParameter(pcm::Parameter pcmParam) 
 	match {
 		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		update umlParam {
-			umlParam.direction = PcmUmlClassHelper.getMatchingParameterDirection(pcmParam.modifier__Parameter)
-		}
+	update {
+		umlParam.direction = PcmUmlClassHelper.getMatchingParameterDirection(pcmParam.modifier__Parameter)
 	}
 }
 
@@ -166,8 +157,8 @@ routine changeTypeOfCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::
 	match {
 		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		call pcmDataTypePropagationReactions.setUmlParameterType(pcmDataType, umlParam)
+	update {
+		pcmDataTypePropagationReactions.setUmlParameterType(pcmDataType, umlParam)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
@@ -111,7 +111,7 @@ routine deleteCorrespondingRegularParameter(pcm::Parameter pcmParam) {
 		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
-		deleteObject(umlParameter)
+		removeObject(umlParameter)
 		removeCorrespondenceBetween(pcmParam, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
@@ -108,7 +108,7 @@ routine deleteCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
-		deleteObject(umlRealization)
+		removeObject(umlRealization)
 		removeCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
@@ -21,9 +21,9 @@ reaction ProvidedRoleInserted {
 }
 
 routine insertCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
-	action {
-		call detectOrCreateCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
-		call moveCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
+	update {
+		detectOrCreateCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
+		moveCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
 	}
 }
 
@@ -33,14 +33,12 @@ routine detectOrCreateCorrespondingProvidedRealization(pcm::OperationProvidedRol
 		val umlInterface = retrieve uml::Interface corresponding to pcmProvided.providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 	    require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		call {
-			var umlRealizationCandidate = umlComponentImpl.interfaceRealizations.findFirst[it.name == pcmProvided.entityName && it.contract === umlInterface]
-			if (umlRealizationCandidate !== null) {
-				addCorrespondenceForExistingRealization(pcmProvided, umlRealizationCandidate)
-			} else {
-				createCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
-			}
+	update {
+		var umlRealizationCandidate = umlComponentImpl.interfaceRealizations.findFirst[it.name == pcmProvided.entityName && it.contract === umlInterface]
+		if (umlRealizationCandidate !== null) {
+			addCorrespondenceForExistingRealization(pcmProvided, umlRealizationCandidate)
+		} else {
+			createCorrespondingProvidedRealization(pcmProvided, pcmIPRE)
 		}
 	}
 }
@@ -50,8 +48,8 @@ routine addCorrespondenceForExistingRealization(pcm::OperationProvidedRole pcmPr
 		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION 
 	}
-	action {
-		add correspondence between pcmProvided and umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+	update {
+		addCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
 	}
 }
 
@@ -62,13 +60,14 @@ routine createCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 		val umlInterface = retrieve optional uml::Interface 
 			corresponding to pcmProvided.providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 	}
-	action {
-		val umlRealization = create uml::InterfaceRealization and initialize {
-			umlRealization.implementingClassifier = umlComponentImpl
-			umlRealization.contract = umlInterface.orElse(null)
-			umlComponentImpl.interfaceRealizations += umlRealization
-		}
-		add correspondence between pcmProvided and umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+	create {
+		val umlRealization = new uml::InterfaceRealization
+	}
+	update {
+		umlRealization.implementingClassifier = umlComponentImpl
+		umlRealization.contract = umlInterface.orElse(null)
+		umlComponentImpl.interfaceRealizations += umlRealization
+		addCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
 	}
 }
 
@@ -77,10 +76,8 @@ routine moveCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvi
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION 
 	}
-	action {
-		update umlComponentImpl {
-			umlComponentImpl.interfaceRealizations += umlRealization
-		}
+	update {
+		umlComponentImpl.interfaceRealizations += umlRealization
 	}
 }
 
@@ -95,13 +92,9 @@ routine removeCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		update umlComponentImpl {
-			umlComponentImpl.interfaceRealizations -= umlRealization
-		}
-		update umlRealization {
-			umlRealization.clients -= umlComponentImpl // not automatically done by the remove
-		}
+	update {
+		umlComponentImpl.interfaceRealizations -= umlRealization
+		umlRealization.clients -= umlComponentImpl // not automatically done by the remove
 	}
 }
 
@@ -114,9 +107,9 @@ routine deleteCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 	match {
 		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		remove correspondence between pcmProvided and umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
-		delete umlRealization
+	update {
+		deleteObject(umlRealization)
+		removeCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
 	}
 }
 
@@ -130,10 +123,8 @@ routine changeNameOfCorrespondingProvidedRealization(pcm::OperationProvidedRole 
 	match {
 		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		update umlRealization {
-			umlRealization.name = newName
-		}
+	update {
+		umlRealization.name = newName
 	}
 }
 
@@ -149,10 +140,8 @@ routine changeInterfaceOfCorrespondingProvidedRealization(pcm::OperationProvided
 		val umlInterface = retrieve optional uml::Interface 
 			corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 	}
-	action {
-		update umlRealization {
-			umlRealization.contract = umlInterface.orElse(null)
-		}
+	update {
+		umlRealization.contract = umlInterface.orElse(null)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -42,8 +42,8 @@ reaction RepositoryCreated {
 }
 
 routine addRepositoryCorrespondence(pcm::Repository pcmRepository) {
-	action {
-		add correspondence between pcmRepository and RepositoryPackage.Literals.REPOSITORY
+	update {
+		addCorrespondenceBetween(pcmRepository, RepositoryPackage.Literals.REPOSITORY)
 	}
 }
 
@@ -52,21 +52,19 @@ routine createOrFindUmlRepositoryPackage(pcm::Repository pcmRepo) {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
-	action {
-		call {
-			var umlPackage = findUmlPackage(umlModel, pcmRepo.correspondingPackageName)
-			if(umlPackage === null) {
-				createUmlRepositoryPackage(pcmRepo)
-			} else {
-				addPackageCorrespondence(pcmRepo, umlPackage)
-			}
+	update {
+		var umlPackage = findUmlPackage(umlModel, pcmRepo.correspondingPackageName)
+		if(umlPackage === null) {
+			createUmlRepositoryPackage(pcmRepo)
+		} else {
+			addPackageCorrespondence(pcmRepo, umlPackage)
 		}
 	}
 }
 
 routine addPackageCorrespondence(pcm::Repository pcmRepo, uml::Package uPackage) {
-	action {
-		add correspondence between pcmRepo and uPackage tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+	update {
+		addCorrespondenceBetween(pcmRepo, uPackage, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
 	}
 }
 
@@ -74,12 +72,13 @@ routine createUmlRepositoryPackage(pcm::Repository pcmRepo) {
 	match {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 	}
-	action {
-		val umlRepositoryPkg = create uml::Package and initialize {
-			umlRepositoryPkg.name = pcmRepo.correspondingPackageName;
-			umlModel.nestedPackages += umlRepositoryPkg
-		}
-		add correspondence between pcmRepo and umlRepositoryPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+	create {
+		val umlRepositoryPkg = new uml::Package
+	}
+	update {
+		umlRepositoryPkg.name = pcmRepo.correspondingPackageName;
+		umlModel.nestedPackages += umlRepositoryPkg
+		addCorrespondenceBetween(pcmRepo, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
 	}
 }
 
@@ -88,15 +87,13 @@ routine createUmlContractsPackage(pcm::Repository pcmRepo) {
 		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 	}
-	action {
-		call {
-			//look for candidate before creating a new Package
-			var umlContractsPkg = umlRepositoryPkg.nestedPackages.findFirst[pkg | pkg.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME]
-			if (umlContractsPkg === null) {
-				umlContractsPkg = umlRepositoryPkg.createNestedPackage(DefaultLiterals.CONTRACTS_PACKAGE_NAME)
-			}
-			ReactionsCorrespondenceHelper.addCorrespondence(correspondenceModel, pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)
+	update {
+		//look for candidate before creating a new Package
+		var umlContractsPkg = umlRepositoryPkg.nestedPackages.findFirst[pkg | pkg.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME]
+		if (umlContractsPkg === null) {
+			umlContractsPkg = umlRepositoryPkg.createNestedPackage(DefaultLiterals.CONTRACTS_PACKAGE_NAME)
 		}
+		ReactionsCorrespondenceHelper.addCorrespondence(correspondenceModel, pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)
 	}
 }
 routine createUmlDatatypesPackage(pcm::Repository pcmRepo) {
@@ -104,15 +101,13 @@ routine createUmlDatatypesPackage(pcm::Repository pcmRepo) {
 		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
-	action {
-		call {
-			//look for candidate before creating a new Package
-			var umlDatatypesPkg = umlRepositoryPkg.nestedPackages.findFirst[pkg | pkg.name == DefaultLiterals.DATATYPES_PACKAGE_NAME]
-			if (umlDatatypesPkg === null) {
-				umlDatatypesPkg = umlRepositoryPkg.createNestedPackage(DefaultLiterals.DATATYPES_PACKAGE_NAME)
-			}
-			ReactionsCorrespondenceHelper.addCorrespondence(correspondenceModel, pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)
+	update {
+		//look for candidate before creating a new Package
+		var umlDatatypesPkg = umlRepositoryPkg.nestedPackages.findFirst[pkg | pkg.name == DefaultLiterals.DATATYPES_PACKAGE_NAME]
+		if (umlDatatypesPkg === null) {
+			umlDatatypesPkg = umlRepositoryPkg.createNestedPackage(DefaultLiterals.DATATYPES_PACKAGE_NAME)
 		}
+		ReactionsCorrespondenceHelper.addCorrespondence(correspondenceModel, pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)
 	}
 }
 
@@ -126,11 +121,9 @@ routine changeNameOfCorrespondingRepositoryPackage(pcm::Repository pcmRepo) {
 	match {
 		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
-	action {
-		update umlRepositoryPkg {
-			if (!umlRepositoryPkg.isPackageFor(pcmRepo))
-				umlRepositoryPkg.name = pcmRepo.correspondingPackageName
-		}
+	update {
+		if (!umlRepositoryPkg.isPackageFor(pcmRepo))
+			umlRepositoryPkg.name = pcmRepo.correspondingPackageName
 	}
 }
 
@@ -146,27 +139,25 @@ routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 		val umlContractsPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		val umlDatatypesPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
-	action {
-		call{
-			// remove correspondences and UML model contents if desired
-			umlRepositoryPkg.ifPresent[umlRepositoryPackage |
-				ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
-					correspondenceModel, pcmRepo, umlRepositoryPackage, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
-				// ask if the corresponding model should also be deleted
-				val deleteCorrespondingUmlRepository = userInteractor.confirmationDialogBuilder
-						.message(DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
-	
-				if (deleteCorrespondingUmlRepository) {// DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL_YES
-					umlContractsPkg.ifPresent[umlRepositoryPackage.packagedElements -= it]
-					umlDatatypesPkg.ifPresent[umlRepositoryPackage.packagedElements -= it]
-					umlModel.packagedElements -= umlRepositoryPackage // remove parent package last to allow the recorder to notice the child package deletion
-				}
-			]
-			umlContractsPkg.ifPresent[ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
-				correspondenceModel, pcmRepo, it, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)]
-			umlDatatypesPkg.ifPresent[ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
-				correspondenceModel, pcmRepo, it, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)]
-		}
+	update {
+		// remove correspondences, UML model contents if desired
+		umlRepositoryPkg.ifPresent[umlRepositoryPackage |
+			ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
+				correspondenceModel, pcmRepo, umlRepositoryPackage, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
+			// ask if the corresponding model should also be deleted
+			val deleteCorrespondingUmlRepository = userInteractor.confirmationDialogBuilder
+					.message(DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
+
+			if (deleteCorrespondingUmlRepository) {// DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL_YES
+				umlContractsPkg.ifPresent[umlRepositoryPackage.packagedElements -= it]
+				umlDatatypesPkg.ifPresent[umlRepositoryPackage.packagedElements -= it]
+				umlModel.packagedElements -= umlRepositoryPackage // remove parent package last to allow the recorder to notice the child package deletion
+			}
+		]
+		umlContractsPkg.ifPresent[ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
+			correspondenceModel, pcmRepo, it, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)]
+		umlDatatypesPkg.ifPresent[ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
+			correspondenceModel, pcmRepo, it, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)]
 	}
 }
 
@@ -176,15 +167,13 @@ routine bootstrapPrimitiveDatatypes(pcm::Repository pcmRepo) {
 	match {
 		val umlDatatypesPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
-	action {
-		execute {
-			val pcmPrimitiveTypes = PcmDataTypeUtil.getPcmPrimitiveTypes(pcmRepo)
-			val umlPrimitiveTypes = UmlTypeUtil.getUmlPrimitiveTypes(pcmRepo.eResource.resourceSet)
-			for (pcmType : pcmPrimitiveTypes) {
-				val umlTypes = PcmUmlClassHelper.mapPrimitiveTypes(pcmType, umlPrimitiveTypes)
-				for (umlType : umlTypes) {
-					addPrimitiveDatatypeCorrespondence(pcmType, umlType)
-				}
+	update {
+		val pcmPrimitiveTypes = PcmDataTypeUtil.getPcmPrimitiveTypes(pcmRepo)
+		val umlPrimitiveTypes = UmlTypeUtil.getUmlPrimitiveTypes(pcmRepo.eResource.resourceSet)
+		for (pcmType : pcmPrimitiveTypes) {
+			val umlTypes = PcmUmlClassHelper.mapPrimitiveTypes(pcmType, umlPrimitiveTypes)
+			for (umlType : umlTypes) {
+				addPrimitiveDatatypeCorrespondence(pcmType, umlType)
 			}
 		}
 	}
@@ -195,8 +184,8 @@ routine addPrimitiveDatatypeCorrespondence(pcm::PrimitiveDataType pcmPrimitiveTy
 		require absence of uml::PrimitiveType corresponding to pcmPrimitiveType tagged with TagLiterals.DATATYPE__TYPE with potentialTarget == umlPrimitiveType
 		require absence of pcm::PrimitiveDataType corresponding to umlPrimitiveType tagged with TagLiterals.DATATYPE__TYPE with potentialTarget == pcmPrimitiveType
 	}
-	action{
-		add correspondence between pcmPrimitiveType and umlPrimitiveType tagged with TagLiterals.DATATYPE__TYPE
+	update {
+		addCorrespondenceBetween(pcmPrimitiveType, umlPrimitiveType, TagLiterals.DATATYPE__TYPE)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
@@ -206,7 +206,7 @@ routine deleteCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
 	update {
-		deleteObject(umlComponentPackage)
+		removeObject(umlComponentPackage)
 		removeCorrespondenceBetween(pcmComponent, umlComponentPackage,TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 		removeCorrespondenceBetween(pcmComponent, umlComponentImplementation, TagLiterals.IPRE__IMPLEMENTATION)
 		removeCorrespondenceBetween(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
@@ -30,11 +30,11 @@ reaction RepositoryComponentInserted {
 }
 
 routine insertCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
-	action {
-		call detectOrCreateCorrespondingComponentPackage(pcmComponent, pcmRepository)
-		call detectOrCreateCorrespondingComponentImplementation(pcmComponent)
-		call detectOrCreateCorrespondingComponentConstructor(pcmComponent)
-		call moveCorrespondingComponentPackage(pcmComponent, pcmRepository)
+	update {
+		detectOrCreateCorrespondingComponentPackage(pcmComponent, pcmRepository)
+		detectOrCreateCorrespondingComponentImplementation(pcmComponent)
+		detectOrCreateCorrespondingComponentConstructor(pcmComponent)
+		moveCorrespondingComponentPackage(pcmComponent, pcmRepository)
 	}
 }
 
@@ -43,15 +43,13 @@ routine detectOrCreateCorrespondingComponentPackage(pcm::RepositoryComponent pcm
 		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		call {
-			if (!umlComponentPackage.isPresent) {
-				val umlComponentPackageCandidate = umlRepositoryPackage.nestedPackages.findFirst[isPackageFor(pcmComponent)]
-				if (umlComponentPackageCandidate !== null) {
-					addCorrespondenceForExistingComponentPackage(pcmComponent, umlComponentPackageCandidate)
-				} else { 
-					createCorrespondingComponentPackage(pcmComponent, pcmRepository)
-				}
+	update {
+		if (!umlComponentPackage.isPresent) {
+			val umlComponentPackageCandidate = umlRepositoryPackage.nestedPackages.findFirst[isPackageFor(pcmComponent)]
+			if (umlComponentPackageCandidate !== null) {
+				addCorrespondenceForExistingComponentPackage(pcmComponent, umlComponentPackageCandidate)
+			} else { 
+				createCorrespondingComponentPackage(pcmComponent, pcmRepository)
 			}
 		}
 	}
@@ -62,8 +60,8 @@ routine addCorrespondenceForExistingComponentPackage(pcm::RepositoryComponent pc
 		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 		require absence of pcm::RepositoryComponent corresponding to umlComponentPackage tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		add correspondence between pcmComponent and umlComponentPackage tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+	update {
+		addCorrespondenceBetween(pcmComponent, umlComponentPackage, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 	}
 }
 
@@ -72,12 +70,13 @@ routine createCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		val umlComponentPackage = create uml::Package and initialize {
-			umlComponentPackage.name = pcmComponent.correspondingPackageName
-			umlRepositoryPackage.packagedElements += umlComponentPackage
-		}
-		add correspondence between pcmComponent and umlComponentPackage tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+	create {
+		val umlComponentPackage = new uml::Package
+	}
+	update {
+		umlComponentPackage.name = pcmComponent.correspondingPackageName
+		umlRepositoryPackage.packagedElements += umlComponentPackage
+		addCorrespondenceBetween(pcmComponent, umlComponentPackage, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 	}
 }
 
@@ -87,16 +86,14 @@ routine detectOrCreateCorrespondingComponentImplementation(pcm::RepositoryCompon
 		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		call {
-			if (!umlComponentImplementation.isPresent) {
-				val umlComponentImplementationCandidate = umlComponentPackage.packagedElements
-						.filter(Class).findFirst[it.name == pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
-				if (umlComponentImplementationCandidate !== null) {
-					addCorrespondenceForExistingComponentImplementation(pcmComponent, umlComponentImplementationCandidate)
-				} else {
-					createCorrespondingComponentImplementation(pcmComponent)
-				}
+	update {
+		if (!umlComponentImplementation.isPresent) {
+			val umlComponentImplementationCandidate = umlComponentPackage.packagedElements
+					.filter(Class).findFirst[it.name == pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+			if (umlComponentImplementationCandidate !== null) {
+				addCorrespondenceForExistingComponentImplementation(pcmComponent, umlComponentImplementationCandidate)
+			} else {
+				createCorrespondingComponentImplementation(pcmComponent)
 			}
 		}
 	}
@@ -107,8 +104,8 @@ routine addCorrespondenceForExistingComponentImplementation(pcm::RepositoryCompo
 		require absence of uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		require absence of pcm::RepositoryComponent corresponding to umlComponentImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		add correspondence between pcmComponent and umlComponentImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
+	update {
+		addCorrespondenceBetween(pcmComponent, umlComponentImplementation, TagLiterals.IPRE__IMPLEMENTATION)
 	}
 }
 
@@ -117,13 +114,14 @@ routine createCorrespondingComponentImplementation(pcm::RepositoryComponent pcmC
 		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 		require absence of uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		val umlComponentImplementation = create uml::Class and initialize {
-			umlComponentImplementation.name = pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
-			umlComponentImplementation.isFinalSpecialization = true
-			umlComponentPackage.packagedElements += umlComponentImplementation
-		} 
-		add correspondence between pcmComponent and umlComponentImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
+	create {
+		val umlComponentImplementation = new uml::Class
+	}
+	update {
+		umlComponentImplementation.name = pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		umlComponentImplementation.isFinalSpecialization = true
+		umlComponentPackage.packagedElements += umlComponentImplementation
+		addCorrespondenceBetween(pcmComponent, umlComponentImplementation, TagLiterals.IPRE__IMPLEMENTATION)
 	}
 }
 
@@ -132,16 +130,14 @@ routine detectOrCreateCorrespondingComponentConstructor(pcm::RepositoryComponent
 		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		call {
-			if (!umlComponentConstructor.isPresent) {
-				val umlComponentConstructorCandidate = umlComponentImplementation.ownedOperations
-						.findFirst[it.name == pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
-				if (umlComponentConstructorCandidate !== null) {
-					addCorrespondenceForExistingComponentConstructor(pcmComponent, umlComponentConstructorCandidate)
-				} else {
-					createCorrespondingComponentConstructor(pcmComponent)
-				}
+	update {
+		if (!umlComponentConstructor.isPresent) {
+			val umlComponentConstructorCandidate = umlComponentImplementation.ownedOperations
+					.findFirst[it.name == pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+			if (umlComponentConstructorCandidate !== null) {
+				addCorrespondenceForExistingComponentConstructor(pcmComponent, umlComponentConstructorCandidate)
+			} else {
+				createCorrespondingComponentConstructor(pcmComponent)
 			}
 		}
 	}
@@ -152,8 +148,8 @@ routine addCorrespondenceForExistingComponentConstructor(pcm::RepositoryComponen
 		require absence of uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
 		require absence of pcm::RepositoryComponent corresponding to umlComponentConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		add correspondence between pcmComponent and umlComponentConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
+	update {
+		addCorrespondenceBetween(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR)
 	}
 }
 
@@ -162,12 +158,13 @@ routine createCorrespondingComponentConstructor(pcm::RepositoryComponent pcmComp
 		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		require absence of uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		val umlComponentConstructor = create uml::Operation and initialize {
-			umlComponentConstructor.name = pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
-			umlComponentImplementation.ownedOperations += umlComponentConstructor
-		}
-		add correspondence between pcmComponent and umlComponentConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
+	create { 
+		val umlComponentConstructor = new uml::Operation
+	}
+	update {
+		umlComponentConstructor.name = pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		umlComponentImplementation.ownedOperations += umlComponentConstructor
+		addCorrespondenceBetween(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR)
 	}
 }
 
@@ -176,10 +173,8 @@ routine moveCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent,
 		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		update umlRepositoryPackage {
-			umlRepositoryPackage.packagedElements += umlComponentPackage
-		}
+	update {
+		umlRepositoryPackage.packagedElements += umlComponentPackage
 	}
 }
 
@@ -194,10 +189,8 @@ routine removeCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		update umlRepositoryPackage {
-			umlRepositoryPackage.packagedElements -= umlComponentPackage
-		}
+	update {
+		umlRepositoryPackage.packagedElements -= umlComponentPackage
 	}
 }
 
@@ -212,11 +205,12 @@ routine deleteCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		remove correspondence between pcmComponent and umlComponentPackage tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
-		remove correspondence between pcmComponent and umlComponentImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
-		remove correspondence between pcmComponent and umlComponentConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
-		delete umlComponentPackage
+	update {
+		deleteObject(umlComponentPackage)
+		removeCorrespondenceBetween(pcmComponent, umlComponentPackage,TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
+		removeCorrespondenceBetween(pcmComponent, umlComponentImplementation, TagLiterals.IPRE__IMPLEMENTATION)
+		removeCorrespondenceBetween(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR)
+		
 	}
 }
 
@@ -232,12 +226,10 @@ routine changeNameOfComponentCorrespondences(pcm::RepositoryComponent pcmCompone
 		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		execute {
-			if (umlComponentPackage.isPresent) umlComponentPackage.get.name = pcmComponent.correspondingPackageName
-			if (umlComponentImplementation.isPresent) umlComponentImplementation.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
-			if (umlComponentConstructor.isPresent) umlComponentConstructor.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
-		}
+	update {
+		if (umlComponentPackage.isPresent) umlComponentPackage.get.name = pcmComponent.correspondingPackageName
+		if (umlComponentImplementation.isPresent) umlComponentImplementation.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		if (umlComponentConstructor.isPresent) umlComponentConstructor.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
@@ -22,10 +22,10 @@ reaction RequiredRoleInserted {
 }
 
 routine insertCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
-	action {
-		call detectOrCreateCorrespondingRequiredConstructorParameter(pcmRequired, pcmIPRE)
-		call detectOrCreateCorrespondingRequiredField(pcmRequired, pcmIPRE)
-		call moveCorrespondingRequiredElements(pcmRequired, pcmIPRE)
+	update {
+		detectOrCreateCorrespondingRequiredConstructorParameter(pcmRequired, pcmIPRE)
+		detectOrCreateCorrespondingRequiredField(pcmRequired, pcmIPRE)
+		moveCorrespondingRequiredElements(pcmRequired, pcmIPRE)
 	}
 }
 
@@ -34,12 +34,10 @@ routine detectOrCreateCorrespondingRequiredConstructorParameter(pcm::OperationRe
 		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.IPRE__CONSTRUCTOR
 		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		call {
-			if (!umlConstructorParameter.isPresent) {
-				// what would be a good criterion for detecting the RequiredConstructorParameter?
-				createCorrespondingRequiredConstructorParameter(pcmRequired, pcmIPRE)
-			}
+	update {
+		if (!umlConstructorParameter.isPresent) {
+			// what would be a good criterion for detecting the RequiredConstructorParameter?
+			createCorrespondingRequiredConstructorParameter(pcmRequired, pcmIPRE)
 		}
 	}
 }
@@ -51,12 +49,13 @@ routine createCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRo
 		val umlRequiredInterface = retrieve optional uml::Interface 
 			corresponding to pcmRequired.requiredInterface__OperationRequiredRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		val umlConstructorParameter = create uml::Parameter and initialize {
-			umlConstructorParameter.name = pcmRequired.entityName
-			umlConstructorParameter.type = umlRequiredInterface.orElse(null) 
-		}
-		add correspondence between pcmRequired and umlConstructorParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+	create {
+		val umlConstructorParameter = new uml::Parameter
+	}
+	update {
+		umlConstructorParameter.name = pcmRequired.entityName
+		umlConstructorParameter.type = umlRequiredInterface.orElse(null) 
+		addCorrespondenceBetween(pcmRequired, umlConstructorParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
 	}
 }
 
@@ -65,12 +64,10 @@ routine detectOrCreateCorrespondingRequiredField(pcm::OperationRequiredRole pcmR
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		call {
-			if (!umlRequiredField.isPresent) {
-				// what would be a good criterion for detecting the RequiredField?
-				createCorrespondingRequiredField(pcmRequired, pcmIPRE)
-			}
+	update {
+		if (!umlRequiredField.isPresent) {
+			// what would be a good criterion for detecting the RequiredField?
+			createCorrespondingRequiredField(pcmRequired, pcmIPRE)
 		}
 	}
 }
@@ -82,12 +79,13 @@ routine createCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired,
 		val umlRequiredInterface = retrieve optional uml::Interface 
 			corresponding to pcmRequired.requiredInterface__OperationRequiredRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		val umlRequiredField = create uml::Property and initialize {
-			umlRequiredField.name = pcmRequired.entityName
-			umlRequiredField.type = umlRequiredInterface.orElse(null) 
-		}
-		add correspondence between pcmRequired and umlRequiredField tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+	create {
+		val umlRequiredField = new uml::Property
+	}
+	update {
+		umlRequiredField.name = pcmRequired.entityName
+		umlRequiredField.type = umlRequiredInterface.orElse(null) 
+		addCorrespondenceBetween(pcmRequired, umlRequiredField, TagLiterals.REQUIRED_ROLE__PROPERTY)
 	}
 }
 
@@ -99,11 +97,9 @@ routine moveCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		update umlComponentImpl {
-			umlComponentConstructor.ownedParameters += umlConstructorParameter
-			umlComponentImpl.ownedAttributes += umlRequiredField
-		}
+	update {
+		umlComponentConstructor.ownedParameters += umlConstructorParameter
+		umlComponentImpl.ownedAttributes += umlRequiredField
 	}
 }
 
@@ -121,13 +117,11 @@ routine removeCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequir
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		execute {
-			if (umlConstructorParameter.isPresent) 	
-				umlComponentConstructor.ownedParameters -= umlConstructorParameter.get
-			if (umlRequiredField.isPresent)
-				umlComponentImpl.ownedAttributes -= umlRequiredField.get
-		}
+	update {
+		if (umlConstructorParameter.isPresent) 	
+			umlComponentConstructor.ownedParameters -= umlConstructorParameter.get
+		if (umlRequiredField.isPresent)
+			umlComponentImpl.ownedAttributes -= umlRequiredField.get
 	}
 }
 
@@ -137,9 +131,9 @@ reaction RequiredRoleDeleted {
 }
 
 routine deleteCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired) {
-	action {
-		call deleteCorrespondingRequiredConstructorParameter(pcmRequired)
-		call deleteCorrespondingRequiredField(pcmRequired)
+	update {
+		deleteCorrespondingRequiredConstructorParameter(pcmRequired)
+		deleteCorrespondingRequiredField(pcmRequired)
 	}
 }
 
@@ -147,9 +141,9 @@ routine deleteCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRo
 	match {
 		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		remove correspondence between pcmRequired and umlConstructorParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		delete umlConstructorParameter
+	update {
+		deleteObject(umlConstructorParameter)
+		removeCorrespondenceBetween(pcmRequired, umlConstructorParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
 	}
 }
 
@@ -157,9 +151,9 @@ routine deleteCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired)
 	match {
 		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		remove correspondence between pcmRequired and umlRequiredField tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
-		delete umlRequiredField
+	update {
+		deleteObject(umlRequiredField)
+		removeCorrespondenceBetween(pcmRequired, umlRequiredField, TagLiterals.REQUIRED_ROLE__PROPERTY)
 	}
 }
 
@@ -174,11 +168,9 @@ routine changeNameOfCorrespondingRequiredElements(pcm::OperationRequiredRole pcm
 		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		execute {
-			umlConstructorParameter.name = newName
-			umlRequiredField.name = newName
-		}
+	update {
+		umlConstructorParameter.name = newName
+		umlRequiredField.name = newName
 	}
 }
 
@@ -195,11 +187,9 @@ routine changeTypeOfCorrespondingRequiredElements(pcm::OperationRequiredRole pcm
 		
 		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		execute {
-			umlConstructorParameter.type = umlInterface.orElse(null)
-			umlRequiredField.type = umlInterface.orElse(null)
-		}
+	update {
+		umlConstructorParameter.type = umlInterface.orElse(null)
+		umlRequiredField.type = umlInterface.orElse(null)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
@@ -142,7 +142,7 @@ routine deleteCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRo
 		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
 	update {
-		deleteObject(umlConstructorParameter)
+		removeObject(umlConstructorParameter)
 		removeCorrespondenceBetween(pcmRequired, umlConstructorParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
 	}
 }
@@ -152,7 +152,7 @@ routine deleteCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired)
 		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
 	update {
-		deleteObject(umlRequiredField)
+		removeObject(umlRequiredField)
 		removeCorrespondenceBetween(pcmRequired, umlRequiredField, TagLiterals.REQUIRED_ROLE__PROPERTY)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
@@ -26,9 +26,9 @@ reaction SignatureInsertedInInterface {
 }
 
 routine insertCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
-	action{
-		call detectOrCreateOperationCandidate(pcmSignature, pcmInterface)
-		call moveCorrespondingOperation(pcmSignature, pcmInterface)
+	update {
+		detectOrCreateOperationCandidate(pcmSignature, pcmInterface)
+		moveCorrespondingOperation(pcmSignature, pcmInterface)
 		
 	}
 }
@@ -39,18 +39,16 @@ routine detectOrCreateOperationCandidate(pcm::OperationSignature pcmSignature, p
 		val umlOperation = retrieve optional uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
 	}
-	action {
-		call {
-			if (umlOperation.isPresent) {
+	update {
+		if (umlOperation.isPresent) {
+			detectOrCreateReturnParameterCandidate(pcmSignature)
+		} else {
+			val umlOperationCandidate = umlInterface.ownedOperations.findFirst[it.name == pcmSignature.entityName]
+			if (umlOperationCandidate !== null) {
+				attemptAddingCorrespondenceForExistingOperationCandidate(pcmSignature, pcmInterface, umlOperationCandidate)
 				detectOrCreateReturnParameterCandidate(pcmSignature)
 			} else {
-				val umlOperationCandidate = umlInterface.ownedOperations.findFirst[it.name == pcmSignature.entityName]
-				if (umlOperationCandidate !== null) {
-					attemptAddingCorrespondenceForExistingOperationCandidate(pcmSignature, pcmInterface, umlOperationCandidate)
-					detectOrCreateReturnParameterCandidate(pcmSignature)
-				} else {
-					createCorrespondingOperation(pcmSignature, pcmInterface)
-				}
+				createCorrespondingOperation(pcmSignature, pcmInterface)
 			}
 		}
 	}
@@ -61,17 +59,15 @@ routine detectOrCreateReturnParameterCandidate(pcm::OperationSignature pcmSignat
 		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
 	}
-	action {
-		call {
-			if (umlReturnParam.isPresent) {
-				return // do nothing, because the correspondences are already established
+	update {
+		if (umlReturnParam.isPresent) {
+			return // do nothing, because the correspondences are already established
+		} else {
+			val umlReturnParamCandidate = umlOperation.ownedParameters.findFirst[it.direction === ParameterDirectionKind.RETURN_LITERAL]
+			if (umlReturnParamCandidate !== null) {
+				attemptAddingCorrespondenceForExistingReturnParamCandidate(pcmSignature, umlReturnParamCandidate)
 			} else {
-				val umlReturnParamCandidate = umlOperation.ownedParameters.findFirst[it.direction === ParameterDirectionKind.RETURN_LITERAL]
-				if (umlReturnParamCandidate !== null) {
-					attemptAddingCorrespondenceForExistingReturnParamCandidate(pcmSignature, umlReturnParamCandidate)
-				} else {
-					createCorrespondingReturnParameter(pcmSignature)
-				}
+				createCorrespondingReturnParameter(pcmSignature)
 			}
 		}
 	}
@@ -87,8 +83,8 @@ routine attemptAddingCorrespondenceForExistingOperationCandidate(
 		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		require absence of pcm::OperationSignature corresponding to umlOperationCandidate tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		add correspondence between pcmSignature and umlOperationCandidate tagged with TagLiterals.SIGNATURE__OPERATION
+	update {
+		addCorrespondenceBetween(pcmSignature, umlOperationCandidate, TagLiterals.SIGNATURE__OPERATION)
 	}
 }
 
@@ -101,11 +97,9 @@ routine attemptAddingCorrespondenceForExistingReturnParamCandidate(
 		require absence of uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
 		require absence of pcm::OperationSignature corresponding to umlReturnParamCandidate tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
 	}
-	action {
-		update umlReturnParamCandidate {
-			umlReturnParamCandidate.name = DefaultLiterals.RETURN_PARAM_NAME
-		}
-		add correspondence between pcmSignature and umlReturnParamCandidate tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
+	update {
+		umlReturnParamCandidate.name = DefaultLiterals.RETURN_PARAM_NAME
+		addCorrespondenceBetween(pcmSignature, umlReturnParamCandidate, TagLiterals.SIGNATURE__RETURN_PARAMETER)
 	}
 }
 
@@ -114,13 +108,13 @@ routine createCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		val umlOperation = create uml::Operation and initialize {
-			umlOperation.name = pcmSignature.entityName
-//			umlInterface.ownedOperations += umlOperation // done in move-routine
-		}
-		add correspondence between pcmSignature and umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
-		call createCorrespondingReturnParameter(pcmSignature)
+	create {
+		val umlOperation = new uml::Operation
+	}
+	update {
+		umlOperation.name = pcmSignature.entityName
+		addCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
+		createCorrespondingReturnParameter(pcmSignature)
 	}
 }
 
@@ -129,14 +123,15 @@ routine createCorrespondingReturnParameter(pcm::OperationSignature pcmSignature)
 		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		require absence of uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
 	}
-	action {
-		val umlReturnParam = create uml::Parameter and initialize {
-			umlReturnParam.direction = ParameterDirectionKind.RETURN_LITERAL
-			umlReturnParam.name = DefaultLiterals.RETURN_PARAM_NAME // the name should be set, so that its TUID is distinct and the object is not confused with new instances
-			umlOperation.ownedParameters += umlReturnParam
-		}
-		add correspondence between pcmSignature and umlReturnParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
-		call changeTypeOfCorrespondingReturnParameter(pcmSignature, pcmSignature.returnType__OperationSignature)
+	create {
+		val umlReturnParam = new uml::Parameter
+	}
+	update {
+		umlReturnParam.direction = ParameterDirectionKind.RETURN_LITERAL
+		umlReturnParam.name = DefaultLiterals.RETURN_PARAM_NAME // the name should be set, so that its TUID is distinct, the object is not confused with new instances
+		umlOperation.ownedParameters += umlReturnParam
+		addCorrespondenceBetween(pcmSignature, umlReturnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER)
+		changeTypeOfCorrespondingReturnParameter(pcmSignature, pcmSignature.returnType__OperationSignature)
 	}
 }
 
@@ -145,10 +140,8 @@ routine moveCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::Op
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		update umlInterface {
-			umlInterface.ownedOperations += umlOperation
-		}
+	update {
+		umlInterface.ownedOperations += umlOperation
 	}
 }
 
@@ -163,10 +156,8 @@ routine removeCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		update umlInterface {
-			umlInterface.ownedOperations -= umlOperation
-		}
+	update {
+		umlInterface.ownedOperations -= umlOperation
 	}
 }
 
@@ -180,10 +171,10 @@ routine deleteCorrespondingOperation(pcm::OperationSignature pcmSignature) {
 		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 		val umlReturnParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
 	}
-	action {
-		remove correspondence between pcmSignature and umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
-		remove correspondence between pcmSignature and umlReturnParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
-		delete umlOperation
+	update {
+		deleteObject(umlOperation)
+		removeCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
+		removeCorrespondenceBetween(pcmSignature, umlReturnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER)
 	}
 }
 
@@ -197,10 +188,8 @@ routine renameCorrespondingOperation(pcm::OperationSignature pcmSignature, Strin
 	match {
 		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		update umlOperation {
-			umlOperation.name = newName
-		}
+	update {
+		umlOperation.name = newName
 	}
 }
 
@@ -214,8 +203,8 @@ routine changeTypeOfCorrespondingReturnParameter(pcm::OperationSignature pcmSign
 	match {
 		val umlParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
 	}
-	action {
-		call pcmDataTypePropagationReactions.setUmlParameterType(pcmDataType, umlParam)
+	update {
+		pcmDataTypePropagationReactions.setUmlParameterType(pcmDataType, umlParam)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
@@ -172,7 +172,7 @@ routine deleteCorrespondingOperation(pcm::OperationSignature pcmSignature) {
 		val umlReturnParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
 	}
 	update {
-		deleteObject(umlOperation)
+		removeObject(umlOperation)
 		removeCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
 		removeCorrespondenceBetween(pcmSignature, umlReturnParam, TagLiterals.SIGNATURE__RETURN_PARAMETER)
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
@@ -27,7 +27,7 @@ import routines sharedRoutines // for UML model handling
 
 reaction SystemCreated {
 	after element pcm::System inserted as root
-	call{
+	call {
 	    addSystemCorrespondence(newValue)
 		ensureUmlModelExists(newValue)
 		createOrFindCorrespondingSystemPackage(newValue)
@@ -37,8 +37,8 @@ reaction SystemCreated {
 }
 
 routine addSystemCorrespondence(pcm::System pcmSystem) {
-    action { // required to enable find-or-create-pattern:
-        add correspondence between pcmSystem and SystemPackage.Literals.SYSTEM
+    update { // required to enable find-or-create-pattern:
+        addCorrespondenceBetween(pcmSystem, SystemPackage.Literals.SYSTEM)
     }
 }
 
@@ -47,21 +47,19 @@ routine createOrFindCorrespondingSystemPackage(pcm::System pcmSystem) {
 		require absence of uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 		 val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 	}
-	action {
-		call {
-			var foundPackage = findUmlPackage(umlModel, pcmSystem.correspondingPackageName)
-			if(foundPackage === null) {
-				createCorrespondingSystemPackage(pcmSystem, umlModel)
-			} else {
-				addSystemPackageCorrespondence(pcmSystem, foundPackage)
-			}
+	update {
+		var foundPackage = findUmlPackage(umlModel, pcmSystem.correspondingPackageName)
+		if(foundPackage === null) {
+			createCorrespondingSystemPackage(pcmSystem, umlModel)
+		} else {
+			addSystemPackageCorrespondence(pcmSystem, foundPackage)
 		}
 	}
 }
 
 routine addSystemPackageCorrespondence(pcm::System pcmSystem, uml::Package umlPackage) {
-	action {
-		add correspondence between pcmSystem and umlPackage tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+	update {
+		addCorrespondenceBetween(pcmSystem, umlPackage, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
 	}
 }
 
@@ -69,12 +67,13 @@ routine createCorrespondingSystemPackage(pcm::System pcmSystem, uml::Model umlRo
 	match {
 		require absence of uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
-	action {
-		val umlSystemPackage = create uml::Package and initialize{
-			umlSystemPackage.name = pcmSystem.correspondingPackageName
-			umlRootModel.nestedPackages += umlSystemPackage
-		}
-		call addSystemPackageCorrespondence(pcmSystem, umlSystemPackage)
+	create {
+		val umlSystemPackage = new uml::Package
+	}
+	update {
+		umlSystemPackage.name = pcmSystem.correspondingPackageName
+		umlRootModel.nestedPackages += umlSystemPackage
+		addSystemPackageCorrespondence(pcmSystem, umlSystemPackage)
 	}
 }
 
@@ -84,15 +83,13 @@ routine detectOrCreateCorrespondingSystemImplementation(pcm::System pcmSystem) {
 		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		call {
-			val umlSystemImplementationCandidate = umlSystemPackage.packagedElements
-					.filter(Class).findFirst[it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
-			if (umlSystemImplementationCandidate !== null) {
-				addCorrespondenceForExistingSystemImplementation(pcmSystem, umlSystemImplementationCandidate)
-			} else {
-				createCorrespondingSystemImplementation(pcmSystem)
-			}
+	update {
+		val umlSystemImplementationCandidate = umlSystemPackage.packagedElements
+				.filter(Class).findFirst[it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+		if (umlSystemImplementationCandidate !== null) {
+			addCorrespondenceForExistingSystemImplementation(pcmSystem, umlSystemImplementationCandidate)
+		} else {
+			createCorrespondingSystemImplementation(pcmSystem)
 		}
 	}
 }
@@ -102,8 +99,8 @@ routine addCorrespondenceForExistingSystemImplementation(pcm::System pcmSystem, 
 		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 		require absence of pcm::System corresponding to umlSystemImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		add correspondence between pcmSystem and umlSystemImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
+	update {
+		addCorrespondenceBetween(pcmSystem, umlSystemImplementation, TagLiterals.IPRE__IMPLEMENTATION)
 	}
 }
 
@@ -112,13 +109,14 @@ routine createCorrespondingSystemImplementation(pcm::System pcmSystem) {
 		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		val umlSystemImplementation = create uml::Class and initialize {
-			umlSystemImplementation.name = pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
-			umlSystemImplementation.isFinalSpecialization = true
-			umlSystemPackage.packagedElements += umlSystemImplementation
-		}
-		add correspondence between pcmSystem and umlSystemImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
+	create {
+		val umlSystemImplementation = new uml::Class
+	}
+	update {
+		umlSystemImplementation.name = pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		umlSystemImplementation.isFinalSpecialization = true
+		umlSystemPackage.packagedElements += umlSystemImplementation
+		addCorrespondenceBetween(pcmSystem, umlSystemImplementation, TagLiterals.IPRE__IMPLEMENTATION)
 	}
 }
 
@@ -127,15 +125,13 @@ routine detectOrCreateCorrespondingSystemConstructor(pcm::System pcmSystem) {
 		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 		require absence of uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		call {
-			val umlSystemConstructorCandidate = umlSystemImplementation.ownedOperations
-					.findFirst[it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
-			if (umlSystemConstructorCandidate !== null) {
-				addCorrespondenceForExistingSystemConstructor(pcmSystem, umlSystemConstructorCandidate)
-			} else {
-				createCorrespondingSystemConstructor(pcmSystem)
-			}
+	update {
+		val umlSystemConstructorCandidate = umlSystemImplementation.ownedOperations
+				.findFirst[it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+		if (umlSystemConstructorCandidate !== null) {
+			addCorrespondenceForExistingSystemConstructor(pcmSystem, umlSystemConstructorCandidate)
+		} else {
+			createCorrespondingSystemConstructor(pcmSystem)
 		}
 	}
 }
@@ -145,8 +141,8 @@ routine addCorrespondenceForExistingSystemConstructor(pcm::System pcmSystem, uml
 		require absence of uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
 		require absence of pcm::System corresponding to umlSystemConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		add correspondence between pcmSystem and umlSystemConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
+	update {
+		addCorrespondenceBetween(pcmSystem, umlSystemConstructor, TagLiterals.IPRE__CONSTRUCTOR)
 	}
 }
 
@@ -155,12 +151,13 @@ routine createCorrespondingSystemConstructor(pcm::System pcmSystem) {
 		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 		require absence of uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		val umlSystemConstructor = create uml::Operation and initialize {
-			umlSystemConstructor.name = pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
-			umlSystemImplementation.ownedOperations += umlSystemConstructor
-		}
-		add correspondence between pcmSystem and umlSystemConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
+	create {
+		val umlSystemConstructor = new uml::Operation
+	}
+	update {
+		umlSystemConstructor.name = pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		umlSystemImplementation.ownedOperations += umlSystemConstructor
+		addCorrespondenceBetween(pcmSystem, umlSystemConstructor, TagLiterals.IPRE__CONSTRUCTOR)
 	}
 }
 
@@ -177,9 +174,9 @@ routine deleteCorrespondenceToSystemPackage(pcm::System pcmSystem) {
 	match {
 		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
-	action {
-		remove correspondence between pcmSystem and umlSystemPackage tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
-		delete umlSystemPackage
+	update {
+		deleteObject(umlSystemPackage)
+		removeCorrespondenceBetween(pcmSystem, umlSystemPackage, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
 	}
 }
 
@@ -187,8 +184,8 @@ routine deleteCorrespondenceToSystemImplementation(pcm::System pcmSystem) {
 	match {
 		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		remove correspondence between pcmSystem and umlSystemImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
+	update {
+		removeCorrespondenceBetween(pcmSystem, umlSystemImplementation, TagLiterals.IPRE__IMPLEMENTATION)
 	}
 }
 
@@ -196,8 +193,8 @@ routine deleteCorrespondenceToSystemConstructor(pcm::System pcmSystem) {
 	match {
 		val umlSystemConstructor = retrieve uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		remove correspondence between pcmSystem and umlSystemConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
+	update {
+		removeCorrespondenceBetween(pcmSystem, umlSystemConstructor, TagLiterals.IPRE__CONSTRUCTOR)
 	}
 }
 
@@ -213,12 +210,10 @@ routine changeNameOfSystemCorrespondences(pcm::System pcmSystem, String newName)
 		val umlSystemImplementation = retrieve optional uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val umlSystemConstructor = retrieve optional uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		execute{
-			umlSystemPackage.ifPresent[name = pcmSystem.correspondingPackageName]
-			umlSystemImplementation.ifPresent[name = newName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
-			umlSystemConstructor.ifPresent[name = newName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
-		}
+	update {
+		umlSystemPackage.ifPresent[name = pcmSystem.correspondingPackageName]
+		umlSystemImplementation.ifPresent[name = newName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+		umlSystemConstructor.ifPresent[name = newName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
@@ -175,7 +175,7 @@ routine deleteCorrespondenceToSystemPackage(pcm::System pcmSystem) {
 		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
-		deleteObject(umlSystemPackage)
+		removeObject(umlSystemPackage)
 		removeCorrespondenceBetween(pcmSystem, umlSystemPackage, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/SharedRoutines.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/SharedRoutines.reactions
@@ -15,32 +15,29 @@ routine ensureUmlModelExists(EObject source) {
     match {
         require absence of uml::Model corresponding to UMLPackage.Literals.MODEL
     }
-    action {
-        call {
-            var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_MODEL_PATH).windowModality(WindowModality.MODAL).startInteraction
-            if (relativeModelPath.nullOrEmpty) {
-                relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.UML_MODEL_FILE_NAME + DefaultLiterals.UML_EXTENSION
-            } else if (!relativeModelPath.endsWith(DefaultLiterals.UML_EXTENSION)) {
-                relativeModelPath += DefaultLiterals.UML_EXTENSION
-            }
-            var umlRootModel = loadPersistedModelFromSource(relativeModelPath, source)
-            umlRootModel.ifPresent[ensureUmlModelCorrespondenceExists]
-            if(umlRootModel.isEmpty) {
-                createUmlModel(source, relativeModelPath)
-            }
+    update {
+        var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_MODEL_PATH).windowModality(WindowModality.MODAL).startInteraction
+        if (relativeModelPath.nullOrEmpty) {
+            relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.UML_MODEL_FILE_NAME + DefaultLiterals.UML_EXTENSION
+        } else if (!relativeModelPath.endsWith(DefaultLiterals.UML_EXTENSION)) {
+            relativeModelPath += DefaultLiterals.UML_EXTENSION
+        }
+        var umlRootModel = loadPersistedModelFromSource(relativeModelPath, source)
+        umlRootModel.ifPresent[ensureUmlModelCorrespondenceExists]
+        if(umlRootModel.isEmpty) {
+            createUmlModel(source, relativeModelPath)
         }
     }
 }
 
-routine createUmlModel(EObject source, String relativeModelPath) { 
-    action {
-        val umlRootModel = create uml::Model and initialize {
-            umlRootModel.name = DefaultLiterals.ROOT_MODEL_NAME;
-        }
-        call {
-            persistProjectRelative(source, umlRootModel, relativeModelPath)
-            ensureUmlModelCorrespondenceExists(umlRootModel)
-        }
+routine createUmlModel(EObject source, String relativeModelPath) {
+	create {
+		val umlRootModel = new uml::Model
+	} 
+    update {
+    	umlRootModel.name = DefaultLiterals.ROOT_MODEL_NAME;
+		persistProjectRelative(source, umlRootModel, relativeModelPath)
+        ensureUmlModelCorrespondenceExists(umlRootModel)
     }
 }
 
@@ -49,7 +46,7 @@ routine ensureUmlModelCorrespondenceExists(uml::Model newModel) {
         val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
         check !alreadyCorrespondingModels.contains(newModel)
     }
-    action {
-        add correspondence between UMLPackage.Literals.MODEL and newModel
+    update {
+        addCorrespondenceBetween(UMLPackage.Literals.MODEL, newModel)
     }
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
@@ -32,16 +32,14 @@ routine insertCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 		val pcmCompositeComponent = retrieve optional pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlProperty.type tagged with TagLiterals.IPRE__IMPLEMENTATION 
 	}
-	action {
-		call {
-			if (pcmCompositeComponent.isPresent && (pcmInnerComponent.isPresent || umlProperty.type === null) // allow 'null' for uninitialized references
-			) {
-				detectOrCreateCorrespondingAssemblyContext(umlProperty, umlComponent)
-				moveCorrespondingAssemblyContext(umlProperty, umlComponent)
-			} else {
-				// not a matching context -> delete correspondence, if it exists
-				deleteCorrespondingAssemblyContext(umlProperty)
-			}
+	update {
+		if (pcmCompositeComponent.isPresent && (pcmInnerComponent.isPresent || umlProperty.type === null) // allow 'null' for uninitialized references
+		) {
+			detectOrCreateCorrespondingAssemblyContext(umlProperty, umlComponent)
+			moveCorrespondingAssemblyContext(umlProperty, umlComponent)
+		} else {
+			// not a matching context -> delete correspondence, if it exists
+			deleteCorrespondingAssemblyContext(umlProperty)
 		}
 	}
 }
@@ -52,14 +50,12 @@ routine detectOrCreateCorrespondingAssemblyContext(uml::Property umlProperty, um
 		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.type tagged with TagLiterals.IPRE__IMPLEMENTATION
 		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		call {
-			val pcmAssemblyContextCandidate = pcmCompositeComponent.assemblyContexts__ComposedStructure.findFirst[entityName == umlProperty.name]
-			if (pcmAssemblyContextCandidate === null) {
-				createCorrespondingAssemblyContext(umlProperty, umlComponent)
-			} else {
-				addCorrespondenceForExistingAssemblyContext(umlProperty, pcmAssemblyContextCandidate)
-			}
+	update {
+		val pcmAssemblyContextCandidate = pcmCompositeComponent.assemblyContexts__ComposedStructure.findFirst[entityName == umlProperty.name]
+		if (pcmAssemblyContextCandidate === null) {
+			createCorrespondingAssemblyContext(umlProperty, umlComponent)
+		} else {
+			addCorrespondenceForExistingAssemblyContext(umlProperty, pcmAssemblyContextCandidate)
 		}
 	}
 }
@@ -69,8 +65,8 @@ routine addCorrespondenceForExistingAssemblyContext(uml::Property umlProperty, p
 		require absence of uml::Property corresponding to pcmAssemblyContext tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		add correspondence between pcmAssemblyContext and umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+	update {
+		addCorrespondenceBetween(pcmAssemblyContext, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
 	}
 }
 
@@ -80,13 +76,14 @@ routine createCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.type tagged with TagLiterals.IPRE__IMPLEMENTATION
 		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		val pcmAssemblyContext = create pcm::AssemblyContext and initialize {
-			pcmAssemblyContext.encapsulatedComponent__AssemblyContext = pcmInnerComponent
-			pcmCompositeComponent.assemblyContexts__ComposedStructure += pcmAssemblyContext
-		}
-		add correspondence between pcmAssemblyContext and umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		call changeNameOfCorrespondingAssemblyContext(umlProperty, umlProperty.name)
+	create {
+		val pcmAssemblyContext = new pcm::AssemblyContext
+	}
+	update {
+		pcmAssemblyContext.encapsulatedComponent__AssemblyContext = pcmInnerComponent
+		pcmCompositeComponent.assemblyContexts__ComposedStructure += pcmAssemblyContext
+		addCorrespondenceBetween(pcmAssemblyContext, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
+		changeNameOfCorrespondingAssemblyContext(umlProperty, umlProperty.name)
 	}
 }
 
@@ -95,10 +92,8 @@ routine moveCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class u
 		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		update pcmCompositeComponent {
-			pcmCompositeComponent.assemblyContexts__ComposedStructure += pcmAssemblyContext
-		}
+	update {
+		pcmCompositeComponent.assemblyContexts__ComposedStructure += pcmAssemblyContext
 	}
 }
 
@@ -113,10 +108,8 @@ routine removeCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		update pcmCompositeComponent {
-			pcmCompositeComponent.assemblyContexts__ComposedStructure -= pcmAssemblyContext
-		}
+	update {
+		pcmCompositeComponent.assemblyContexts__ComposedStructure -= pcmAssemblyContext
 	}
 }
 
@@ -129,9 +122,9 @@ routine deleteCorrespondingAssemblyContext(uml::Property umlProperty) {
 	match {
 		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		remove correspondence between pcmAssemblyContext and umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		delete pcmAssemblyContext
+	update {
+		removeCorrespondenceBetween(pcmAssemblyContext, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
+		deleteObject(pcmAssemblyContext)
 	}
 }
 
@@ -145,10 +138,8 @@ routine changeNameOfCorrespondingAssemblyContext(uml::Property umlProperty, Stri
 	match {
 		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 	}
-	action {
-		update pcmAssemblyContext {
-			pcmAssemblyContext.entityName = newName
-		}
+	update {
+		pcmAssemblyContext.entityName = newName
 	}
 }
 
@@ -164,20 +155,18 @@ routine changeTypeOfCorrespondingAssemblyContext(uml::Property umlProperty, uml:
 		val pcmAssemblyContext = retrieve optional pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 		val pcmNewInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlNewInnerComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		execute {
-			if (!pcmAssemblyContext.isPresent && pcmNewInnerComponent.isPresent) {
-				createCorrespondingAssemblyContext(umlProperty, umlProperty.owner as Class)
-			} else if (pcmAssemblyContext.isPresent && pcmNewInnerComponent.isPresent) {
-				pcmAssemblyContext.get.encapsulatedComponent__AssemblyContext = pcmNewInnerComponent.get
-			} else if(pcmAssemblyContext.isPresent && pcmNewInnerComponent === null) {
-				//might be a transitional state -> keep correspondence, but synchronize 'null'
-				pcmAssemblyContext.get.encapsulatedComponent__AssemblyContext = null
-			} else {
-				logger.warn("The type of a uml::Property in a pcm::AssemblyContext ~ uml::Property correspondence"
-							+ "has been set to a non-RepositoryComponent type. This is against convention and the corresponding AssemblyContext will be deleted.")
-				deleteCorrespondingAssemblyContext(umlProperty)
-			}
+	update {
+		if (!pcmAssemblyContext.isPresent && pcmNewInnerComponent.isPresent) {
+			createCorrespondingAssemblyContext(umlProperty, umlProperty.owner as Class)
+		} else if (pcmAssemblyContext.isPresent && pcmNewInnerComponent.isPresent) {
+			pcmAssemblyContext.get.encapsulatedComponent__AssemblyContext = pcmNewInnerComponent.get
+		} else if(pcmAssemblyContext.isPresent && pcmNewInnerComponent === null) {
+			//might be a transitional state -> keep correspondence, but synchronize 'null'
+			pcmAssemblyContext.get.encapsulatedComponent__AssemblyContext = null
+		} else {
+			logger.warn("The type of a uml::Property in a pcm::AssemblyContext ~ uml::Property correspondence"
+						+ "has been set to a non-RepositoryComponent type. This is against convention and the corresponding AssemblyContext will be deleted.")
+			deleteCorrespondingAssemblyContext(umlProperty)
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
@@ -124,7 +124,7 @@ routine deleteCorrespondingAssemblyContext(uml::Property umlProperty) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmAssemblyContext, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
-		deleteObject(pcmAssemblyContext)
+		removeObject(pcmAssemblyContext)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
@@ -30,14 +30,12 @@ routine insertCorrespondingCompositeDataType(uml::Class umlClass, uml::Package u
 	match {
 		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
-	action {
-		call {
-			if (pcmRepository.isPresent) {
-				detectOrCreateCorrespondingCompositeDataType(umlClass, umlPackage)
-				moveCorrespondingCompositeDataType(umlClass, umlPackage)
-			} else {
-				deleteCorrespondingCompositeDataType(umlClass)
-			}
+	update {
+		if (pcmRepository.isPresent) {
+			detectOrCreateCorrespondingCompositeDataType(umlClass, umlPackage)
+			moveCorrespondingCompositeDataType(umlClass, umlPackage)
+		} else {
+			deleteCorrespondingCompositeDataType(umlClass)
 		}
 	}
 }
@@ -47,16 +45,14 @@ routine detectOrCreateCorrespondingCompositeDataType(uml::Class umlClass, uml::P
 		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		call {
-			val candidates = pcmRepository.dataTypes__Repository.filter(CompositeDataType).filter[type | type.entityName == umlClass.name]
-			switch (candidates.size) {
-				case 0: createCorrespondingCompositeDataType(umlClass, umlPackage)
-				case 1: addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
-				default: {
-					logger.warn(DefaultLiterals.WARNING_MULTIPLE_COMPOSITE_DATA_TYPE_CANDIDATES + umlClass)
-					addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
-				}
+	update {
+		val candidates = pcmRepository.dataTypes__Repository.filter(CompositeDataType).filter[type | type.entityName == umlClass.name]
+		switch (candidates.size) {
+			case 0: createCorrespondingCompositeDataType(umlClass, umlPackage)
+			case 1: addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
+			default: {
+				logger.warn(DefaultLiterals.WARNING_MULTIPLE_COMPOSITE_DATA_TYPE_CANDIDATES + umlClass)
+				addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
 			}
 		}
 	}
@@ -66,11 +62,12 @@ routine createCorrespondingCompositeDataType(uml::Class umlClass, uml::Package u
 	match {
 		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
-	action {
-		val pcmCompositeType = create pcm::CompositeDataType and initialize {
-			pcmCompositeType.entityName = umlClass.name
-		}
-		add correspondence between pcmCompositeType and umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+	create {
+		val pcmCompositeType = new pcm::CompositeDataType
+	}
+	update {
+		pcmCompositeType.entityName = umlClass.name
+		addCorrespondenceBetween(pcmCompositeType, umlClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
 	}
 }
 
@@ -79,8 +76,8 @@ routine addCorrespondenceForExistingCompositeDataType(pcm::CompositeDataType pcm
 		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		require absence of uml::Class corresponding to pcmCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action{
-		add correspondence between pcmCompositeType and umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+	update {
+		addCorrespondenceBetween(pcmCompositeType, umlClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
 	}
 }
 
@@ -89,10 +86,8 @@ routine moveCorrespondingCompositeDataType(uml::Class umlClass, uml::Package uml
 		val pcmCompositeType = retrieve asserted pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
-	action {
-		update pcmCompositeType {
-			pcmRepository.dataTypes__Repository += pcmCompositeType
-		}
+	update {
+		pcmRepository.dataTypes__Repository += pcmCompositeType
 	}
 }
 
@@ -107,10 +102,8 @@ routine removeCorrespondingCompositeType(uml::Class umlClass, uml::Package umlPa
 		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
-	action {
-		update pcmCompositeType {
-			pcmRepository.dataTypes__Repository -= pcmCompositeType
-		}
+	update {
+		pcmRepository.dataTypes__Repository -= pcmCompositeType
 	}
 }
 
@@ -123,9 +116,9 @@ routine deleteCorrespondingCompositeDataType(uml::Class umlClass) {
 	match {
 		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		remove correspondence between pcmCompositeType and umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		delete pcmCompositeType
+	update {
+		removeCorrespondenceBetween(pcmCompositeType, umlClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
+		deleteObject(pcmCompositeType)
 	}
 }
 
@@ -139,10 +132,8 @@ routine changeNameOfCorrespondingCompositeDataType(uml::Class umlClass, String n
 	match {
 		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		update pcmCompositeType {
-			pcmCompositeType.entityName = newName
-		}
+	update {
+		pcmCompositeType.entityName = newName
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
@@ -118,7 +118,7 @@ routine deleteCorrespondingCompositeDataType(uml::Class umlClass) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmCompositeType, umlClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
-		deleteObject(pcmCompositeType)
+		removeObject(pcmCompositeType)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
@@ -27,11 +27,9 @@ routine addCompositeDatatypeParent(uml::Class umlClass, uml::Classifier umlNewPa
 		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlNewParent tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		execute {
-			if (!pcmCompositeDataType.parentType_CompositeDataType.contains(pcmParentCompositeDataType)) {
-				pcmCompositeDataType.parentType_CompositeDataType += pcmParentCompositeDataType
-			}
+	update {
+		if (!pcmCompositeDataType.parentType_CompositeDataType.contains(pcmParentCompositeDataType)) {
+			pcmCompositeDataType.parentType_CompositeDataType += pcmParentCompositeDataType
 		}
 	}
 }
@@ -47,11 +45,9 @@ routine removeCompositeDatatypeParent(uml::Class umlClass, uml::Classifier umlOl
 		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlOldParent tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		execute {
-			if (pcmCompositeDataType.parentType_CompositeDataType.contains(pcmParentCompositeDataType)) {
-				pcmCompositeDataType.parentType_CompositeDataType -= pcmParentCompositeDataType
-			}
+	update {
+		if (pcmCompositeDataType.parentType_CompositeDataType.contains(pcmParentCompositeDataType)) {
+			pcmCompositeDataType.parentType_CompositeDataType -= pcmParentCompositeDataType
 		}
 	}
 }
@@ -67,12 +63,10 @@ routine replaceCollectionDatatypeParent(uml::Generalization gen, uml::Classifier
 	match {
 		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to gen.specific tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
-	action {
-		call {
-			removeCompositeDatatypeParent(gen.specific as Class, umlOldParent)
-			if (gen.general === umlNewParent) { // delayed validity check
-				addCompositeDatatypeParent(gen.specific as Class, umlNewParent)
-			}
+	update {
+		removeCompositeDatatypeParent(gen.specific as Class, umlOldParent)
+		if (gen.general === umlNewParent) { // delayed validity check
+			addCompositeDatatypeParent(gen.specific as Class, umlNewParent)
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREClass.reactions
@@ -30,8 +30,8 @@ routine warnUserAboutImplRemoveIfIPRECorrespondenceExists(uml::Class umlClass, u
 	match {
 		val pcmRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to umlClass tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		execute logger.warn(DefaultLiterals.WARNING_IPRE_IMPLEMENTATION_REMOVED + umlClass)
+	update {
+		logger.warn(DefaultLiterals.WARNING_IPRE_IMPLEMENTATION_REMOVED + umlClass)
 	}
 }
 
@@ -45,13 +45,11 @@ routine changeNameOfCorrespondingIPRE_Implementation(uml::Class umlClass, String
 	match {
 		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlClass tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
-	action {
-		update pcmIPRE {
-			if (newName.endsWith(DefaultLiterals.IMPLEMENTATION_SUFFIX)) {
-				pcmIPRE.entityName = newName.substring(0, newName.length - DefaultLiterals.IMPLEMENTATION_SUFFIX.length).toFirstUpper
-			} else {
-				pcmIPRE.entityName = newName
-			}
+	update {
+		if (newName.endsWith(DefaultLiterals.IMPLEMENTATION_SUFFIX)) {
+			pcmIPRE.entityName = newName.substring(0, newName.length - DefaultLiterals.IMPLEMENTATION_SUFFIX.length).toFirstUpper
+		} else {
+			pcmIPRE.entityName = newName
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREConstructorOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREConstructorOperation.reactions
@@ -28,13 +28,11 @@ routine changeNameOfCorrespondingIPRE_Constructor(uml::Operation umlOperation, S
 	match {
 		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlOperation tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	action {
-		update pcmIPRE {
-			if (newName.endsWith(DefaultLiterals.IMPLEMENTATION_SUFFIX)) {
-				pcmIPRE.entityName = newName.substring(0, newName.length - DefaultLiterals.IMPLEMENTATION_SUFFIX.length).toFirstUpper
-			} else {
-				pcmIPRE.entityName = newName
-			}
+	update {
+		if (newName.endsWith(DefaultLiterals.IMPLEMENTATION_SUFFIX)) {
+			pcmIPRE.entityName = newName.substring(0, newName.length - DefaultLiterals.IMPLEMENTATION_SUFFIX.length).toFirstUpper
+		} else {
+			pcmIPRE.entityName = newName
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
@@ -28,15 +28,13 @@ routine insertCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Clas
 	match {
 		val pcmCompositeType = retrieve optional pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS 
 	}
-	action {
-		call {
-			if (pcmCompositeType.isPresent) {
-				detectOrCreateCorrespondingInnerDeclaration(umlProperty, umlCompositeType)
-				moveCorrespondingInnerDeclaration(umlProperty, umlCompositeType)
-			} else {
-				// not a matching context -> delete correspondence, if it exists
-				deleteCorrespondingInnerDeclaration(umlProperty)
-			}
+	update {
+		if (pcmCompositeType.isPresent) {
+			detectOrCreateCorrespondingInnerDeclaration(umlProperty, umlCompositeType)
+			moveCorrespondingInnerDeclaration(umlProperty, umlCompositeType)
+		} else {
+			// not a matching context -> delete correspondence, if it exists
+			deleteCorrespondingInnerDeclaration(umlProperty)
 		}
 	}
 }
@@ -46,16 +44,14 @@ routine detectOrCreateCorrespondingInnerDeclaration(uml::Property umlProperty, u
 		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS 
 		val pcmInnerDeclaration = retrieve optional pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		call {
-			if (!pcmInnerDeclaration.isPresent) {
-				val pcmInnerDeclarationCandidate = pcmCompositeType.innerDeclaration_CompositeDataType
-						.findFirst[it.entityName === umlProperty.name]
-				if (pcmInnerDeclarationCandidate !== null) {
-					addCorrespondenceForExistingInnerDeclaration(umlProperty, pcmInnerDeclarationCandidate)
-				} else {
-					createCorrespondingInnerDeclaration(umlProperty, umlCompositeType)
-				}
+	update {
+		if (!pcmInnerDeclaration.isPresent) {
+			val pcmInnerDeclarationCandidate = pcmCompositeType.innerDeclaration_CompositeDataType
+					.findFirst[it.entityName === umlProperty.name]
+			if (pcmInnerDeclarationCandidate !== null) {
+				addCorrespondenceForExistingInnerDeclaration(umlProperty, pcmInnerDeclarationCandidate)
+			} else {
+				createCorrespondingInnerDeclaration(umlProperty, umlCompositeType)
 			}
 		}
 	}
@@ -66,8 +62,8 @@ routine addCorrespondenceForExistingInnerDeclaration(uml::Property umlProperty, 
 		require absence of uml::Property corresponding to pcmInnerDeclaration tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		add correspondence between pcmInnerDeclaration and umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+	update {
+		addCorrespondenceBetween(pcmInnerDeclaration, umlProperty, TagLiterals.INNER_DECLARATION__PROPERTY)
 	}
 }
 
@@ -76,13 +72,14 @@ routine createCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Clas
 		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		val pcmInnerDeclaration = create pcm::InnerDeclaration and initialize {
-			pcmInnerDeclaration.entityName = umlProperty.name
-			pcmCompositeType.innerDeclaration_CompositeDataType += pcmInnerDeclaration
-		}
-		add correspondence between pcmInnerDeclaration and umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
-		call propagateTypeChange(umlProperty)
+	create {
+		val pcmInnerDeclaration = new pcm::InnerDeclaration
+	}
+	update {
+		pcmInnerDeclaration.entityName = umlProperty.name
+		pcmCompositeType.innerDeclaration_CompositeDataType += pcmInnerDeclaration
+		addCorrespondenceBetween(pcmInnerDeclaration, umlProperty, TagLiterals.INNER_DECLARATION__PROPERTY)
+		propagateTypeChange(umlProperty)
 	}
 }
 
@@ -91,10 +88,8 @@ routine moveCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class 
 		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		update pcmCompositeType {
-			pcmCompositeType.innerDeclaration_CompositeDataType += pcmInnerDeclaration
-		}
+	update {
+		pcmCompositeType.innerDeclaration_CompositeDataType += pcmInnerDeclaration
 	}
 }
 
@@ -109,10 +104,8 @@ routine removeCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Clas
 		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		update pcmCompositeType {
-			pcmCompositeType.innerDeclaration_CompositeDataType -= pcmInnerDeclaration
-		}
+	update {
+		pcmCompositeType.innerDeclaration_CompositeDataType -= pcmInnerDeclaration
 	}
 }
 
@@ -125,9 +118,9 @@ routine deleteCorrespondingInnerDeclaration(uml::Property umlProperty) {
 	match {
 		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		remove correspondence between pcmInnerDeclaration and umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
-		delete pcmInnerDeclaration
+	update {
+		removeCorrespondenceBetween(pcmInnerDeclaration, umlProperty, TagLiterals.INNER_DECLARATION__PROPERTY)
+		deleteObject(pcmInnerDeclaration)
 	}
 }
 
@@ -141,10 +134,8 @@ routine changeNameOfCorrespondingInnerDeclaration(uml::Property umlProperty, Str
 	match {
 		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
 	}
-	action {
-		update pcmInnerDeclaration {
-			pcmInnerDeclaration.entityName = newName
-		}
+	update {
+		pcmInnerDeclaration.entityName = newName
 	}
 }
 
@@ -185,15 +176,13 @@ routine propagateTypeChange(uml::Property umlProperty) {
 		
 		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
 	}
-	action {
-		execute {
-			val pcmRepository = pcmInnerDeclaration.eResource.allContents.filter(Repository).head
-			val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(correspondenceModel, umlProperty.type, umlProperty.lower, umlProperty.upper, pcmRepository, userInteractor)
-			pcmInnerDeclaration.datatype_InnerDeclaration = pcmDataType
-			
-			if(pcmOldCollectionType.isPresent && pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType(umlProperty)
-			if(pcmDataType instanceof CollectionDataType) addCorrespondenceForCollectionType(umlProperty, pcmDataType)
-		}
+	update {
+		val pcmRepository = pcmInnerDeclaration.eResource.allContents.filter(Repository).head
+		val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(correspondenceModel, umlProperty.type, umlProperty.lower, umlProperty.upper, pcmRepository, userInteractor)
+		pcmInnerDeclaration.datatype_InnerDeclaration = pcmDataType
+		
+		if(pcmOldCollectionType.isPresent && pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType(umlProperty)
+		if(pcmDataType instanceof CollectionDataType) addCorrespondenceForCollectionType(umlProperty, pcmDataType)
 	}
 }
 
@@ -201,8 +190,8 @@ routine removeCorrespondenceForOldCollectionType(uml::Property umlProperty) {
 	match {
 		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
 	}
-	action {
-		remove correspondence between pcmCollectionType and umlProperty tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
+	update {
+		removeCorrespondenceBetween(pcmCollectionType, umlProperty, TagLiterals.COLLECTION_DATATYPE__PROPERTY)
 	}
 }
 
@@ -211,7 +200,7 @@ routine addCorrespondenceForCollectionType(uml::Property umlProperty, pcm::Colle
 		// one Parameter can only correspond to one CollectionDataType, but one CollectionDataType can correspond to many Parameters
 		require absence of pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
 	}
-	action {
-		add correspondence between pcmCollectionType and umlProperty tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
+	update {
+		addCorrespondenceBetween(pcmCollectionType, umlProperty, TagLiterals.COLLECTION_DATATYPE__PROPERTY)
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
@@ -120,7 +120,7 @@ routine deleteCorrespondingInnerDeclaration(uml::Property umlProperty) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmInnerDeclaration, umlProperty, TagLiterals.INNER_DECLARATION__PROPERTY)
-		deleteObject(pcmInnerDeclaration)
+		removeObject(pcmInnerDeclaration)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
@@ -27,14 +27,12 @@ routine insertCorrespondingInterface(uml::Interface umlInterface, uml::Package u
 	match {
 		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 	}
-	action {
-		call {
-			if (pcmRepository.isPresent) {
-				detectOrCreateCorrespondingInterface(umlInterface, umlPackage) 
-				moveCorrespondingInterface(umlInterface, umlPackage) 
-			} else {
-				deleteCorrespondingInterface(umlInterface) 
-			}
+	update {
+		if (pcmRepository.isPresent) {
+			detectOrCreateCorrespondingInterface(umlInterface, umlPackage) 
+			moveCorrespondingInterface(umlInterface, umlPackage) 
+		} else {
+			deleteCorrespondingInterface(umlInterface) 
 		}
 	}
 }
@@ -43,14 +41,12 @@ routine detectOrCreateCorrespondingInterface(uml::Interface umlInterface, uml::P
 		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		call {
-			val pcmInterfaceCandidate = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[it.entityName == umlInterface.name]
-			if (pcmInterfaceCandidate !== null) {
-				addCorrespondenceForExistingInterface(umlInterface, pcmInterfaceCandidate)
-			} else {
-				createCorrespondingInterface(umlInterface, umlPackage)
-			}
+	update {
+		val pcmInterfaceCandidate = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[it.entityName == umlInterface.name]
+		if (pcmInterfaceCandidate !== null) {
+			addCorrespondenceForExistingInterface(umlInterface, pcmInterfaceCandidate)
+		} else {
+			createCorrespondingInterface(umlInterface, umlPackage)
 		}
 	}
 }
@@ -60,8 +56,8 @@ routine addCorrespondenceForExistingInterface(uml::Interface umlInterface, pcm::
 		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		require absence of uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		add correspondence between pcmInterface and umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+	update {
+		addCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
 	}
 }
 
@@ -69,11 +65,12 @@ routine createCorrespondingInterface(uml::Interface umlInterface, uml::Package u
 	match {
 		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		val pcmInterface = create pcm::OperationInterface and initialize {
-			pcmInterface.entityName = umlInterface.name
-		}
-		add correspondence between pcmInterface and umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+	create {
+		val pcmInterface = new pcm::OperationInterface
+	}
+	update {
+		pcmInterface.entityName = umlInterface.name
+		addCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
 	}
 }
 
@@ -82,10 +79,8 @@ routine moveCorrespondingInterface(uml::Interface umlInterface, uml::Package uml
 		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		update pcmRepository {
-			pcmRepository.interfaces__Repository += pcmInterface
-		}
+	update {
+		pcmRepository.interfaces__Repository += pcmInterface
 	}
 }
 
@@ -99,10 +94,8 @@ routine removeCorrespondingInterface(uml::Interface umlInterface, uml::Package u
 		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		update pcmRepository {
-			pcmRepository.interfaces__Repository -= pcmInterface
-		}
+	update {
+		pcmRepository.interfaces__Repository -= pcmInterface
 	}
 }
 
@@ -115,9 +108,9 @@ routine deleteCorrespondingInterface(uml::Interface umlInterface) {
 	match {
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		remove correspondence between pcmInterface and umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		delete pcmInterface
+	update {
+		removeCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
+		deleteObject(pcmInterface)
 	}
 }
 
@@ -131,10 +124,8 @@ routine renameCorrespondingInterface(uml::Interface umlInterface, String newName
 	match {
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		update pcmInterface {
-			pcmInterface.entityName = umlInterface.name
-		}
+	update {
+		pcmInterface.entityName = umlInterface.name
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
@@ -110,7 +110,7 @@ routine deleteCorrespondingInterface(uml::Interface umlInterface) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
-		deleteObject(pcmInterface)
+		removeObject(pcmInterface)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterfaceGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterfaceGeneralization.reactions
@@ -28,12 +28,10 @@ routine addParentInterface(uml::Interface umlInterface, uml::Classifier umlNewPa
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		val pcmNewParent = retrieve pcm::OperationInterface corresponding to umlNewParent tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		execute {
-			val isAlreadyParent = pcmInterface.parentInterfaces__Interface.contains(pcmNewParent) 
-			if (!isAlreadyParent) {
-				pcmInterface.parentInterfaces__Interface += pcmNewParent
-			}
+	update {
+		val isAlreadyParent = pcmInterface.parentInterfaces__Interface.contains(pcmNewParent) 
+		if (!isAlreadyParent) {
+			pcmInterface.parentInterfaces__Interface += pcmNewParent
 		}
 	}
 }
@@ -49,11 +47,9 @@ routine removeParentInterface(uml::Interface umlInterface, uml::Classifier umlOl
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		val pcmOldParent = retrieve pcm::OperationInterface corresponding to umlOldParent tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		execute {
-			if (pcmInterface.parentInterfaces__Interface.contains(pcmOldParent))
-				pcmInterface.parentInterfaces__Interface -= pcmOldParent
-		}
+	update {
+		if (pcmInterface.parentInterfaces__Interface.contains(pcmOldParent))
+			pcmInterface.parentInterfaces__Interface -= pcmOldParent
 	}
 }
 
@@ -68,14 +64,11 @@ routine replaceParentInterface(uml::Generalization gen, uml::Classifier newParen
 	match {
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to gen.specific tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		call {
-			if (oldParent === newParent) return; //nothing to do
-			
-			removeParentInterface(gen.specific as Interface, oldParent)
-			if (gen.general === newParent) { // delayed validity check
-				addParentInterface(gen.specific as Interface, newParent)
-			}
+	update {
+		if (oldParent === newParent) return; //nothing to do
+		removeParentInterface(gen.specific as Interface, oldParent)
+		if (gen.general === newParent) { // delayed validity check
+			addParentInterface(gen.specific as Interface, newParent)
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
@@ -126,7 +126,7 @@ routine deleteCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 	}
 	update {
 		removeCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
-		deleteObject(pcmProvided)
+		removeObject(pcmProvided)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
@@ -7,7 +7,7 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	The following reactions and routines synchronize a pcm::OperationProvidedRole in an pcm::InterfaceProvidingRequiringEntity (IPRE)
 //	with an uml::InterfaceRealization in the uml::Class (implementation) corresponding to the IPRE.
 //
-//	Because a pcm::OperationProvidedRole defines which Interface are provided/implemented by the IPRE, 
+//	Because a pcm::OperationProvidedRole defines which Interface are provided/implemented by the IPRE,
 //	only architecturally relevant uml::Interfaces (uml::Interfaces that are defined in the contracts package of a pcm::Repository)
 //	should be set for uml::InterfaceRealization[contract] of the IPRE implementation class.
 //
@@ -31,17 +31,15 @@ routine insertCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlRealization.contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		call {
-			if (pcmComponent.isPresent 
-				&& (pcmInterface.isPresent || umlRealization.contract === null) // allow 'null' for uninitialized InterfaceRealization
-			) {
-				detectOrCreateCorrespondingProvidedRole(umlRealization, umlComponent)
-				moveCorrespondingProvidedRole(umlRealization, umlComponent)
-			} else {
-				// not a matching context -> delete correspondence, if it exists
-				deleteCorrespondingProvidedRole(umlRealization)
-			}
+	update {
+		if (pcmComponent.isPresent 
+			&& (pcmInterface.isPresent || umlRealization.contract === null) // allow 'null' for uninitialized InterfaceRealization
+		) {
+			detectOrCreateCorrespondingProvidedRole(umlRealization, umlComponent)
+			moveCorrespondingProvidedRole(umlRealization, umlComponent)
+		} else {
+			// not a matching context -> delete correspondence, if it exists
+			deleteCorrespondingProvidedRole(umlRealization)
 		}
 	}
 }
@@ -52,15 +50,13 @@ routine detectOrCreateCorrespondingProvidedRole(uml::InterfaceRealization umlRea
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		call {
-			val pcmProvidedCandidate = pcmComponent.providedRoles_InterfaceProvidingEntity
-				.filter(OperationProvidedRole).findFirst[it.providedInterface__OperationProvidedRole === pcmInterface]
-			if (pcmProvidedCandidate !== null) {
-				addCorrespondenceForExistingProvidedRole(umlRealization, pcmProvidedCandidate)
-			} else {
-				createCorrespondingProvidedRole(umlRealization, umlComponent)
-			}
+	update {
+		val pcmProvidedCandidate = pcmComponent.providedRoles_InterfaceProvidingEntity
+			.filter(OperationProvidedRole).findFirst[it.providedInterface__OperationProvidedRole === pcmInterface]
+		if (pcmProvidedCandidate !== null) {
+			addCorrespondenceForExistingProvidedRole(umlRealization, pcmProvidedCandidate)
+		} else {
+			createCorrespondingProvidedRole(umlRealization, umlComponent)
 		}
 	}
 }
@@ -70,8 +66,8 @@ routine addCorrespondenceForExistingProvidedRole(uml::InterfaceRealization umlRe
 		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		add correspondence between pcmProvided and umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+	update {
+		addCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
 	}
 }
 
@@ -81,13 +77,14 @@ routine createCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		val pcmProvided = create pcm::OperationProvidedRole and initialize {
-			pcmProvided.providedInterface__OperationProvidedRole = pcmInterface
-			pcmComponent.providedRoles_InterfaceProvidingEntity += pcmProvided
-		}
-		add correspondence between pcmProvided and umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
-		call changeNameOfCorrespondingProvidedRole(umlRealization, umlRealization.name)
+	create {
+		val pcmProvided = new pcm::OperationProvidedRole
+	}
+	update {
+		pcmProvided.providedInterface__OperationProvidedRole = pcmInterface
+		pcmComponent.providedRoles_InterfaceProvidingEntity += pcmProvided
+		addCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
+		changeNameOfCorrespondingProvidedRole(umlRealization, umlRealization.name)
 	}
 }
 
@@ -96,10 +93,8 @@ routine moveCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, 
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		update pcmComponent {
-			pcmComponent.providedRoles_InterfaceProvidingEntity += pcmProvided
-		}
+	update {
+		pcmComponent.providedRoles_InterfaceProvidingEntity += pcmProvided
 	}
 }
 
@@ -114,13 +109,9 @@ routine removeCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		update umlRealization {
-			umlRealization.clients -= umlComponent // isn't automatically done, when the InterfaceRealization is removed
-		}
-		update pcmComponent {
-			pcmComponent.providedRoles_InterfaceProvidingEntity -= pcmProvided
-		}
+	update {
+		umlRealization.clients -= umlComponent // isn't automatically done, when the InterfaceRealization is removed
+		pcmComponent.providedRoles_InterfaceProvidingEntity -= pcmProvided
 	}
 }
 
@@ -133,9 +124,9 @@ routine deleteCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 	match {
 		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		remove correspondence between pcmProvided and umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
-		delete pcmProvided
+	update {
+		removeCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
+		deleteObject(pcmProvided)
 	}
 }
 
@@ -149,10 +140,8 @@ routine changeNameOfCorrespondingProvidedRole(uml::InterfaceRealization umlReali
 	match{
 		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
-	action {
-		update pcmProvided {
-			pcmProvided.entityName = newName
-		}
+	update {
+		pcmProvided.entityName = newName
 	}
 }
 
@@ -168,20 +157,18 @@ routine changeTypeOfCorrespondingProvidedRole(uml::InterfaceRealization umlReali
 		val pcmProvided = retrieve optional pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
 		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		execute {
-			if (!pcmProvided.isPresent && pcmNewInterface.isPresent) {
-				createCorrespondingProvidedRole(umlRealization, umlRealization.implementingClassifier as org.eclipse.uml2.uml.Class)
-			} else if (pcmProvided.isPresent && pcmNewInterface.isPresent) {
-				pcmProvided.get.providedInterface__OperationProvidedRole = pcmNewInterface.get
-			} else if(pcmProvided.isPresent && umlNewInterface === null) {
-				//might be a transitional state -> keep correspondence, but synchronize 'null'
-				pcmProvided.get.providedInterface__OperationProvidedRole = null
-			} else {
-				logger.warn("The general-type of a uml::InterfaceRealization in a pcm::OperationProvidedRole ~ uml::InterfaceRealization correspondence"
-							+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationProvidedRole will be deleted.")
-				deleteCorrespondingProvidedRole(umlRealization)
-			}
+	update {
+		if (!pcmProvided.isPresent && pcmNewInterface.isPresent) {
+			createCorrespondingProvidedRole(umlRealization, umlRealization.implementingClassifier as org.eclipse.uml2.uml.Class)
+		} else if (pcmProvided.isPresent && pcmNewInterface.isPresent) {
+			pcmProvided.get.providedInterface__OperationProvidedRole = pcmNewInterface.get
+		} else if(pcmProvided.isPresent && umlNewInterface === null) {
+			//might be a transitional state -> keep correspondence, but synchronize 'null'
+			pcmProvided.get.providedInterface__OperationProvidedRole = null
+		} else {
+			logger.warn("The general-type of a uml::InterfaceRealization in a pcm::OperationProvidedRole ~ uml::InterfaceRealization correspondence"
+						+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationProvidedRole will be deleted.")
+			deleteCorrespondingProvidedRole(umlRealization)
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
@@ -32,15 +32,13 @@ routine insertCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operat
 		
 		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		call {
-			if (pcmSignature.isPresent) {
-				detectOrCreateCorrespondingRegularParameter(umlParam, umlOperation)
-				moveCorrespondingRegularParameter(umlParam, umlOperation)
-			} else {
-				// not a synchronized context -> delete corresponding parameter if necessary
-				deleteCorrespondingRegularParameter(umlParam)				
-			}
+	update {
+		if (pcmSignature.isPresent) {
+			detectOrCreateCorrespondingRegularParameter(umlParam, umlOperation)
+			moveCorrespondingRegularParameter(umlParam, umlOperation)
+		} else {
+			// not a synchronized context -> delete corresponding parameter if necessary
+			deleteCorrespondingRegularParameter(umlParam)				
 		}
 	}
 }
@@ -51,15 +49,13 @@ routine detectOrCreateCorrespondingRegularParameter(uml::Parameter umlParam, uml
 		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
 		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		call {
-			if (!pcmParam.isPresent) {
-				val pcmParamCandidate = pcmSignature.parameters__OperationSignature.findFirst[it.parameterName == umlParam.name]
-				if (pcmParamCandidate !== null) {
-					addCorrespondenceForExistingRegularParameter(umlParam, pcmParamCandidate)
-				} else {
-					createCorrespondingRegularParameter(umlParam, umlOperation)
-				}
+	update {
+		if (!pcmParam.isPresent) {
+			val pcmParamCandidate = pcmSignature.parameters__OperationSignature.findFirst[it.parameterName == umlParam.name]
+			if (pcmParamCandidate !== null) {
+				addCorrespondenceForExistingRegularParameter(umlParam, pcmParamCandidate)
+			} else {
+				createCorrespondingRegularParameter(umlParam, umlOperation)
 			}
 		}
 	}
@@ -70,8 +66,8 @@ routine addCorrespondenceForExistingRegularParameter(uml::Parameter umlParameter
 		require absence of pcm::Parameter corresponding to umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 		require absence of uml::Parameter corresponding to pcmParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		add correspondence between pcmParameter and umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+	update {
+		addCorrespondenceBetween(pcmParameter, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
 	}
 }
 
@@ -81,11 +77,12 @@ routine createCorrespondingRegularParameter(uml::Parameter umlParameter, uml::Op
 		require absence of pcm::OperationSignature corresponding to umlParameter tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
 		require absence of pcm::Parameter corresponding to umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		val pcmParameter = create pcm::Parameter and initialize {
-			pcmParameter.parameterName = umlParameter.name
-		}
-		add correspondence between pcmParameter and umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+	create {
+		val pcmParameter = new pcm::Parameter
+	}
+	update {
+		pcmParameter.parameterName = umlParameter.name
+		addCorrespondenceBetween(pcmParameter, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
 		// type propagation is done in UmlReturnAndRegularParameterType.reactions
 	}
 }
@@ -96,10 +93,8 @@ routine moveCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operatio
 		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
 		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		update pcmSignature {
-			pcmSignature.parameters__OperationSignature += pcmParam
-		}
+	update {
+		pcmSignature.parameters__OperationSignature += pcmParam
 	}
 }
 
@@ -115,10 +110,8 @@ routine removeCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operat
 		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
 		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		update pcmSignature {
-			pcmSignature.parameters__OperationSignature -= pcmParam
-		}
+	update {
+		pcmSignature.parameters__OperationSignature -= pcmParam
 	}
 }
 
@@ -132,9 +125,9 @@ routine deleteCorrespondingRegularParameter(uml::Parameter umlParam) {
 		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
 		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		remove correspondence between pcmParam and umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
-		delete pcmParam
+	update {
+		removeCorrespondenceBetween(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER)
+		deleteObject(pcmParam)
 	}
 }
 
@@ -149,10 +142,8 @@ routine changeNameOfCorrespondingRegularParameter(uml::Parameter umlParam, Strin
 		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
 		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		update pcmParam{
-			pcmParam.parameterName = newName
-		}
+	update {
+		pcmParam.parameterName = newName
 	}
 }
 
@@ -167,16 +158,14 @@ routine changeModifierOfCorrespondingRegularParameter(uml::Parameter umlParamete
 	match {
 		val pcmParameter = retrieve pcm::Parameter corresponding to umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
-	action {
-		update pcmParameter {
-			var matchingModifier = ParameterModifier.NONE
-			for (modifier : ParameterModifier.values) {
-				if (PcmUmlClassHelper.getMatchingParameterDirection(modifier) === umlParameter.direction) {
-					matchingModifier = modifier
-				}
+	update {
+		var matchingModifier = ParameterModifier.NONE
+		for (modifier : ParameterModifier.values) {
+			if (PcmUmlClassHelper.getMatchingParameterDirection(modifier) === umlParameter.direction) {
+				matchingModifier = modifier
 			}
-			pcmParameter.modifier__Parameter = matchingModifier
 		}
+		pcmParameter.modifier__Parameter = matchingModifier
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
@@ -127,7 +127,7 @@ routine deleteCorrespondingRegularParameter(uml::Parameter umlParam) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER)
-		deleteObject(pcmParam)
+		removeObject(pcmParam)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -40,8 +40,8 @@ routine ensureModelCorrespondenceExists(uml::Model newModel) {
         val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
         check !alreadyCorrespondingModels.contains(newModel)
     }
-    action {
-        add correspondence between UMLPackage.Literals.MODEL and newModel
+    update {
+        addCorrespondenceBetween(UMLPackage.Literals.MODEL, newModel)
     }
 }
 
@@ -63,36 +63,32 @@ routine insertCorrespondingRepositoryOrSystem(uml::Package umlPackage, uml::Pack
 		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val pcmSystem = retrieve optional pcm::System corresponding to umlPackage tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
-	action {
-		call {
-			if(!PcmUmlClassHelper.isContainedInRepositoryHierarchy(umlPackage, correspondenceModel)) {
-				if (!pcmRepository.isPresent && !pcmSystem.isPresent)
-					userDisambiguateRepositoryOrSystemCreation(umlPackage, umlParentPackage)
-				//no move-operation necessary since both repository and system are root elements
-			} else {
-				// nested component repositories and component based systems are not allowed
-				deleteCorrespondingRepository(umlPackage)
-				deleteCorrespondingSystem(umlPackage)
-			}
+	update {
+		if(!PcmUmlClassHelper.isContainedInRepositoryHierarchy(umlPackage, correspondenceModel)) {
+			if (!pcmRepository.isPresent && !pcmSystem.isPresent)
+				userDisambiguateRepositoryOrSystemCreation(umlPackage, umlParentPackage)
+			//no move-operation necessary since both repository and system are root elements
+		} else {
+			// nested component repositories and component based systems are not allowed
+			deleteCorrespondingRepository(umlPackage)
+			deleteCorrespondingSystem(umlPackage)
 		}
 	}
 }
 
 routine userDisambiguateRepositoryOrSystemCreation(uml::Package umlPkg, uml::Package umlParentPkg) {
-	action {
-		execute {
-			val pcmElementType = userInteractor.singleSelectionDialogBuilder
-					.message(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REQUEST)
-					.choices(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__OPTIONS)
-					.windowModality(WindowModality.MODAL)
-					.startInteraction
-			switch (pcmElementType) {
-				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REPOSITORY:
-						createOrFindCorrespondingRepository(umlPkg, umlParentPkg)
-				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__SYSTEM:
-						createOrFindCorrespondingSystem(umlPkg, umlParentPkg)
-				default: return //do nothing
-			}
+	update {
+		val pcmElementType = userInteractor.singleSelectionDialogBuilder
+				.message(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REQUEST)
+				.choices(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__OPTIONS)
+				.windowModality(WindowModality.MODAL)
+				.startInteraction
+		switch (pcmElementType) {
+			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REPOSITORY:
+					createOrFindCorrespondingRepository(umlPkg, umlParentPkg)
+			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__SYSTEM:
+					createOrFindCorrespondingSystem(umlPkg, umlParentPkg)
+			default: return //do nothing
 		}
 	}
 }
@@ -103,14 +99,12 @@ routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package um
         val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
            with umlPkg.isPackageFor(foundRepository)
     }
-    action {
-        call {
-            if (foundRepository.isPresent) {
-                ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, umlPkg)
-                addRepositoryCorrespondence(foundRepository.get, umlPkg)
-            } else {
-                createCorrespondingRepository(umlPkg, umlParentPkg)
-            }
+    update {
+        if (foundRepository.isPresent) {
+            ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, umlPkg)
+            addRepositoryCorrespondence(foundRepository.get, umlPkg)
+        } else {
+            createCorrespondingRepository(umlPkg, umlParentPkg)
         }
     }
 }
@@ -119,50 +113,47 @@ routine ensureFirstCaseUpperCaseRepositoryNaming(pcm::Repository pcmRepository, 
     match {
        check pcmRepository.entityName == umlPackage.name
     }
-    action {
-        update pcmRepository {
-            pcmRepository.entityName = umlPackage.name.toFirstUpper
-        }
+    update {
+		pcmRepository.entityName = umlPackage.name.toFirstUpper
     }
 }
 
 routine addRepositoryCorrespondence(pcm::Repository pcmRepository, uml::Package umlPkg) {
-    action {
-        add correspondence between pcmRepository and umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+    update {
+        addCorrespondenceBetween(pcmRepository, umlPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
     }
 }
 
 routine createCorrespondingRepository(uml::Package umlPkg, uml::Package umlParentPkg) {
-	action {
-		val pcmRepository = create pcm::Repository and initialize {
-			pcmRepository.entityName = umlPkg.name?.toFirstUpper
+	create {
+		val pcmRepository = new pcm::Repository
+	}
+	update {
+		pcmRepository.entityName = umlPkg.name?.toFirstUpper
+		addCorrespondenceBetween(pcmRepository, umlPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
+		addCorrespondenceBetween(pcmRepository, RepositoryPackage.Literals.REPOSITORY)
+		val fileExtension = DefaultLiterals.PCM_REPOSITORY_EXTENSION
+
+		var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction
+		if (relativeModelPath.nullOrEmpty) {
+			relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.PCM_REPOSITORY_FILE_NAME;
 		}
-		add correspondence between pcmRepository and umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		add correspondence between pcmRepository and RepositoryPackage.Literals.REPOSITORY
-		execute {
-			val fileExtension = DefaultLiterals.PCM_REPOSITORY_EXTENSION
 
-			var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction
-			if (relativeModelPath.nullOrEmpty) {
-				relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.PCM_REPOSITORY_FILE_NAME;
-			}
-
-			//check if a model at the specified path already exists; if so, append a number
-			//remove extension for now, so that it is easier to add a suffix if necessary
-			if (relativeModelPath.endsWith(fileExtension)) {
-				relativeModelPath.substring(0, relativeModelPath.length - fileExtension.length)
-			}
-			var uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + fileExtension)
-			while(URIUtil.existsResourceAtUri(uri)) {
-				uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + "-2" + fileExtension)
-			}
-			//append file extension now
-			if (!relativeModelPath.endsWith(fileExtension)) {
-				relativeModelPath += fileExtension
-			}
-
-			persistProjectRelative(umlPkg, pcmRepository, relativeModelPath);
+		//check if a model at the specified path already exists; if so, append a number
+		//remove extension for now, so that it is easier to add a suffix if necessary
+		if (relativeModelPath.endsWith(fileExtension)) {
+			relativeModelPath.substring(0, relativeModelPath.length - fileExtension.length)
 		}
+		var uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + fileExtension)
+		while(URIUtil.existsResourceAtUri(uri)) {
+			uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + "-2" + fileExtension)
+		}
+		//append file extension now
+		if (!relativeModelPath.endsWith(fileExtension)) {
+			relativeModelPath += fileExtension
+		}
+
+		persistProjectRelative(umlPkg, pcmRepository, relativeModelPath);
 	}
 }
 
@@ -172,53 +163,50 @@ routine createOrFindCorrespondingSystem(uml::Package umlPkg, uml::Package umlPar
         val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM
             with umlPkg.isPackageFor(foundSystem)
     }
-    action {
-        call {
-            if (foundSystem.isPresent) {
-                addSystemCorrespondence(foundSystem.get, umlPkg)
-            } else {
-                createCorrespondingSystem(umlPkg, umlParentPkg)
-            }
+    update {
+        if (foundSystem.isPresent) {
+            addSystemCorrespondence(foundSystem.get, umlPkg)
+        } else {
+            createCorrespondingSystem(umlPkg, umlParentPkg)
         }
     }
 }
 
 routine addSystemCorrespondence(pcm::System pcmSystem, uml::Package umlPkg) {
-    action {
-        add correspondence between pcmSystem and umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+    update {
+        addCorrespondenceBetween(pcmSystem, umlPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
     }
 }
 
 routine createCorrespondingSystem(uml::Package umlPkg, uml::Package umlParentPkg) {
-	action {
-		val pcmSystem = create pcm::System and initialize {
-			pcmSystem.entityName = umlPkg.name?.toFirstUpper
+	create {
+		val pcmSystem = new pcm::System
+	}
+	update {
+		pcmSystem.entityName = umlPkg.name?.toFirstUpper
+		addCorrespondenceBetween(pcmSystem, umlPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
+		addCorrespondenceBetween(pcmSystem,  SystemPackage.Literals.SYSTEM)
+		val fileExtension = DefaultLiterals.PCM_SYSTEM_EXTENSION
+		var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction
+		if (relativeModelPath.nullOrEmpty) {
+			relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.PCM_SYSTEM_FILE_NAME;
 		}
-		add correspondence between pcmSystem and umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
-		add correspondence between pcmSystem and  SystemPackage.Literals.SYSTEM
-		execute {
-			val fileExtension = DefaultLiterals.PCM_SYSTEM_EXTENSION
-			var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction
-			if (relativeModelPath.nullOrEmpty) {
-				relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.PCM_SYSTEM_FILE_NAME;
-			}
 
-			//check if a model at the specified path already exists; if so, append a number
-			//remove extension for now, so that it is easier to add a suffix if necessary
-			if (relativeModelPath.endsWith(fileExtension)) {
-				relativeModelPath.substring(0, relativeModelPath.length - fileExtension.length)
-			}
-			var uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + fileExtension)
-			while(URIUtil.existsResourceAtUri(uri)) {
-				uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + "-2" + fileExtension)
-			}
-			//append file extension now
-			if (!relativeModelPath.endsWith(fileExtension)) {
-				relativeModelPath += fileExtension
-			}
-
-			persistProjectRelative(umlPkg, pcmSystem, relativeModelPath);
+		//check if a model at the specified path already exists; if so, append a number
+		//remove extension for now, so that it is easier to add a suffix if necessary
+		if (relativeModelPath.endsWith(fileExtension)) {
+			relativeModelPath.substring(0, relativeModelPath.length - fileExtension.length)
 		}
+		var uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + fileExtension)
+		while(URIUtil.existsResourceAtUri(uri)) {
+			uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + "-2" + fileExtension)
+		}
+		//append file extension now
+		if (!relativeModelPath.endsWith(fileExtension)) {
+			relativeModelPath += fileExtension
+		}
+
+		persistProjectRelative(umlPkg, pcmSystem, relativeModelPath);
 	}
 }
 
@@ -236,11 +224,9 @@ reaction RepositoryOrSystemPackageDeleted {
 }
 
 routine deletePackage(uml::Package umlPackage) {
-	action {
-		call {
-			deleteCorrespondingRepository(umlPackage)
-			deleteCorrespondingSystem(umlPackage)
-		}
+	update {
+		deleteCorrespondingRepository(umlPackage)
+		deleteCorrespondingSystem(umlPackage)
 	}
 }
 
@@ -248,9 +234,9 @@ routine deleteCorrespondingRepository(uml::Package umlRepositoryPkg) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to umlRepositoryPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
-	action {
-		remove correspondence between pcmRepository and umlRepositoryPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		delete pcmRepository
+	update {
+		removeCorrespondenceBetween(pcmRepository, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
+		deleteObject(pcmRepository)
 	}
 }
 
@@ -258,9 +244,9 @@ routine deleteCorrespondingSystem(uml::Package umlSystemPkg) {
 	match {
 		val pcmSystem = retrieve pcm::System corresponding to umlSystemPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
-	action {
-		remove correspondence between pcmSystem and umlSystemPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
-		delete pcmSystem
+	update {
+		removeCorrespondenceBetween(pcmSystem, umlSystemPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
+		deleteObject(pcmSystem)
 	}
 }
 
@@ -275,13 +261,11 @@ routine renameCorrespondingRepositoryOrSystem(uml::Package umlPkg, String newNam
 		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val pcmSystem = retrieve optional pcm::System corresponding to umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
-	action {
-		call {
-			if (pcmRepository.isPresent)
-				pcmRepository.get.entityName = newName?.toFirstUpper
-			else if (pcmSystem.isPresent)
-				pcmSystem.get.entityName = newName?.toFirstUpper
-		}
+	update {
+		if (pcmRepository.isPresent)
+			pcmRepository.get.entityName = newName?.toFirstUpper
+		else if (pcmSystem.isPresent)
+			pcmSystem.get.entityName = newName?.toFirstUpper
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -236,7 +236,7 @@ routine deleteCorrespondingRepository(uml::Package umlRepositoryPkg) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmRepository, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
-		deleteObject(pcmRepository)
+		removeObject(pcmRepository)
 	}
 }
 
@@ -246,7 +246,7 @@ routine deleteCorrespondingSystem(uml::Package umlSystemPkg) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmSystem, umlSystemPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
-		deleteObject(pcmSystem)
+		removeObject(pcmSystem)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
@@ -178,7 +178,7 @@ routine deleteCorrespondingRepositoryComponent(uml::Package umlComponentPkg) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmComponent, umlComponentPkg)
-		deleteObject(pcmComponent)
+		removeObject(pcmComponent)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
@@ -35,8 +35,8 @@ routine detectDatatypesSubpackage(uml::Package umlPackage, uml::Package umlParen
 		check umlPackage.name == DefaultLiterals.DATATYPES_PACKAGE_NAME
 		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
-	action {
-		add correspondence between umlPackage and pcmRepository tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+	update {
+		addCorrespondenceBetween(umlPackage, pcmRepository, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)
 	}
 }
 
@@ -45,8 +45,8 @@ routine detectContractsSubpackage(uml::Package umlPackage, uml::Package umlParen
 		check umlPackage.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME
 		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
-	action {
-		add correspondence between umlPackage and pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
+	update {
+		addCorrespondenceBetween(umlPackage, pcmRepository, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)
 	}
 }
 
@@ -56,15 +56,13 @@ routine insertCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package
 		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
-	action {
-		call {
-			if (pcmRepository.isPresent) {
-				detectOrCreateCorrespondingRepositoryComponent(umlPkg, umlParentPkg)
-				moveCorrespondingRepositoryComponent(umlPkg, umlParentPkg)
-			} else {
-				// context does not match, delete correspondence if necessary
-				deleteCorrespondingRepositoryComponent(umlPkg)
-			}
+	update {
+		if (pcmRepository.isPresent) {
+			detectOrCreateCorrespondingRepositoryComponent(umlPkg, umlParentPkg)
+			moveCorrespondingRepositoryComponent(umlPkg, umlParentPkg)
+		} else {
+			// context does not match, delete correspondence if necessary
+			deleteCorrespondingRepositoryComponent(umlPkg)
 		}
 	}
 }
@@ -74,14 +72,12 @@ routine detectOrCreateCorrespondingRepositoryComponent(uml::Package umlPkg, uml:
 		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		call {
-			val pcmComponentCandidate = pcmRepository.components__Repository.findFirst[umlPkg.isPackageFor(it)]
-			if (pcmComponentCandidate === null) {
-				userDisambiguateCorrespondingRepositoryComponentType(umlPkg, umlParentPkg)
-			} else {
-				addCorrespondenceForExistingRepositoryComponent(umlPkg, pcmComponentCandidate)
-			}
+	update {
+		val pcmComponentCandidate = pcmRepository.components__Repository.findFirst[umlPkg.isPackageFor(it)]
+		if (pcmComponentCandidate === null) {
+			userDisambiguateCorrespondingRepositoryComponentType(umlPkg, umlParentPkg)
+		} else {
+			addCorrespondenceForExistingRepositoryComponent(umlPkg, pcmComponentCandidate)
 		}
 	}
 }
@@ -91,56 +87,57 @@ routine addCorrespondenceForExistingRepositoryComponent(uml::Package umlPkg, pcm
 		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action{
-		add correspondence between pcmComponent and umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+	update {
+		addCorrespondenceBetween(pcmComponent, umlPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 	}
 }
 
 routine userDisambiguateCorrespondingRepositoryComponentType(uml::Package umlPkg, uml::Package umlParentPkg) {
-	action {
-		execute {
-			val componentType = userInteractor.singleSelectionDialogBuilder
-					.message(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__REQUEST)
-					.choices(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__OPTIONS)
-					.startInteraction
-					
-			switch (componentType) {
-				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__BASIC_COMPONENT: 
-					createCorrespondingBasicComponent(umlPkg, umlParentPkg)
-				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__COMPOSITE_COMPONENT:
-					createCorrespondingCompositeComponent(umlPkg, umlParentPkg)
-				case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__SUB_SYSTEM:
-					createCorrespondingSubSystem(umlPkg, umlParentPkg)
-				default: return //do nothing
-			}
+	update {
+		val componentType = userInteractor.singleSelectionDialogBuilder
+				.message(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__REQUEST)
+				.choices(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__OPTIONS)
+				.startInteraction
+				
+		switch (componentType) {
+			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__BASIC_COMPONENT: 
+				createCorrespondingBasicComponent(umlPkg, umlParentPkg)
+			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__COMPOSITE_COMPONENT:
+				createCorrespondingCompositeComponent(umlPkg, umlParentPkg)
+			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__SUB_SYSTEM:
+				createCorrespondingSubSystem(umlPkg, umlParentPkg)
+			default: return //do nothing
 		}
 	}
 }
 
 routine createCorrespondingBasicComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
-	action {
-		val pcmComponent = create pcm::BasicComponent and initialize {
-			pcmComponent.entityName = umlPkg.name?.toFirstUpper
-		}
-		add correspondence between pcmComponent and umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+	create {
+		val pcmComponent = new pcm::BasicComponent
+	}
+	update {
+		pcmComponent.entityName = umlPkg.name?.toFirstUpper
+		addCorrespondenceBetween(pcmComponent, umlPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 	}
 }
 
 routine createCorrespondingCompositeComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
-	action {
-		val pcmComponent = create pcm::CompositeComponent and initialize {
-			pcmComponent.entityName = umlPkg.name?.toFirstUpper
-		}
-		add correspondence between pcmComponent and umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+	create {
+		val pcmComponent = new pcm::CompositeComponent
+	}
+	update {
+		pcmComponent.entityName = umlPkg.name?.toFirstUpper
+		addCorrespondenceBetween(pcmComponent, umlPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 	}
 }
 
 routine createCorrespondingSubSystem(uml::Package umlPkg, uml::Package umlParentPkg) {
-	action {
-		val pcmComponent = create pcm::SubSystem and initialize {
-			pcmComponent.entityName = umlPkg.name?.toFirstUpper
-		}
-		add correspondence between pcmComponent and umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+	create {
+		val pcmComponent = new pcm::SubSystem
+	}
+	update {
+		pcmComponent.entityName = umlPkg.name?.toFirstUpper
+		addCorrespondenceBetween(pcmComponent, umlPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 	}
 }
 
@@ -149,10 +146,8 @@ routine moveCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package u
 		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		update pcmRepository {
-			pcmRepository.components__Repository += pcmComponent
-		}
+	update {
+		pcmRepository.components__Repository += pcmComponent
 	}
 }
 
@@ -167,10 +162,8 @@ routine removeCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package
 		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		update pcmRepository {
-			pcmRepository.components__Repository -= pcmComponent
-		}
+	update {
+		pcmRepository.components__Repository -= pcmComponent
 	}
 }
 
@@ -183,9 +176,9 @@ routine deleteCorrespondingRepositoryComponent(uml::Package umlComponentPkg) {
 	match {
 		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlComponentPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		remove correspondence between pcmComponent and umlComponentPkg
-		delete pcmComponent
+	update {
+		removeCorrespondenceBetween(pcmComponent, umlComponentPkg)
+		deleteObject(pcmComponent)
 	}
 }
 
@@ -199,10 +192,8 @@ routine changeNameOfCorrespondingRepositoryComponent(uml::Package umlPkg, String
 	match {
 		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
-	action {
-		update pcmComponent {
-			pcmComponent.entityName = newName?.toFirstUpper
-		}
+	update {
+		pcmComponent.entityName = newName?.toFirstUpper
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
@@ -127,7 +127,7 @@ routine parameter_deleteCorrespondingRequiredRole(uml::Parameter umlParameter) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmRequired, umlParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
-		deleteObject(pcmRequired)
+		removeObject(pcmRequired)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
@@ -30,17 +30,15 @@ routine parameter_insertCorrespondingRequiredRole(uml::Parameter umlParameter, u
 		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		call {
-			if (pcmComponent.isPresent 
-				&& (pcmInterface.isPresent || umlParameter.type === null) // allow 'null' for uninitialized Generalizations
-			) {
-				parameter_detectOrCreateCorrespondingRequiredRole(umlParameter, umlConstructor)
-				parameter_moveCorrespondingRequiredRole(umlParameter, umlConstructor)
-			} else {
-				// not a matching context -> delete correspondence, if it exists
-				parameter_deleteCorrespondingRequiredRole(umlParameter)
-			}
+	update {
+		if (pcmComponent.isPresent 
+			&& (pcmInterface.isPresent || umlParameter.type === null) // allow 'null' for uninitialized Generalizations
+		) {
+			parameter_detectOrCreateCorrespondingRequiredRole(umlParameter, umlConstructor)
+			parameter_moveCorrespondingRequiredRole(umlParameter, umlConstructor)
+		} else {
+			// not a matching context -> delete correspondence, if it exists
+			parameter_deleteCorrespondingRequiredRole(umlParameter)
 		}
 	}
 }
@@ -51,17 +49,15 @@ routine parameter_detectOrCreateCorrespondingRequiredRole(uml::Parameter umlPara
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		call {
-			if (!pcmRequired.isPresent) {
-				val pcmRequiredCandidate = pcmComponent.requiredRoles_InterfaceRequiringEntity
-					.filter(OperationRequiredRole)
-					.findFirst[it.requiredInterface__OperationRequiredRole === pcmInterface && it.entityName == umlParameter.name]
-				if (pcmRequiredCandidate !== null) {
-					parameter_addCorrespondenceForExistingRequiredRole(umlParameter, pcmRequiredCandidate)
-				} else {
-					parameter_createCorrespondingRequiredRole(umlParameter, umlConstructor)
-				}
+	update {
+		if (!pcmRequired.isPresent) {
+			val pcmRequiredCandidate = pcmComponent.requiredRoles_InterfaceRequiringEntity
+				.filter(OperationRequiredRole)
+				.findFirst[it.requiredInterface__OperationRequiredRole === pcmInterface && it.entityName == umlParameter.name]
+			if (pcmRequiredCandidate !== null) {
+				parameter_addCorrespondenceForExistingRequiredRole(umlParameter, pcmRequiredCandidate)
+			} else {
+				parameter_createCorrespondingRequiredRole(umlParameter, umlConstructor)
 			}
 		}
 	}
@@ -72,8 +68,8 @@ routine parameter_addCorrespondenceForExistingRequiredRole(uml::Parameter umlPar
 		require absence of uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		add correspondence between pcmRequired and umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+	update {
+		addCorrespondenceBetween(pcmRequired, umlParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
 	}
 }
 
@@ -83,13 +79,14 @@ routine parameter_createCorrespondingRequiredRole(uml::Parameter umlParameter, u
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		val pcmRequired = create pcm::OperationRequiredRole and initialize {
-			pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
-		}
-		add correspondence between pcmRequired and umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		call parameter_changeTypeOfCorrespondingRequiredRole(umlParameter, umlParameter.type as Interface) // cast is ok since the retrieve already worked
-		call parameter_changeNameOfCorrespondingRequiredRole(umlParameter, umlParameter.name)
+	create {
+		val pcmRequired = new pcm::OperationRequiredRole
+	}
+	update {
+		pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
+		addCorrespondenceBetween(pcmRequired, umlParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
+		parameter_changeTypeOfCorrespondingRequiredRole(umlParameter, umlParameter.type as Interface) // cast is ok since the retrieve already worked
+		parameter_changeNameOfCorrespondingRequiredRole(umlParameter, umlParameter.name)
 	}
 }
 
@@ -98,10 +95,8 @@ routine parameter_moveCorrespondingRequiredRole(uml::Parameter umlParameter, uml
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
 		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		update pcmComponent {
-			pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
-		}
+	update {
+		pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
 	}
 }
 
@@ -116,10 +111,8 @@ routine parameter_removeCorrespondingRequiredRole(uml::Parameter umlParameter, u
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
 		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		update pcmComponent {
-			pcmComponent.requiredRoles_InterfaceRequiringEntity -= pcmRequired
-		}
+	update {
+		pcmComponent.requiredRoles_InterfaceRequiringEntity -= pcmRequired
 	}
 }
 
@@ -132,9 +125,9 @@ routine parameter_deleteCorrespondingRequiredRole(uml::Parameter umlParameter) {
 	match {
 		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
 	}
-	action {
-		remove correspondence between pcmRequired and umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		delete pcmRequired
+	update {
+		removeCorrespondenceBetween(pcmRequired, umlParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
+		deleteObject(pcmRequired)
 	}
 }
 
@@ -148,10 +141,8 @@ routine parameter_changeNameOfCorrespondingRequiredRole(uml::Parameter umlParame
 	match {
 		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER 
 	}
-	action {
-		update pcmRequired {
-			pcmRequired.entityName = newName
-		}
+	update {
+		pcmRequired.entityName = newName
 	}
 }
 
@@ -168,20 +159,18 @@ routine parameter_changeTypeOfCorrespondingRequiredRole(uml::Parameter umlParame
 		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER 
 		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		execute {
-			if (!pcmRequired.isPresent && pcmNewInterface.isPresent) {
-				parameter_createCorrespondingRequiredRole(umlParameter, umlParameter.owner as Operation)
-			} else if (pcmRequired.isPresent && pcmNewInterface.isPresent) {
-				pcmRequired.get.requiredInterface__OperationRequiredRole = pcmNewInterface.get
-			} else if(pcmRequired.isPresent && umlNewInterface === null) {
-				//might be a transitional state -> keep correspondence, but synchronize 'null'
-				pcmRequired.get.requiredInterface__OperationRequiredRole = null
-			} else {
-				logger.warn("The type of a uml::Property in a pcm::OperationRequiredRole ~ uml::Property correspondence"
-							+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationRequiredRole will be deleted.")
-				parameter_deleteCorrespondingRequiredRole(umlParameter)
-			}
+	update {
+		if (!pcmRequired.isPresent && pcmNewInterface.isPresent) {
+			parameter_createCorrespondingRequiredRole(umlParameter, umlParameter.owner as Operation)
+		} else if (pcmRequired.isPresent && pcmNewInterface.isPresent) {
+			pcmRequired.get.requiredInterface__OperationRequiredRole = pcmNewInterface.get
+		} else if(pcmRequired.isPresent && umlNewInterface === null) {
+			//might be a transitional state -> keep correspondence, but synchronize 'null'
+			pcmRequired.get.requiredInterface__OperationRequiredRole = null
+		} else {
+			logger.warn("The type of a uml::Property in a pcm::OperationRequiredRole ~ uml::Property correspondence"
+						+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationRequiredRole will be deleted.")
+			parameter_deleteCorrespondingRequiredRole(umlParameter)
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
@@ -29,17 +29,15 @@ routine insertCorrespondingRequiredRole(uml::Property umlProperty, uml::Class um
 		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 	}
-	action {
-		call {
-			if (pcmComponent.isPresent 
-				&& (pcmInterface.isPresent || umlProperty.type === null) // allow 'null' for uninitialized Generalizations
-			) {
-				detectOrCreateCorrespondingRequiredRole(umlProperty, umlComponent)
-				moveCorrespondingRequiredRole(umlProperty, umlComponent)
-			} else {
-				// not a matching context -> delete correspondence, if it exists
-				deleteCorrespondingRequiredRole(umlProperty)
-			}
+	update {
+		if (pcmComponent.isPresent 
+			&& (pcmInterface.isPresent || umlProperty.type === null) // allow 'null' for uninitialized Generalizations
+		) {
+			detectOrCreateCorrespondingRequiredRole(umlProperty, umlComponent)
+			moveCorrespondingRequiredRole(umlProperty, umlComponent)
+		} else {
+			// not a matching context -> delete correspondence, if it exists
+			deleteCorrespondingRequiredRole(umlProperty)
 		}
 	}
 }
@@ -50,17 +48,15 @@ routine detectOrCreateCorrespondingRequiredRole(uml::Property umlProperty, uml::
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		call {
-			if (!pcmRequired.isPresent) {
-				val pcmRequiredCandidate = pcmComponent.requiredRoles_InterfaceRequiringEntity
-					.filter(OperationRequiredRole)
-					.findFirst[it.requiredInterface__OperationRequiredRole === pcmInterface && it.entityName == umlProperty.name]
-				if (pcmRequiredCandidate !== null) {
-					addCorrespondenceForExistingRequiredRole(umlProperty, pcmRequiredCandidate)
-				} else {
-					createCorrespondingRequiredRole(umlProperty, umlComponent)
-				}
+	update {
+		if (!pcmRequired.isPresent) {
+			val pcmRequiredCandidate = pcmComponent.requiredRoles_InterfaceRequiringEntity
+				.filter(OperationRequiredRole)
+				.findFirst[it.requiredInterface__OperationRequiredRole === pcmInterface && it.entityName == umlProperty.name]
+			if (pcmRequiredCandidate !== null) {
+				addCorrespondenceForExistingRequiredRole(umlProperty, pcmRequiredCandidate)
+			} else {
+				createCorrespondingRequiredRole(umlProperty, umlComponent)
 			}
 		}
 	}
@@ -71,8 +67,8 @@ routine addCorrespondenceForExistingRequiredRole(uml::Property umlProperty, pcm:
 		require absence of uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		add correspondence between pcmRequired and umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+	update {
+		addCorrespondenceBetween(pcmRequired, umlProperty, TagLiterals.REQUIRED_ROLE__PROPERTY)
 	}
 }
 
@@ -82,13 +78,14 @@ routine createCorrespondingRequiredRole(uml::Property umlProperty, uml::Class um
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		val pcmRequired = create pcm::OperationRequiredRole and initialize {
-			pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
-		}
-		add correspondence between pcmRequired and umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
-		call changeTypeOfCorrespondingRequiredRole(umlProperty, umlProperty.type as Interface) // cast is ok since the retrieve already worked
-		call changeNameOfCorrespondingRequiredRole(umlProperty, umlProperty.name)
+	create {
+		val pcmRequired = new pcm::OperationRequiredRole
+	}
+	update {
+		pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
+		addCorrespondenceBetween(pcmRequired, umlProperty, TagLiterals.REQUIRED_ROLE__PROPERTY)
+		changeTypeOfCorrespondingRequiredRole(umlProperty, umlProperty.type as Interface) // cast is ok since the retrieve already worked
+		changeNameOfCorrespondingRequiredRole(umlProperty, umlProperty.name)
 	}
 }
 
@@ -97,10 +94,8 @@ routine moveCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlC
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		update pcmComponent {
-			pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
-		}
+	update {
+		pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
 	}
 }
 
@@ -115,10 +110,8 @@ routine removeCorrespondingRequiredRole(uml::Property umlProperty, uml::Class um
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		update pcmComponent {
-			pcmComponent.requiredRoles_InterfaceRequiringEntity -= pcmRequired
-		}
+	update {
+		pcmComponent.requiredRoles_InterfaceRequiringEntity -= pcmRequired
 	}
 }
 
@@ -131,9 +124,9 @@ routine deleteCorrespondingRequiredRole(uml::Property umlProperty) {
 	match {
 		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		remove correspondence between pcmRequired and umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
-		delete pcmRequired
+	update {
+		removeCorrespondenceBetween(pcmRequired, umlProperty, TagLiterals.REQUIRED_ROLE__PROPERTY)
+		deleteObject(pcmRequired)
 	}
 }
 
@@ -147,10 +140,8 @@ routine changeNameOfCorrespondingRequiredRole(uml::Property umlProperty, String 
 	match {
 		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 	}
-	action {
-		update pcmRequired {
-			pcmRequired.entityName = newName
-		}
+	update {
+		pcmRequired.entityName = newName
 	}
 }
 
@@ -166,20 +157,18 @@ routine changeTypeOfCorrespondingRequiredRole(uml::Property umlProperty, uml::In
 		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
 		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE 
 	}
-	action {
-		execute {
-			if (!pcmRequired.isPresent && pcmNewInterface.isPresent) {
-				createCorrespondingRequiredRole(umlProperty, umlProperty.owner as Class)
-			} else if (pcmRequired.isPresent && pcmNewInterface.isPresent) {
-				pcmRequired.get.requiredInterface__OperationRequiredRole = pcmNewInterface.get
-			} else if(pcmRequired.isPresent && umlNewInterface === null) {
-				//might be a transitional state -> keep correspondence, but synchronize 'null'
-				pcmRequired.get.requiredInterface__OperationRequiredRole = null
-			} else {
-				logger.warn("The type of a uml::Property in a pcm::OperationRequiredRole ~ uml::Property correspondence"
-							+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationRequiredRole will be deleted.")
-				deleteCorrespondingRequiredRole(umlProperty)
-			}
+	update {
+		if (!pcmRequired.isPresent && pcmNewInterface.isPresent) {
+			createCorrespondingRequiredRole(umlProperty, umlProperty.owner as Class)
+		} else if (pcmRequired.isPresent && pcmNewInterface.isPresent) {
+			pcmRequired.get.requiredInterface__OperationRequiredRole = pcmNewInterface.get
+		} else if(pcmRequired.isPresent && umlNewInterface === null) {
+			//might be a transitional state -> keep correspondence, but synchronize 'null'
+			pcmRequired.get.requiredInterface__OperationRequiredRole = null
+		} else {
+			logger.warn("The type of a uml::Property in a pcm::OperationRequiredRole ~ uml::Property correspondence"
+						+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationRequiredRole will be deleted.")
+			deleteCorrespondingRequiredRole(umlProperty)
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
@@ -126,7 +126,7 @@ routine deleteCorrespondingRequiredRole(uml::Property umlProperty) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmRequired, umlProperty, TagLiterals.REQUIRED_ROLE__PROPERTY)
-		deleteObject(pcmRequired)
+		removeObject(pcmRequired)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
@@ -60,18 +60,16 @@ routine propagateTypeChange(uml::Parameter umlParameter) {
 		
 		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
 	}
-	action {
-		execute {
-			if (pcmSignature.isPresent || pcmParameter.isPresent) { // limit context to synchronized uml::Parameters
-				val EObject pcmStoredElement = if (pcmSignature.isPresent) pcmSignature.get else pcmParameter.get
-				val pcmRepository = pcmStoredElement.eResource.allContents.filter(Repository).head
-				val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(correspondenceModel, umlParameter.type, umlParameter.lower, umlParameter.upper, pcmRepository, userInteractor)
-				if (pcmSignature.isPresent) {pcmSignature.get.returnType__OperationSignature = pcmDataType}
-				if (pcmParameter.isPresent) {pcmParameter.get.dataType__Parameter = pcmDataType}
-				
-				if(pcmOldCollectionType.isPresent  && pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType_Parameter(umlParameter)
-				if(pcmDataType instanceof CollectionDataType) addCorrespondenceForCollectionType_Parameter(umlParameter, pcmDataType)
-			}
+	update {
+		if (pcmSignature.isPresent || pcmParameter.isPresent) { // limit context to synchronized uml::Parameters
+			val EObject pcmStoredElement = if (pcmSignature.isPresent) pcmSignature.get else pcmParameter.get
+			val pcmRepository = pcmStoredElement.eResource.allContents.filter(Repository).head
+			val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(correspondenceModel, umlParameter.type, umlParameter.lower, umlParameter.upper, pcmRepository, userInteractor)
+			if (pcmSignature.isPresent) {pcmSignature.get.returnType__OperationSignature = pcmDataType}
+			if (pcmParameter.isPresent) {pcmParameter.get.dataType__Parameter = pcmDataType}
+			
+			if(pcmOldCollectionType.isPresent  && pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType_Parameter(umlParameter)
+			if(pcmDataType instanceof CollectionDataType) addCorrespondenceForCollectionType_Parameter(umlParameter, pcmDataType)
 		}
 	}
 }
@@ -80,8 +78,8 @@ routine removeCorrespondenceForOldCollectionType_Parameter(uml::Parameter umlPar
 	match {
 		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.COLLECTION_DATATYPE__PARAMETER
 	}
-	action {
-		remove correspondence between pcmCollectionType and umlParameter tagged with TagLiterals.COLLECTION_DATATYPE__PARAMETER
+	update {
+		removeCorrespondenceBetween(pcmCollectionType, umlParameter, TagLiterals.COLLECTION_DATATYPE__PARAMETER)
 	}
 }
 
@@ -90,8 +88,8 @@ routine addCorrespondenceForCollectionType_Parameter(uml::Parameter umlParameter
 		// one Parameter can only correspond to one CollectionDataType, but one CollectionDataType can correspond to many Parameters
 		require absence of pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.COLLECTION_DATATYPE__PARAMETER
 	}
-	action {
-		add correspondence between pcmCollectionType and umlParameter tagged with TagLiterals.COLLECTION_DATATYPE__PARAMETER
+	update {
+		addCorrespondenceBetween(pcmCollectionType, umlParameter, TagLiterals.COLLECTION_DATATYPE__PARAMETER)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
@@ -5,7 +5,7 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationSignature with its corresponding uml::Operation.
 //
-//	The return parameter for the signature is created via round-trip by the PcmSignature.reactions and synchronized by 
+//	The return parameter for the signature is created via round-trip by the PcmSignature.reactions, synchronized by 
 //	the UmlReturnAndRegularParameterType.reactions.
 //
 //	Related files: 
@@ -27,14 +27,12 @@ routine insertCorrespondingSignature(uml::Operation umlOperation, uml::Interface
 	match {
 		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		call {
-			if (pcmInterface.isPresent) {
-				detectOrCreateCorrespondingSignature(umlOperation, umlInterface)
-				moveCorrespondingSignature(umlOperation, umlInterface)
-			} else {
-				deleteCorrespondingSignature(umlOperation)
-			}
+	update {
+		if (pcmInterface.isPresent) {
+			detectOrCreateCorrespondingSignature(umlOperation, umlInterface)
+			moveCorrespondingSignature(umlOperation, umlInterface)
+		} else {
+			deleteCorrespondingSignature(umlOperation)
 		}
 	}
 }
@@ -44,15 +42,13 @@ routine detectOrCreateCorrespondingSignature(uml::Operation umlOperation, uml::I
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		call {
-			if (!pcmSignature.isPresent) {
-				val pcmSignatureCandidate = pcmInterface.signatures__OperationInterface.findFirst[it.entityName == umlOperation.name]
-				if (pcmSignatureCandidate !== null) {
-					addCorrespondenceForExistingSignature(umlOperation, pcmSignatureCandidate)
-				} else {
-					createCorrespondingSignature(umlOperation, umlInterface)
-				}
+	update {
+		if (!pcmSignature.isPresent) {
+			val pcmSignatureCandidate = pcmInterface.signatures__OperationInterface.findFirst[it.entityName == umlOperation.name]
+			if (pcmSignatureCandidate !== null) {
+				addCorrespondenceForExistingSignature(umlOperation, pcmSignatureCandidate)
+			} else {
+				createCorrespondingSignature(umlOperation, umlInterface)
 			}
 		}
 	}
@@ -63,8 +59,8 @@ routine addCorrespondenceForExistingSignature(uml::Operation umlOperation, pcm::
 		require absence of pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
 		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		add correspondence between pcmSignature and umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
+	update {
+		addCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
 	}
 }
 
@@ -73,12 +69,13 @@ routine createCorrespondingSignature(uml::Operation umlOperation, uml::Interface
 		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 		require absence of pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		val pcmSignature = create pcm::OperationSignature and initialize {
-			pcmSignature.entityName = umlOperation.name
-			pcmInterface.signatures__OperationInterface += pcmSignature
-		}
-		add correspondence between pcmSignature and umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
+	create {
+		val pcmSignature = new pcm::OperationSignature
+	}
+	update {
+		pcmSignature.entityName = umlOperation.name
+		pcmInterface.signatures__OperationInterface += pcmSignature
+		addCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
 	}
 }
 
@@ -87,10 +84,8 @@ routine moveCorrespondingSignature(uml::Operation umlOperation, uml::Interface u
 		val pcmSignature = retrieve asserted pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
 		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		update pcmInterface {
-			pcmInterface.signatures__OperationInterface += pcmSignature
-		}
+	update {
+		pcmInterface.signatures__OperationInterface += pcmSignature
 	}
 }
 
@@ -105,10 +100,8 @@ routine removeCorrespondingSignature(uml::Operation umlOperation, uml::Interface
 		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
-	action {
-		update pcmInterface {
-			pcmInterface.signatures__OperationInterface -= pcmSignature
-		}
+	update {
+		pcmInterface.signatures__OperationInterface -= pcmSignature
 	}
 }
 
@@ -121,9 +114,9 @@ routine deleteCorrespondingSignature(uml::Operation umlOperation) {
 	match {
 		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		remove correspondence between pcmSignature and umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
-		delete pcmSignature
+	update {
+		removeCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
+		deleteObject(pcmSignature)
 	}
 }
 
@@ -137,10 +130,8 @@ routine renameCorrespondingSignature(uml::Operation umlOperation, String newName
 	match {
 		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
 	}
-	action {
-		update pcmSignature {
-			pcmSignature.entityName = umlOperation.name
-		}
+	update {
+		pcmSignature.entityName = umlOperation.name
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
@@ -116,7 +116,7 @@ routine deleteCorrespondingSignature(uml::Operation umlOperation) {
 	}
 	update {
 		removeCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
-		deleteObject(pcmSignature)
+		removeObject(pcmSignature)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
@@ -21,26 +21,24 @@ reaction JavaAttributeCreatedInEnum {
 }
 
 routine addAttributeCorrespondence(uml::Property umlAttribute, java::Field javaField) {
-     action {
-         add correspondence between umlAttribute and javaField
+     update {
+         addCorrespondenceBetween(umlAttribute, javaField)
      }
 }
 
-//UML-Enumeration and UML-Class don't have a common superclass for "having ownedAttributes".
+//UML-Enumeration, UML-Class don't have a common superclass for "having ownedAttributes".
 //Therefore we implemented two separate routines
 routine createOrFindUmlAttributeInEnum(java::Enumeration javaEnum, java::Field javaField) {
     match {
         val umlEnum = retrieve uml::Enumeration corresponding to javaEnum
         require absence of uml::Property corresponding to javaField
     }
-    action {
-        call {
-            val foundAttribute = umlEnum.ownedAttributes.filter[name == javaField.name].claimNotMany
-            if (foundAttribute === null) {
-                createUmlAttributeInEnum(javaEnum, javaField)
-            } else {
-                addAttributeCorrespondence(foundAttribute, javaField)
-            }
+    update {
+        val foundAttribute = umlEnum.ownedAttributes.filter[name == javaField.name].claimNotMany
+        if (foundAttribute === null) {
+            createUmlAttributeInEnum(javaEnum, javaField)
+        } else {
+            addAttributeCorrespondence(foundAttribute, javaField)
         }
     }
 }
@@ -50,33 +48,30 @@ routine createOrFindUmlAttributeInClass(java::Class javaClass, java::Field javaF
         val umlClass = retrieve uml::Class corresponding to javaClass
         require absence of uml::Property corresponding to javaField
     }
-    action {
-        call {
-            val foundAttribute = umlClass.ownedAttributes.filter[name == javaField.name].claimNotMany
-            if (foundAttribute === null) {
-                createUmlAttributeInClass(javaClass, javaField)
-            } else {
-                addAttributeCorrespondence(foundAttribute, javaField)
-            }
+    update {
+        val foundAttribute = umlClass.ownedAttributes.filter[name == javaField.name].claimNotMany
+        if (foundAttribute === null) {
+            createUmlAttributeInClass(javaClass, javaField)
+        } else {
+            addAttributeCorrespondence(foundAttribute, javaField)
         }
     }
 }
 
-//UML-Enumeration and UML-Class don't have a common superclass for "having ownedAttributes".
+//UML-Enumeration, UML-Class don't have a common superclass for "having ownedAttributes".
 //Therefore we implemented two separate routines
 routine createUmlAttributeInEnum(java::Enumeration jEnum, java::Field jAttr) {
     match {
         val uEnum = retrieve uml::Enumeration corresponding to jEnum
         require absence of uml::Property corresponding to jAttr
     }
-    action {
-        val uAttr = create uml::Property and initialize {
-            uAttr.name = jAttr.name;
-        }
-        add correspondence between uAttr and jAttr
-        update uEnum {
-            uEnum.ownedAttributes += uAttr;
-        }
+    create {
+    	val uAttr = new uml::Property
+    }
+    update {
+		uAttr.name = jAttr.name
+        addCorrespondenceBetween(uAttr, jAttr)
+        uEnum.ownedAttributes += uAttr
     }
 }
 
@@ -85,14 +80,13 @@ routine createUmlAttributeInClass(java::Class jClass, java::Field jAttr) {
         val uClass = retrieve uml::Class corresponding to jClass
         require absence of uml::Property corresponding to jAttr
     }
-    action {
-        val uAttr = create uml::Property and initialize {
-            uAttr.name = jAttr.name;
-        }
-        add correspondence between uAttr and jAttr
-        update uClass {
-            uClass.ownedAttributes += uAttr;
-        }
+    create {
+    	val uAttr = new uml::Property
+   	}
+    update {
+		uAttr.name = jAttr.name;
+        addCorrespondenceBetween(uAttr, jAttr)
+		uClass.ownedAttributes += uAttr
     }
 }
 
@@ -107,8 +101,8 @@ routine changeUmlAttributeType(java::Field jAttr, java::TypeReference jType) {
     match {
         val uAttr = retrieve uml::Property corresponding to jAttr
     }
-    action {
-        call javaToUmlTypePropagation.propagateAttributeTypeChange(jAttr, uAttr)
+    update {
+        javaToUmlTypePropagation.propagateAttributeTypeChange(jAttr, uAttr)
     }
 }
 
@@ -126,10 +120,8 @@ routine setUmlAttributeFinal(java::Field jAttr, Boolean isFinal) {
     match {
         val uAttr = retrieve uml::Property corresponding to jAttr 
     }
-    action {
-        update uAttr {
-            uAttr.isReadOnly = isFinal
-        }
+    update {
+		uAttr.isReadOnly = isFinal
     }
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -29,8 +29,8 @@ execute actions in uml
 //===========================================
 
 routine addTypeCorrespondence(java::ConcreteClassifier jClassifier, uml::Type umlType) {
-	action {
-		add correspondence between umlType and jClassifier
+	update {
+		addCorrespondenceBetween(umlType, jClassifier)
 	}
 }
 
@@ -38,42 +38,40 @@ routine detectOrCreateUmlModel(EObject alreadyPersistedEObject) { // TODO TS Thi
 	match {
 		require absence of uml::Model corresponding to UMLPackage.Literals.MODEL
 	}
-	action {
-		execute {
-			val MODELNAME_INPUTMESSAGE = "Please enter a name for the UML root model (no file ending)"
-			val MODELPATH_INPUTMESSAGE = "Please enter a path for the UML root model (project relative)"
-			var userModelName = userInteractor.textInputDialogBuilder.message(MODELNAME_INPUTMESSAGE).startInteraction()
-			var userModelPath = userInteractor.textInputDialogBuilder.message(MODELPATH_INPUTMESSAGE).startInteraction()
-			if (userModelName.nullOrEmpty) {
-				userModelName = "model"
-			}
-			if (userModelPath.nullOrEmpty) {
-				userModelPath = "model"
-			}
-			val rootModelFile = userModelPath + "/" + userModelName + ".uml"
-			// Check if a model at the specified path already exists; create one if necessary
-			var Model umlRootModel = null
-			if(alreadyPersistedEObject === null) {
-				// no objects persisted jet -> can't automatically retrieve projectPath
-				throw new UnsupportedOperationException(
-					"Cannot persist/load a uml::Model from JavaToUml-reactions without any previously persisted elements.")
-			}
-			val uri = PersistenceHelper.getURIFromSourceProjectFolder(alreadyPersistedEObject, rootModelFile)
-			if (URIUtil.existsResourceAtUri(uri)) {
-				// The resource is only found if it was previously persisted, which only happens after the change propagation terminates.
-				// This should not be a problem, as long as any created model is registered on creation, to prevent creating a second one.
-				val resource = alreadyPersistedEObject.eResource.resourceSet.getResource(uri,true)
-				umlRootModel = resource.allContents.filter(Model).head
-			}
-			if (umlRootModel === null) {
-				// The resource didn't exist, or did not contain a uml::Model object
-				umlRootModel = UMLFactory.eINSTANCE.createModel
-				umlRootModel.name = userModelName
-				persistProjectRelative(alreadyPersistedEObject, umlRootModel, rootModelFile)
-			}
-			if (umlRootModel !== null ) {
-				registerUmlModelInCorrespondenceModel(umlRootModel)
-			}
+	update {
+		val MODELNAME_INPUTMESSAGE = "Please enter a name for the UML root model (no file ending)"
+		val MODELPATH_INPUTMESSAGE = "Please enter a path for the UML root model (project relative)"
+		var userModelName = userInteractor.textInputDialogBuilder.message(MODELNAME_INPUTMESSAGE).startInteraction()
+		var userModelPath = userInteractor.textInputDialogBuilder.message(MODELPATH_INPUTMESSAGE).startInteraction()
+		if (userModelName.nullOrEmpty) {
+			userModelName = "model"
+		}
+		if (userModelPath.nullOrEmpty) {
+			userModelPath = "model"
+		}
+		val rootModelFile = userModelPath + "/" + userModelName + ".uml"
+		// Check if a model at the specified path already exists; create one if necessary
+		var Model umlRootModel = null
+		if(alreadyPersistedEObject === null) {
+			// no objects persisted jet -> can't automatically retrieve projectPath
+			throw new UnsupportedOperationException(
+				"Cannot persist/load a uml::Model from JavaToUml-reactions without any previously persisted elements.")
+		}
+		val uri = PersistenceHelper.getURIFromSourceProjectFolder(alreadyPersistedEObject, rootModelFile)
+		if (URIUtil.existsResourceAtUri(uri)) {
+			// The resource is only found if it was previously persisted, which only happens after the change propagation terminates.
+			// This should not be a problem, as long as any created model is registered on creation, to prevent creating a second one.
+			val resource = alreadyPersistedEObject.eResource.resourceSet.getResource(uri,true)
+			umlRootModel = resource.allContents.filter(Model).head
+		}
+		if (umlRootModel === null) {
+			// The resource didn't exist, or did not contain a uml::Model object
+			umlRootModel = UMLFactory.eINSTANCE.createModel
+			umlRootModel.name = userModelName
+			persistProjectRelative(alreadyPersistedEObject, umlRootModel, rootModelFile)
+		}
+		if (umlRootModel !== null ) {
+			registerUmlModelInCorrespondenceModel(umlRootModel)
 		}
 	}
 }
@@ -82,17 +80,15 @@ routine registerUmlModelInCorrespondenceModel(uml::Model uModel) {
 	match {
 		require absence of uml::Model corresponding to UMLPackage.Literals.MODEL
 	}
-	action {
-		add correspondence between uModel and UMLPackage.Literals.MODEL
+	update {
+		addCorrespondenceBetween(uModel, UMLPackage.Literals.MODEL)
 	}
 }
 
 routine rootElementPreSetup(EObject alreadyPersistedEObject) {
-    action {
-        call {
-            detectOrCreateUmlModel(alreadyPersistedEObject)
-            registerPredefinedUmlPrimitiveTypes(correspondenceModel, alreadyPersistedEObject.eResource.resourceSet)
-        }
+    update {
+        detectOrCreateUmlModel(alreadyPersistedEObject)
+        registerPredefinedUmlPrimitiveTypes(correspondenceModel, alreadyPersistedEObject.eResource.resourceSet)
     }
 }
 
@@ -117,8 +113,8 @@ routine insertUmlClassifier(java::ConcreteClassifier jClassifier, java::Compilat
     match {
         val umlClassifier = retrieve uml::Classifier corresponding to jClassifier
     }
-    action {
-        call addUmlElementToModelOrPackage(jCompUnit, umlClassifier)
+    update {
+        addUmlElementToModelOrPackage(jCompUnit, umlClassifier)
     }
 }
 
@@ -127,10 +123,8 @@ routine insertUmlClassifierIntoPackage(java::ConcreteClassifier jClassifier, jav
         val uClassifier = retrieve uml::Classifier corresponding to jClassifier
         val uPackage = retrieve uml::Package corresponding to jPackage
     }
-    action {
-        update uPackage {
-            uPackage.packagedElements += uClassifier
-        }
+    update {
+        uPackage.packagedElements += uClassifier
     }
 }
 
@@ -138,26 +132,22 @@ routine addUmlElementToModelOrPackage(java::JavaRoot javaRoot, uml::PackageableE
     match {
         val uModel = retrieve asserted uml::Model corresponding to UMLPackage.Literals.MODEL
     }
-    action {
-        call {
-            val uPackage = if (javaRoot.namespaces.nullOrEmpty) {
-                uModel
-            } else {
-                findUmlPackage(uModel, javaRoot.namespaces.last)
-            }
-            checkState(uPackage !== null, "Package %s does not exist in UML model", javaRoot.namespaces)
-            if (uPackage !== umlPackageableElement.eContainer) {
-                addUmlElementToPackage(umlPackageableElement, uPackage)
-            }
+    update {
+        val uPackage = if (javaRoot.namespaces.nullOrEmpty) {
+            uModel
+        } else {
+            findUmlPackage(uModel, javaRoot.namespaces.last)
+        }
+        checkState(uPackage !== null, "Package %s does not exist in UML model", javaRoot.namespaces)
+        if (uPackage !== umlPackageableElement.eContainer) {
+            addUmlElementToPackage(umlPackageableElement, uPackage)
         }
     }
 }
 
 routine addUmlElementToPackage(uml::PackageableElement uPackageable, uml::Package uPackage) {
-    action {
-        update uPackage {
-            uPackage.packagedElements += uPackageable
-        }
+    update {
+        uPackage.packagedElements += uPackageable
     }
 }
 
@@ -173,10 +163,11 @@ reaction JavaClassifierDeleted {
 
 routine deleteUmlClassifier(java::ConcreteClassifier javaClassifier) {
 	match {
-		val umlClassfier = retrieve uml::Classifier corresponding to javaClassifier
+		val umlClassifier = retrieve uml::Classifier corresponding to javaClassifier
 	}
-	action {
-		delete umlClassfier
+	update {
+		deleteObject(umlClassifier)
+		removeCorrespondenceBetween(umlClassifier, javaClassifier)
 	}
 }
 
@@ -186,8 +177,8 @@ reaction JavaClassifierRemoved {
 }
 
 routine cleanUpJavaCompilationUnit(java::CompilationUnit jCompUnit) {
-    action {
-        delete jCompUnit
+    update {
+        deleteObject(jCompUnit)
     }
 }
 
@@ -210,27 +201,24 @@ routine createOrFindUmlClass(java::Class jClass, java::CompilationUnit jCompUnit
         require absence of uml::Class corresponding to jClass
         require absence of uml::DataType corresponding to jClass
     }
-    action {
-        call {
-            val uClass = findUmlClass(uModel, jClass.name, jCompUnit.namespaces.last)
-            if(uClass === null) {
-                createUmlClass(jClass, jCompUnit)
-            } else {
-                addTypeCorrespondence(jClass, uClass)
-            }
+    update {
+        val uClass = findUmlClass(uModel, jClass.name, jCompUnit.namespaces.last)
+        if(uClass === null) {
+            createUmlClass(jClass, jCompUnit)
+        } else {
+            addTypeCorrespondence(jClass, uClass)
         }
     }
 }
 
 routine createUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
-    action {
-        val uClass = create uml::Class and initialize {
-            uClass.name = jClass.name
-            uClass.visibility = getUmlVisibilityKindFromJavaElement(jClass)
-        }
-        call {
-            addTypeCorrespondence(jClass, uClass)
-        }
+	create {
+		val uClass = new uml::Class
+	}
+    update {
+		uClass.name = jClass.name
+        uClass.visibility = getUmlVisibilityKindFromJavaElement(jClass)
+        addTypeCorrespondence(jClass, uClass)
     }
 }
 
@@ -248,10 +236,8 @@ routine setUmlClassAbstract(java::Class jClass, Boolean isAbstract) {
 	match {
 		val uClass = retrieve uml::Class corresponding to jClass
 	}
-	action {
-		update uClass {
-			uClass.isAbstract = isAbstract
-		}
+	update {
+		uClass.isAbstract = isAbstract
 	}
 }
 
@@ -269,10 +255,8 @@ routine setUmlClassFinal(java::Class jClass, Boolean isFinal) {
 	match {
 		val uClass = retrieve uml::Class corresponding to jClass
 	}
-	action {
-		update uClass {
-			uClass.isFinalSpecialization = isFinal
-		}
+	update {
+		uClass.isFinalSpecialization = isFinal
 	}
 }
 
@@ -294,14 +278,12 @@ routine addUmlSuperClassGeneralization(java::Class jClass, java::TypeReference j
 		val uSuperClass = retrieve uml::Class corresponding to jSuperClass
 		require absence of uml::Generalization corresponding to jReference
 	}
-	action {
-		execute {
-			if (uSuperClass !== null) {
-				val uGeneralization = uClass.createGeneralization(uSuperClass)
-				addGeneralizationCorrespondence(uGeneralization, jReference)
-			} else {
-				logger.warn("Could not add " + jSuperClass.name + " as super class for " + uClass + " because the corresponding UML-SuperClass is null")
-			}
+	update {
+		if (uSuperClass !== null) {
+			val uGeneralization = uClass.createGeneralization(uSuperClass)
+			addGeneralizationCorrespondence(uGeneralization, jReference)
+		} else {
+			logger.warn("Could not add " + jSuperClass.name + " as super class for " + uClass + " because the corresponding UML-SuperClass is null")
 		}
 	}
 }
@@ -310,8 +292,9 @@ routine deleteUmlSuperClassGeneralization(java::TypeReference jReference){
 	match {
 		val uGeneralization = retrieve uml::Generalization corresponding to jReference
 	}
-	action {
-		delete uGeneralization
+	update {
+		deleteObject(uGeneralization)
+		removeCorrespondenceBetween(jReference, uGeneralization)
 	}
 }
 
@@ -329,19 +312,17 @@ routine addUmlClassImplement(java::Class jClass, java::TypeReference jReference,
 		val uInterface = retrieve uml::Interface corresponding to jInterface
 		require absence of uml::InterfaceRealization corresponding to jReference
 	}
-	action {
-		execute {
-			val matchingInterfaceRealization = uClass.interfaceRealizations.filter[contract == uInterface]
-			checkState(matchingInterfaceRealization.size <= 1, "There was more than one realization of interface %s in class %s", uInterface, uClass)
-			if (matchingInterfaceRealization.size == 1) {
-				addImplementsCorrespondence(jReference, matchingInterfaceRealization.get(0))
-			} else if (uInterface !== null) {
-				val uRealization = uClass.createInterfaceRealization(uInterface.name, uInterface)
-				addImplementsCorrespondence(jReference, uRealization)
-			} else {
-				logger.warn("Could not add " + jInterface.name + " as implemented interface for " + uClass
-					+ " because the corresponding UML-Interface is null")
-			}
+	update {
+		val matchingInterfaceRealization = uClass.interfaceRealizations.filter[contract == uInterface]
+		checkState(matchingInterfaceRealization.size <= 1, "There was more than one realization of interface %s in class %s", uInterface, uClass)
+		if (matchingInterfaceRealization.size == 1) {
+			addImplementsCorrespondence(jReference, matchingInterfaceRealization.get(0))
+		} else if (uInterface !== null) {
+			val uRealization = uClass.createInterfaceRealization(uInterface.name, uInterface)
+			addImplementsCorrespondence(jReference, uRealization)
+		} else {
+			logger.warn("Could not add " + jInterface.name + " as implemented interface for " + uClass
+				+ " because the corresponding UML-Interface is null")
 		}
 	}
 }
@@ -350,8 +331,8 @@ routine addImplementsCorrespondence(java::TypeReference jReference, uml::Interfa
 	match {
 		require absence of uml::InterfaceRealization corresponding to jReference
 	}
-	action {
-		add correspondence between uRealization and jReference
+	update {
+		addCorrespondenceBetween(uRealization, jReference)
 	}
 }
 
@@ -365,11 +346,10 @@ routine removeUmlClassImplement(java::Class jClass, java::TypeReference jReferen
 		val uClass = retrieve uml::Class corresponding to jClass
 		val uRealization = retrieve uml::InterfaceRealization corresponding to jReference
 	}
-	action {
-		update uClass {
-			uClass.interfaceRealizations -= uRealization
-		}
-		delete uRealization
+	update {
+		uClass.interfaceRealizations -= uRealization
+		deleteObject(uRealization)
+		removeCorrespondenceBetween(jReference, uRealization)
 	}
 }
 
@@ -391,27 +371,24 @@ routine createOrFindUmlInterface(java::Interface jInterface, java::CompilationUn
 		val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 		require absence of uml::Interface corresponding to jInterface
 	}
-	action {
-		call {
-			val uInterface = findUmlInterface(uModel, jInterface.name, jCompUnit.namespaces.last)
-			if(uInterface === null) {
-				createUmlInterface(jInterface, jCompUnit)
-			} else {
-				addTypeCorrespondence(jInterface, uInterface)
-			}
+	update {
+		val uInterface = findUmlInterface(uModel, jInterface.name, jCompUnit.namespaces.last)
+		if(uInterface === null) {
+			createUmlInterface(jInterface, jCompUnit)
+		} else {
+			addTypeCorrespondence(jInterface, uInterface)
 		}
 	}
 }
 
 routine createUmlInterface(java::Interface jInterface, java::CompilationUnit jCompUnit) {
-	action {
-		val uInterface = create uml::Interface and initialize {
-			uInterface.name = jInterface.name
-			uInterface.visibility = getUmlVisibilityKindFromJavaElement(jInterface)
-		}
-		call {
-			addTypeCorrespondence(jInterface, uInterface)
-		}
+	create {
+		val uInterface = new uml::Interface
+	}
+	update {
+		uInterface.name = jInterface.name
+		uInterface.visibility = getUmlVisibilityKindFromJavaElement(jInterface)
+		addTypeCorrespondence(jInterface, uInterface)
 	}
 }
 
@@ -429,16 +406,14 @@ routine addUmlSuperinterfaces(java::Interface jInterface, java::TypeReference jR
 		val uSuperInterface = retrieve uml::Interface corresponding to jSuperInterface
 		require absence of uml::Generalization corresponding to jReference
 	}
-	action {
-		execute {
-			if (uSuperInterface !== null) {
-				val uGeneralization = uInterface.createGeneralization(uSuperInterface)
-				addGeneralizationCorrespondence(uGeneralization, jReference)
-			} else {
-				logger.warn("Could not add " + jSuperInterface.name + " as super interface for " + uInterface
-					+ " because the corresponding UML-Superinterface is null"
-				)
-			}
+	update {
+		if (uSuperInterface !== null) {
+			val uGeneralization = uInterface.createGeneralization(uSuperInterface)
+			addGeneralizationCorrespondence(uGeneralization, jReference)
+		} else {
+			logger.warn("Could not add " + jSuperInterface.name + " as super interface for " + uInterface
+				+ " because the corresponding UML-Superinterface is null"
+			)
 		}
 	}
 }
@@ -448,8 +423,8 @@ routine addGeneralizationCorrespondence(uml::Generalization uGeneralization, jav
 		require absence of uml::Generalization corresponding to jReference
 		require absence of java::TypeReference corresponding to uGeneralization
 	}
-	action {
-		add correspondence between uGeneralization and jReference
+	update {
+		addCorrespondenceBetween(uGeneralization, jReference)
 	}
 }
 
@@ -463,8 +438,9 @@ routine removeUmlSuperInterface(java::Interface jInterface, java::TypeReference 
 		val uInterface = retrieve uml::Interface corresponding to jInterface
 		val uGeneralization = retrieve uml::Generalization corresponding to jReference
 	}
-	action {
-		delete uGeneralization
+	update {
+		deleteObject(uGeneralization)
+		removeCorrespondenceBetween(jReference, uGeneralization)
 	}
 }
 
@@ -486,14 +462,12 @@ routine createOrFindUmlEnum(java::Enumeration jEnum, java::CompilationUnit jComp
         val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
         require absence of uml::Enumeration corresponding to jEnum
     }
-    action {
-        call {
-            val uEnum = findUmlEnum(uModel, jEnum.name, jCompUnit.namespaces.last)
-            if(uEnum === null) {
-                createUmlEnum(jEnum, jCompUnit)
-            } else {
-                addTypeCorrespondence(jEnum, uEnum)
-            }
+    update {
+        val uEnum = findUmlEnum(uModel, jEnum.name, jCompUnit.namespaces.last)
+        if(uEnum === null) {
+            createUmlEnum(jEnum, jCompUnit)
+        } else {
+            addTypeCorrespondence(jEnum, uEnum)
         }
     }
 }
@@ -502,14 +476,13 @@ routine createUmlEnum(java::Enumeration jEnum, java::CompilationUnit jCompUnit) 
     match {
         require absence of uml::Enumeration corresponding to jEnum
     }
-    action {
-        val uEnum = create uml::Enumeration and initialize {
-            uEnum.name = jEnum.name
-            uEnum.visibility = getUmlVisibilityKindFromJavaElement(jEnum)
-        }
-        call {
-            addTypeCorrespondence(jEnum, uEnum)
-        }
+    create {
+    	val uEnum = new uml::Enumeration
+    }
+    update {
+        uEnum.name = jEnum.name
+        uEnum.visibility = getUmlVisibilityKindFromJavaElement(jEnum)
+        addTypeCorrespondence(jEnum, uEnum)
     }
 }
 
@@ -523,14 +496,13 @@ routine createUmlEnumLiteral(java::Enumeration jEnum, java::EnumConstant jConsta
         val uEnum = retrieve uml::Enumeration corresponding to jEnum
         require absence of uml::EnumerationLiteral corresponding to jConstant
     }
-    action {
-        val uLiteral = create uml::EnumerationLiteral and initialize {
-            uLiteral.name = jConstant.name
-        }
-        add correspondence between uLiteral and jConstant
-        update uEnum {
-            uEnum.ownedLiterals += uLiteral
-        }
+    create {
+    	val uLiteral = new uml::EnumerationLiteral
+    }
+    update {
+        uLiteral.name = jConstant.name
+        addCorrespondenceBetween(uLiteral, jConstant)
+        uEnum.ownedLiterals += uLiteral
     }
 }
 
@@ -543,8 +515,9 @@ routine deleteUmlEnumLiteral(java::EnumConstant jConstant) {
     match {
         val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
     }
-    action {
-        delete uLiteral
+    update {
+        deleteObject(uLiteral)
+        removeCorrespondenceBetween(uLiteral, jConstant)
     }
 }
 
@@ -557,10 +530,8 @@ routine renameUmlEnumLiteral(java::EnumConstant jConstant) {
     match {
         val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
     }
-    action {
-        update uLiteral {
-            uLiteral.name = jConstant.name
-        }
+    update {
+        uLiteral.name = jConstant.name
     }
 }
 
@@ -586,8 +557,8 @@ routine createPackageEClassCorrespondence(java::Package jPackage) {
 		val allPackages = retrieve many java::Package corresponding to jPackage.eClass
 		check !allPackages.contains(jPackage)
 	}
-	action {
-		add correspondence between jPackage and jPackage.eClass
+	update {
+		addCorrespondenceBetween(jPackage, jPackage.eClass)
 	}
 }
 
@@ -595,10 +566,8 @@ routine potentiallyMoveUmlPackage(java::Package jPackage) {
 	match {
 		val umlPackage = retrieve uml::Package corresponding to jPackage
 	}
-	action {
-		call {
-			addUmlElementToModelOrPackage(jPackage, umlPackage)
-		}
+	update {
+		addUmlElementToModelOrPackage(jPackage, umlPackage)
 	}
 }
 
@@ -607,17 +576,15 @@ routine createOrFindUmlPackage(java::Package jPackage) {
 		val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 		require absence of uml::Package corresponding to jPackage
 	}
-	action {
-		call {
-			val uPackage = findUmlPackage(uModel, jPackage.name)
-			if(uPackage === null) {
-				createUmlPackage(jPackage, uModel)
-			} else {
-				// Existing package was created again, so delete the old one to ensure
-				// that no duplicate elements and correspondences exist
-				deleteExistingJavaPackage(uPackage)
-				addPackageCorrespondence(jPackage, uPackage)
-			}
+	update {
+		val uPackage = findUmlPackage(uModel, jPackage.name)
+		if(uPackage === null) {
+			createUmlPackage(jPackage, uModel)
+		} else {
+			// Existing package was created again, so delete the old one to ensure
+			// that no duplicate elements, correspondences exist
+			deleteExistingJavaPackage(uPackage)
+			addPackageCorrespondence(jPackage, uPackage)
 		}
 	}
 }
@@ -626,32 +593,32 @@ routine deleteExistingJavaPackage(uml::Package umlPackage) {
 	match {
 		val javaPackage = retrieve java::Package corresponding to umlPackage
 	}
-	action {
-		delete javaPackage
+	update {
+		deleteObject(javaPackage)
+		removeCorrespondenceBetween(umlPackage, javaPackage)
 	}
 }
 
 routine addPackageCorrespondence(java::Package jPackage, uml::Package uPackage) {
-	action {
-		 add correspondence between uPackage and jPackage
+	update {
+		 addCorrespondenceBetween(uPackage, jPackage)
 	}
 }
 
 routine createUmlPackage(java::Package jPackage, uml::Model uModel) {
-	action {
-		val uPackage = create uml::Package and initialize {
-			uPackage.name = jPackage.name
-		}
-		add correspondence between uPackage and jPackage
-		call {
-			if (jPackage.namespaces.nullOrEmpty) {
-				addUmlElementToPackage(uPackage, uModel)
-			} else {
-				// find package by name is necessary, since jPackage does not explicitly model parent-child package relations
-				val parentPackage = findUmlPackage(uModel, jPackage.namespaces.last)
-				checkState(parentPackage !== null, "UML package %s does not exist", jPackage.namespaces)
-				addUmlElementToPackage(uPackage, parentPackage)
-			}
+	create {
+		val uPackage = new uml::Package
+	}
+	update {
+		uPackage.name = jPackage.name
+		addCorrespondenceBetween(uPackage, jPackage)
+		if (jPackage.namespaces.nullOrEmpty) {
+			addUmlElementToPackage(uPackage, uModel)
+		} else {
+			// find package by name is necessary, since jPackage does not explicitly model parent-child package relations
+			val parentPackage = findUmlPackage(uModel, jPackage.namespaces.last)
+			checkState(parentPackage !== null, "UML package %s does not exist", jPackage.namespaces)
+			addUmlElementToPackage(uPackage, parentPackage)
 		}
 	}
 }
@@ -665,18 +632,16 @@ routine deleteCorrespondingUmlPackage(java::Package jPackage) {
 	match {
 		val uPackage = retrieve uml::Package corresponding to jPackage
 	}
-	action {
-		call deleteUmlPackage(uPackage)
+	update {
+		deleteUmlPackage(uPackage)
 	}
 }
 
 routine deleteUmlPackage(uml::Package umlPackage) {
-	action {
-		call {
-			val nestedPackages = new ArrayList(umlPackage.nestedPackages)
-			nestedPackages.forEach[deleteUmlPackage()]
-		}
-		delete umlPackage
+	update {
+		val nestedPackages = new ArrayList(umlPackage.nestedPackages)
+		nestedPackages.forEach[deleteUmlPackage()]
+		deleteObject(umlPackage)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -166,7 +166,7 @@ routine deleteUmlClassifier(java::ConcreteClassifier javaClassifier) {
 		val umlClassifier = retrieve uml::Classifier corresponding to javaClassifier
 	}
 	update {
-		deleteObject(umlClassifier)
+		removeObject(umlClassifier)
 		removeCorrespondenceBetween(umlClassifier, javaClassifier)
 	}
 }
@@ -178,7 +178,7 @@ reaction JavaClassifierRemoved {
 
 routine cleanUpJavaCompilationUnit(java::CompilationUnit jCompUnit) {
     update {
-        deleteObject(jCompUnit)
+        removeObject(jCompUnit)
     }
 }
 
@@ -293,7 +293,7 @@ routine deleteUmlSuperClassGeneralization(java::TypeReference jReference){
 		val uGeneralization = retrieve uml::Generalization corresponding to jReference
 	}
 	update {
-		deleteObject(uGeneralization)
+		removeObject(uGeneralization)
 		removeCorrespondenceBetween(jReference, uGeneralization)
 	}
 }
@@ -348,7 +348,7 @@ routine removeUmlClassImplement(java::Class jClass, java::TypeReference jReferen
 	}
 	update {
 		uClass.interfaceRealizations -= uRealization
-		deleteObject(uRealization)
+		removeObject(uRealization)
 		removeCorrespondenceBetween(jReference, uRealization)
 	}
 }
@@ -439,7 +439,7 @@ routine removeUmlSuperInterface(java::Interface jInterface, java::TypeReference 
 		val uGeneralization = retrieve uml::Generalization corresponding to jReference
 	}
 	update {
-		deleteObject(uGeneralization)
+		removeObject(uGeneralization)
 		removeCorrespondenceBetween(jReference, uGeneralization)
 	}
 }
@@ -516,7 +516,7 @@ routine deleteUmlEnumLiteral(java::EnumConstant jConstant) {
         val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
     }
     update {
-        deleteObject(uLiteral)
+        removeObject(uLiteral)
         removeCorrespondenceBetween(uLiteral, jConstant)
     }
 }
@@ -594,7 +594,7 @@ routine deleteExistingJavaPackage(uml::Package umlPackage) {
 		val javaPackage = retrieve java::Package corresponding to umlPackage
 	}
 	update {
-		deleteObject(javaPackage)
+		removeObject(javaPackage)
 		removeCorrespondenceBetween(umlPackage, javaPackage)
 	}
 }
@@ -641,7 +641,7 @@ routine deleteUmlPackage(uml::Package umlPackage) {
 	update {
 		val nestedPackages = new ArrayList(umlPackage.nestedPackages)
 		nestedPackages.forEach[deleteUmlPackage()]
-		deleteObject(umlPackage)
+		removeObject(umlPackage)
 	}
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -171,7 +171,7 @@ routine deleteUmlMethod(java::Member jMem) {
         val uMem = retrieve uml::NamedElement corresponding to jMem tagged with ""
     }
     update {
-        deleteObject(uMem)
+        removeObject(uMem)
         removeCorrespondenceBetween(uMem, jMem)
     }
 }
@@ -298,7 +298,7 @@ routine deleteJavaParameter(java::Parameter jParam) {
         val uParam = retrieve uml::Parameter corresponding to jParam
     }
     update {
-        deleteObject(uParam)
+        removeObject(uParam)
         removeCorrespondenceBetween(uParam, jParam)
     }
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -43,29 +43,28 @@ routine createOrFindUmlClassMethod(java::ClassMethod jMethod, java::ConcreteClas
         require absence of uml::Property corresponding to jMethod tagged with UmlJavaCorrespondenceTag.GETTER
         require absence of uml::Property corresponding to jMethod tagged with UmlJavaCorrespondenceTag.SETTER
     }
-    action {
-        call {
-            val foundMethod = (uClassifier as OperationOwner).ownedOperations.findFirst[
-                name == jMethod.name && 
-                ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
-                jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
-            ]
-            if (foundMethod === null) {
-                createUmlClassMethod(jMethod, uClassifier)
-            } else {
-                addUmlMethodCorrespondence(foundMethod, jMethod)
-            }
+    update {
+        val foundMethod = (uClassifier as OperationOwner).ownedOperations.findFirst[
+            name == jMethod.name && 
+            ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
+            jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
+        ]
+        if (foundMethod === null) {
+            createUmlClassMethod(jMethod, uClassifier)
+        } else {
+            addUmlMethodCorrespondence(foundMethod, jMethod)
         }
     }
 }
 
 routine createUmlClassMethod(java::ClassMethod jMethod, uml::Classifier uClassifier) {
-    action {
-        val uOperation = create uml::Operation and initialize {
-            uOperation.name = jMethod.name
-            uOperation.visibility = getUmlVisibilityKindFromJavaElement(jMethod)
-        }
-        add correspondence between uOperation and jMethod
+	create {
+		val uOperation = new uml::Operation
+	}
+    update {
+        uOperation.name = jMethod.name
+        uOperation.visibility = getUmlVisibilityKindFromJavaElement(jMethod)
+        addCorrespondenceBetween(uOperation, jMethod)
     }
 }
 
@@ -82,36 +81,35 @@ routine createOrFindUmlInterfaceMethod(java::InterfaceMethod jMethod, java::Inte
         val uInterface = retrieve uml::Interface corresponding to jInterface
         require absence of uml::Operation corresponding to jMethod
     }
-    action {
-        call {
-            val foundMethod = uInterface.ownedOperations.findFirst[
-                name == jMethod.name && 
-                ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
-                jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
-            ]
-            if (foundMethod === null) {
-                createUmlInterfaceMethod(jMethod, uInterface)
-            } else {
-                addUmlMethodCorrespondence(foundMethod, jMethod)
-            }
+    update {
+        val foundMethod = uInterface.ownedOperations.findFirst[
+            name == jMethod.name && 
+            ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
+            jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
+        ]
+        if (foundMethod === null) {
+            createUmlInterfaceMethod(jMethod, uInterface)
+        } else {
+            addUmlMethodCorrespondence(foundMethod, jMethod)
         }
     }
 }
 
 routine createUmlInterfaceMethod(java::InterfaceMethod jMeth, uml::Interface uInterface) {
-    action {
-        val uOperation = create uml::Operation and initialize {
-            uOperation.name = jMeth.name
-            uOperation.isAbstract = true
-        }
-        add correspondence between uOperation and jMeth
+	create {
+		val uOperation = new uml::Operation
+	}
+    update {
+        uOperation.name = jMeth.name
+        uOperation.isAbstract = true
+        addCorrespondenceBetween(uOperation, jMeth)
     }
 }
 
-// Shared between interface methods, class methods and constructors:
+// Shared between interface methods, class methods, constructors:
 routine addUmlMethodCorrespondence(uml::Operation uOperation, java::Member jMethodOrConstructor) {
-    action {
-        add correspondence between uOperation and jMethodOrConstructor
+    update {
+        addCorrespondenceBetween(uOperation, jMethodOrConstructor)
     }
 }
 
@@ -128,25 +126,24 @@ routine createOrFindUmlConstructor(java::Constructor jConstructor, java::Concret
         val uClassifier = retrieve uml::Class corresponding to jClassifier
         require absence of uml::Operation corresponding to jConstructor
     }
-    action {
-        call {
-            val foundConstructor = uClassifier.ownedOperations.findFirst[name == jConstructor.name]
-            if (foundConstructor === null) {
-                createUmlConstructor(jConstructor, uClassifier)
-            } else {
-                addUmlMethodCorrespondence(foundConstructor, jConstructor)
-            }
+    update {
+        val foundConstructor = uClassifier.ownedOperations.findFirst[name == jConstructor.name]
+        if (foundConstructor === null) {
+            createUmlConstructor(jConstructor, uClassifier)
+        } else {
+            addUmlMethodCorrespondence(foundConstructor, jConstructor)
         }
     }
 }
 
 routine createUmlConstructor(java::Constructor jConstructor, uml::Class uClassifier) {
-    action {
-        val uConstructor = create uml::Operation and initialize {
-            uConstructor.name = jConstructor.name
-            uConstructor.visibility = getUmlVisibilityKindFromJavaElement(jConstructor)
-        }
-        add correspondence between uConstructor and jConstructor
+	create {
+		val uConstructor = new uml::Operation
+	}
+    update {
+        uConstructor.name = jConstructor.name
+        uConstructor.visibility = getUmlVisibilityKindFromJavaElement(jConstructor)
+        addCorrespondenceBetween(uConstructor, jConstructor)
     }
 }
 
@@ -155,10 +152,8 @@ routine insertUmlMethod(java::Member javaMethod, java::ConcreteClassifier javaCl
         val umlMethod = retrieve uml::Operation corresponding to javaMethod 
         val umlClassifier = retrieve uml::Classifier corresponding to javaClassifier
     }
-    action {
-        update umlClassifier {
-            (umlClassifier as OperationOwner).ownedOperations += umlMethod
-        }
+    update {
+        (umlClassifier as OperationOwner).ownedOperations += umlMethod
     }
 }
 
@@ -175,8 +170,9 @@ routine deleteUmlMethod(java::Member jMem) {
     match {
         val uMem = retrieve uml::NamedElement corresponding to jMem tagged with ""
     }
-    action {
-        delete uMem
+    update {
+        deleteObject(uMem)
+        removeCorrespondenceBetween(uMem, jMem)
     }
 }
 
@@ -184,8 +180,8 @@ routine deleteAccessorCorrespondence(java::Member jMember, String tag) {
     match {
         val uProperty = retrieve uml::Property corresponding to jMember tagged with tag
     }
-    action {
-        remove correspondence between uProperty and jMember tagged with tag
+    update {
+        removeCorrespondenceBetween(uProperty, jMember, tag)
     }
 }
 
@@ -205,10 +201,8 @@ routine setUmlMethodAbstract(java::ClassMethod jMeth, Boolean isAbstract) {
     match {
         val uOperation = retrieve uml::Operation corresponding to jMeth
     }
-    action {
-        update uOperation {
-            uOperation.isAbstract = isAbstract
-        }
+    update {
+		uOperation.isAbstract = isAbstract
     }
 }
 
@@ -226,10 +220,8 @@ routine setUmlMethodFinal(java::Method jMethod, Boolean isFinal) {
     match {
         val uOperation = retrieve uml::Operation corresponding to jMethod
     }
-    action {
-        update uOperation {
-            uOperation.isLeaf = isFinal
-        }
+    update {
+        uOperation.isLeaf = isFinal
     }
 }
 
@@ -247,10 +239,8 @@ routine setUmlFeatureStatic(java::AnnotableAndModifiable jElem, Boolean isStatic
     match {
         val uFeature = retrieve uml::Feature corresponding to jElem
     }
-    action {
-        update uFeature {
-            uFeature.isStatic = isStatic
-        }
+    update {
+        uFeature.isStatic = isStatic
     }
 }
 
@@ -276,14 +266,13 @@ routine createUmlParameter(java::Parametrizable jMeth, java::Parameter jParam) {
         val uOperation = retrieve uml::Operation corresponding to jMeth
         require absence of uml::Parameter corresponding to jParam
     }
-    action {
-        val uParam = create uml::Parameter and initialize {
-            uParam.name = jParam.name
-        }
-        add correspondence between uParam and jParam
-        update uOperation {
-            uOperation.ownedParameters += uParam
-        }
+    create {
+    	val uParam = new uml::Parameter
+    }
+    update {
+        uParam.name = jParam.name
+        addCorrespondenceBetween(uParam, jParam)
+        uOperation.ownedParameters += uParam
     }
 }
 
@@ -291,13 +280,11 @@ routine setMultiplicityOfCorrespondingParameterToUnlimited(java::Parameter param
     match {
         val umlParameter = retrieve uml::Parameter corresponding to parameter
     }
-    action {
-        update umlParameter {
-            umlParameter => [
-                lower = 0
-                upper = LiteralUnlimitedNatural.UNLIMITED
-            ]
-        }
+    update {
+        umlParameter => [
+            lower = 0
+            upper = LiteralUnlimitedNatural.UNLIMITED
+        ]
     }
 }
 
@@ -310,8 +297,9 @@ routine deleteJavaParameter(java::Parameter jParam) {
     match {
         val uParam = retrieve uml::Parameter corresponding to jParam
     }
-    action{
-        delete uParam
+    update {
+        deleteObject(uParam)
+        removeCorrespondenceBetween(uParam, jParam)
     }
 }
 
@@ -324,8 +312,8 @@ routine changeUmlParameterType(java::Parameter jParam, java::TypeReference jType
     match {
         val uParam = retrieve uml::Parameter corresponding to jParam
     }
-    action {
-        call javaToUmlTypePropagation.propagateParameterTypeChange(jParam, uParam)
+    update {
+        javaToUmlTypePropagation.propagateParameterTypeChange(jParam, uParam)
     }
 }
 
@@ -338,16 +326,14 @@ routine changeUmlReturnType(java::Method jMeth, java::TypeReference jType) {
     match {
         val uOperation = retrieve uml::Operation corresponding to jMeth
     }
-    action {
-        execute {
-            var uParam = uOperation.getReturnResult
-            if (uParam === null){
-                // create a new return parameter
-                uParam = uOperation.createOwnedParameter("returnParameter", null)
-                uParam.direction = ParameterDirectionKind.RETURN_LITERAL
-            }
-            javaToUmlTypePropagation.propagateMethodReturnTypeChange(jMeth, uParam)
+    update {
+        var uParam = uOperation.getReturnResult
+        if (uParam === null){
+            // create a new return parameter
+            uParam = uOperation.createOwnedParameter("returnParameter", null)
+            uParam.direction = ParameterDirectionKind.RETURN_LITERAL
         }
+        javaToUmlTypePropagation.propagateMethodReturnTypeChange(jMeth, uParam)
     }
 }
 
@@ -373,10 +359,8 @@ routine changeUmlNamedElementVisibility(java::AnnotableAndModifiable jElem) {
     match {
         val uElem = retrieve uml::NamedElement corresponding to jElem tagged with ""
     }
-    action {
-        update uElem {
-            uElem.visibility = getUmlVisibilityKindFromJavaElement(jElem)
-        }
+    update {
+        uElem.visibility = getUmlVisibilityKindFromJavaElement(jElem)
     }
 }
 
@@ -390,10 +374,8 @@ routine renameUmlNamedElement(java::NamedElement jElement) {
     match {
         val uElement = retrieve uml::NamedElement corresponding to jElement tagged with ""
     }
-    action {
-        update uElement {
-            uElement.name = jElement.name
-        }
+    update {
+        uElement.name = jElement.name
     }
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
@@ -15,20 +15,20 @@ in reaction to changes in java
 execute actions in uml
 
 routine propagateAttributeTypeChange(java::Field jAtt, uml::Property uAtt) {
-	action {
-		call propagateTypeChangeToTypedMultiplicityElement(uAtt, uAtt, jAtt)
+	update {
+		propagateTypeChangeToTypedMultiplicityElement(uAtt, uAtt, jAtt)
 	}
 }
 
 routine propagateMethodReturnTypeChange(java::Method jMethod, uml::Parameter uReturnParameter) {
-	action {
-		call propagateTypeChangeToTypedMultiplicityElement(uReturnParameter, uReturnParameter, jMethod)
+	update {
+		propagateTypeChangeToTypedMultiplicityElement(uReturnParameter, uReturnParameter, jMethod)
 	}
 }
 
 routine propagateParameterTypeChange(java::Parameter jParam, uml::Parameter uParam) {
-	action {
-		call propagateTypeChangeToTypedMultiplicityElement(uParam, uParam, jParam)
+	update {
+		propagateTypeChangeToTypedMultiplicityElement(uParam, uParam, jParam)
 	}
 }
 
@@ -39,44 +39,40 @@ routine propagateTypeChangeToTypedMultiplicityElement(uml::TypedElement uTyped, 
 	match {
 		check {
 			if(uTyped !== uMultiplicity) {
-				throw new IllegalStateException("uml::TypedElement uTyped and uml::MultiplicityElement uMultiplicity"
+				throw new IllegalStateException("uml::TypedElement uTyped, uml::MultiplicityElement uMultiplicity"
 					+ "have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
 				)
 			}
 			true
 		}
 	}
-	action {
-		execute {
-			val existingUmlType = uTyped.type
-			val jType = jElement.typeReference
-			val isCollectionReference = isCollectionTypeReference(jType)
-			val newJavaType = if (isCollectionReference) {
-				uMultiplicity.lower = 0
-				uMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
-				getInnerTypeRefOfCollectionReference(jType)
-			} else {
-				jType
-			}
-			if (newJavaType !== null && newJavaType.target instanceof ConcreteClassifier && newJavaType.target.containingCompilationUnit.namespaces.head == "java") {
-				createExistingUmlClassifier(newJavaType.target as ConcreteClassifier)
-			}
-			val newUmlType = getUmlTypeFromReference(newJavaType, correspondenceModel)
-			if (!EcoreUtil.equals(existingUmlType, newUmlType)) {
-				uTyped.type = newUmlType
-			}
+	update {
+		val existingUmlType = uTyped.type
+		val jType = jElement.typeReference
+		val isCollectionReference = isCollectionTypeReference(jType)
+		val newJavaType = if (isCollectionReference) {
+			uMultiplicity.lower = 0
+			uMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
+			getInnerTypeRefOfCollectionReference(jType)
+		} else {
+			jType
+		}
+		if (newJavaType !== null && newJavaType.target instanceof ConcreteClassifier && newJavaType.target.containingCompilationUnit.namespaces.head == "java") {
+			createExistingUmlClassifier(newJavaType.target as ConcreteClassifier)
+		}
+		val newUmlType = getUmlTypeFromReference(newJavaType, correspondenceModel)
+		if (!EcoreUtil.equals(existingUmlType, newUmlType)) {
+			uTyped.type = newUmlType
 		}
 	}
 }
 
 routine createExistingUmlClassifier(java::ConcreteClassifier existingJavaClassifier) {
-	action {
-		call {
-			createExistingUmlPackage(existingJavaClassifier.containingCompilationUnit.namespacesAsString)
-			switch (existingJavaClassifier) {
-				Interface: createExistingUmlInterface(existingJavaClassifier)
-				org.emftext.language.java.classifiers.Class: createExistingUmlClass(existingJavaClassifier)
-			}
+	update {
+		createExistingUmlPackage(existingJavaClassifier.containingCompilationUnit.namespacesAsString)
+		switch (existingJavaClassifier) {
+			Interface: createExistingUmlInterface(existingJavaClassifier)
+			org.emftext.language.java.classifiers.Class: createExistingUmlClass(existingJavaClassifier)
 		}
 	}
 }
@@ -86,16 +82,15 @@ routine createExistingUmlClass(java::Class existingJavaClass) {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 		require absence of uml::Class corresponding to existingJavaClass
 	}
-	action {
-		val umlClass = create uml::Class and initialize {
-			umlClass.name = existingJavaClass.name
-		}
-		execute {
-			findUmlPackage(umlModel, existingJavaClass.containingCompilationUnit.namespaces.last) => [
-				packagedElements += umlClass
-			]
-		}
-		add correspondence between existingJavaClass and umlClass
+	create {
+		val umlClass = new uml::Class
+	}
+	update {
+		umlClass.name = existingJavaClass.name
+		findUmlPackage(umlModel, existingJavaClass.containingCompilationUnit.namespaces.last) => [
+			packagedElements += umlClass
+		]
+		addCorrespondenceBetween(existingJavaClass, umlClass)
 	}
 }
 
@@ -104,16 +99,15 @@ routine createExistingUmlInterface(java::Interface existingJavaInterface) {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 		require absence of uml::Interface corresponding to existingJavaInterface
 	}
-	action {
-		val umlInterface = create uml::Interface and initialize {
-			umlInterface.name = existingJavaInterface.name
-		}
-		execute {
-			findUmlPackage(umlModel, existingJavaInterface.containingCompilationUnit.namespaces.last) => [
-				packagedElements += umlInterface
-			]
-		}
-		add correspondence between existingJavaInterface and umlInterface
+	create {
+		val umlInterface = new uml::Interface
+	}
+	update {
+		umlInterface.name = existingJavaInterface.name
+		findUmlPackage(umlModel, existingJavaInterface.containingCompilationUnit.namespaces.last) => [
+			packagedElements += umlInterface
+		]
+		addCorrespondenceBetween(existingJavaInterface, umlInterface)
 	}
 }
 
@@ -121,29 +115,26 @@ routine createExistingUmlPackage(String namespaces) {
 	match {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 	}
-	action {
-		call {
-			var org.eclipse.uml2.uml.Package currentPackage = umlModel
-			for (namespace : namespaces.split("\\.")) {
-				val existingUmlPackage = currentPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).findFirst[name == namespace]
-				currentPackage = if (existingUmlPackage !== null) {
-					existingUmlPackage
-				} else {
-					createUmlPackage(currentPackage, namespace)
-					currentPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).findFirst[name == namespace]
-				}
+	update {
+		var org.eclipse.uml2.uml.Package currentPackage = umlModel
+		for (namespace : namespaces.split("\\.")) {
+			val existingUmlPackage = currentPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).findFirst[name == namespace]
+			currentPackage = if (existingUmlPackage !== null) {
+				existingUmlPackage
+			} else {
+				createUmlPackage(currentPackage, namespace)
+				currentPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).findFirst[name == namespace]
 			}
 		}
 	}
 }
 
 routine createUmlPackage(uml::Package parentPackage, String packageName) {
-	action {
-		val umlPackage = create uml::Package and initialize {
-			umlPackage.name = packageName
-		}
-		update parentPackage {
-			parentPackage.packagedElements += umlPackage
-		}
+	create {
+		val umlPackage = new uml::Package
+	}
+	update {
+		umlPackage.name = packageName
+		parentPackage.packagedElements += umlPackage
 	}
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
@@ -109,7 +109,7 @@ routine deleteJavaField(uml::Property umlProperty) {
 
     }
     update {
-        deleteObject(javaField)
+        removeObject(javaField)
         removeCorrespondenceBetween(javaField, umlProperty)
     	deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.GETTER)
     	deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.SETTER)
@@ -121,7 +121,7 @@ routine deleteJavaAccessor(uml::Property umlProperty, String tag) {
 		val javaAccessor = retrieve java::ClassMethod corresponding to umlProperty tagged with tag
 	}
 	update {
-		deleteObject(javaAccessor)
+		removeObject(javaAccessor)
 		removeCorrespondenceBetween(javaAccessor, umlProperty)
 	}
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
@@ -41,24 +41,22 @@ routine createOrFindJavaField(uml::Property umlProperty, uml::Classifier umlClas
         val jClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
         require absence of java::Field corresponding to umlProperty
     }
-    action {
-        call {
-            val foundField = jClassifier.members.filter(Field).filter[name == umlProperty.name].claimNotMany
-            if (foundField === null) {
-                createJavaField(umlProperty) 
-            } else {
-                addAttributeCorrespondence(umlProperty, foundField)
-                val getter = jClassifier.methods.filter(ClassMethod).filter [ name == buildGetterName(umlProperty.name) ].claimNotMany
-                val setter = jClassifier.methods.filter(ClassMethod).filter [ name == buildSetterName(umlProperty.name) ].claimNotMany
-                if (getter !== null) {
-                	createAccessorCorrespondence(umlProperty, getter, UmlJavaCorrespondenceTag.GETTER)
-                }
-                if (setter !== null) {
-                	createAccessorCorrespondence(umlProperty, setter, UmlJavaCorrespondenceTag.SETTER)
-                }
+    update {
+        val foundField = jClassifier.members.filter(Field).filter[name == umlProperty.name].claimNotMany
+        if (foundField === null) {
+            createJavaField(umlProperty) 
+        } else {
+            addAttributeCorrespondence(umlProperty, foundField)
+            val getter = jClassifier.methods.filter(ClassMethod).filter [ name == buildGetterName(umlProperty.name) ].claimNotMany
+            val setter = jClassifier.methods.filter(ClassMethod).filter [ name == buildSetterName(umlProperty.name) ].claimNotMany
+            if (getter !== null) {
+            	createAccessorCorrespondence(umlProperty, getter, UmlJavaCorrespondenceTag.GETTER)
             }
-            changeJavaAttributeType(umlProperty)
+            if (setter !== null) {
+            	createAccessorCorrespondence(umlProperty, setter, UmlJavaCorrespondenceTag.SETTER)
+            }
         }
+        changeJavaAttributeType(umlProperty)
     }    
 }
 
@@ -66,22 +64,21 @@ routine createJavaField(uml::Property umlProperty) {
     match {
         require absence of java::Field corresponding to umlProperty
     }
-    action {
-        val javaField = create java::Field and initialize {
-            javaField.name = umlProperty.name
-            javaField.makePublic
-        }
-        add correspondence between umlProperty and javaField
-        call {
-            createOrFindJavaGetter(umlProperty, javaField)
-            createOrFindJavaSetter(umlProperty, javaField)
-        }
+    create {
+    	val javaField = new java::Field
+    }
+    update {
+        javaField.name = umlProperty.name
+        javaField.makePublic
+        addCorrespondenceBetween(umlProperty, javaField)
+        createOrFindJavaGetter(umlProperty, javaField)
+        createOrFindJavaSetter(umlProperty, javaField)
     }
 }
 
 routine addAttributeCorrespondence(uml::Property umlAttribute, java::Field javaField) {
-     action {
-         add correspondence between umlAttribute and javaField
+     update {
+         addCorrespondenceBetween(umlAttribute, javaField)
      }
 }
 
@@ -92,12 +89,10 @@ routine insertJavaField(uml::Property umlProperty, uml::Classifier umlClassifier
         val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.GETTER
         val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.SETTER
     }
-    action {
-        update javaClassifier {
-            javaClassifier.members += javaField
-            javaGetter.ifPresent [ javaClassifier.members += it ]
-            javaSetter.ifPresent [ javaClassifier.members += it ]
-        }
+    update {
+        javaClassifier.members += javaField
+        javaGetter.ifPresent [ javaClassifier.members += it ]
+        javaSetter.ifPresent [ javaClassifier.members += it ]
     }
 }
 
@@ -113,12 +108,11 @@ routine deleteJavaField(uml::Property umlProperty) {
         val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.SETTER
 
     }
-    action {
-        delete javaField
-        call {
-        	deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.GETTER)
-        	deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.SETTER)
-        }
+    update {
+        deleteObject(javaField)
+        removeCorrespondenceBetween(javaField, umlProperty)
+    	deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.GETTER)
+    	deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.SETTER)
     }
 }
 
@@ -126,8 +120,9 @@ routine deleteJavaAccessor(uml::Property umlProperty, String tag) {
 	match {
 		val javaAccessor = retrieve java::ClassMethod corresponding to umlProperty tagged with tag
 	}
-	action {
-		delete javaAccessor
+	update {
+		deleteObject(javaAccessor)
+		removeCorrespondenceBetween(javaAccessor, umlProperty)
 	}
 }
 
@@ -140,10 +135,8 @@ routine setJavaAttributeFinal(uml::Property umlAttr) {
     match {
         val jAttr = retrieve java::Field corresponding to umlAttr
     }
-    action {
-        update jAttr {
-            jAttr.final = umlAttr.readOnly
-        }
+    update {
+        jAttr.final = umlAttr.readOnly
     }
 }
 
@@ -156,10 +149,8 @@ routine setStatic(uml::Property umlAttr) {
     match {
         val jAttr = retrieve java::Field corresponding to umlAttr tagged with ""
     }
-    action {
-        update jAttr {
-            jAttr.static = umlAttr.isStatic
-        }
+    update {
+        jAttr.static = umlAttr.isStatic
         //TODO: updating the static property of a java field requires an update of its corresponding accessors
     }
 }
@@ -188,43 +179,37 @@ routine changeJavaAttributeType(uml::Property uAttribute) {
         val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.GETTER
         val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.SETTER
     }
-    action {
-        call {
-            umlToJavaTypePropagation.propagatePropertyTypeChanged(uAttribute, jAttribute, jCustomType.orElse(null))
-            jGetter.ifPresent [ updateAttributeTypeInGetter(it, jAttribute) ]
-            jSetter.ifPresent [ updateAttributeTypeInSetter(it, jAttribute) ]
-        }
+    update {
+        umlToJavaTypePropagation.propagatePropertyTypeChanged(uAttribute, jAttribute, jCustomType.orElse(null))
+        jGetter.ifPresent [ updateAttributeTypeInGetter(it, jAttribute) ]
+        jSetter.ifPresent [ updateAttributeTypeInSetter(it, jAttribute) ]
     }
 }
 
 
 routine createOrFindJavaGetter(uml::Property uAttribute, java::Field jAttribute) {
-    action {
-        call {
-            var javaGetter = getJavaGettersOfAttribute(jAttribute).head
-            if (javaGetter === null) {
-                javaGetter = createGetterForAttribute(jAttribute)
-            }
-            createAccessorCorrespondence(uAttribute, javaGetter, UmlJavaCorrespondenceTag.GETTER)
+    update {
+        var javaGetter = getJavaGettersOfAttribute(jAttribute).head
+        if (javaGetter === null) {
+            javaGetter = createGetterForAttribute(jAttribute)
         }
+        createAccessorCorrespondence(uAttribute, javaGetter, UmlJavaCorrespondenceTag.GETTER)
     }
 }
 
 routine createOrFindJavaSetter(uml::Property uAttribute, java::Field jAttribute) {
-    action {
-        call {
-            var javaSetter = getJavaSettersOfAttribute(jAttribute).head
-            if (javaSetter === null) {
-                javaSetter = createSetterForAttribute(jAttribute)
-            }
-            createAccessorCorrespondence(uAttribute, javaSetter, UmlJavaCorrespondenceTag.SETTER)
+    update {
+        var javaSetter = getJavaSettersOfAttribute(jAttribute).head
+        if (javaSetter === null) {
+            javaSetter = createSetterForAttribute(jAttribute)
         }
+        createAccessorCorrespondence(uAttribute, javaSetter, UmlJavaCorrespondenceTag.SETTER)
     }
 }
 
 routine createAccessorCorrespondence(uml::Property uAttribute, java::ClassMethod jMethod, String tag) {
-    action {
-        add correspondence between uAttribute and jMethod tagged with tag
+    update {
+        addCorrespondenceBetween(uAttribute, jMethod, tag)
     }
 }
 
@@ -239,12 +224,10 @@ routine renameJavaAttribute(String newName, String oldName, uml::Property uAttri
         val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.GETTER
         val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.SETTER
     }
-    action {
-        call {
-            jAttribute.name = uAttribute.name
-            jGetter.ifPresent [ renameGetterOfAttribute(it, jAttribute) ]
-            jSetter.ifPresent [ renameSetter(it, jAttribute, oldName) ]
-        }
+    update {
+        jAttribute.name = uAttribute.name
+        jGetter.ifPresent [ renameGetterOfAttribute(it, jAttribute) ]
+        jSetter.ifPresent [ renameSetter(it, jAttribute, oldName) ]
     }
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -140,7 +140,7 @@ routine deleteJavaClass(uml::Classifier umlClassifier) {
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
 	}
 	update {
-	    deleteObject(javaClassifier.containingCompilationUnit)
+	    removeObject(javaClassifier.containingCompilationUnit)
 	    removeCorrespondenceBetween(javaClassifier.containingCompilationUnit, umlClassifier)
 	}
 }
@@ -209,7 +209,7 @@ routine deleteJavaSuperClass(uml::Generalization uGeneralization) {
 		val jReference = retrieve java::TypeReference corresponding to uGeneralization
 	}
 	update {
-		deleteObject(jReference)
+		removeObject(jReference)
 		removeCorrespondenceBetween(jReference, uGeneralization)
 	}
 }
@@ -273,7 +273,7 @@ routine deleteJavaClassImplementsReference(uml::InterfaceRealization uRealizatio
 	}
 	update {
 		uRealization.clients -= uClass
-		deleteObject(jReference)
+		removeObject(jReference)
 		removeCorrespondenceBetween(jReference, uRealization)
 	}
 }
@@ -396,7 +396,7 @@ routine deleteJavaSuperInterface(uml::Generalization uGeneralization) {
 		val jReference = retrieve java::TypeReference corresponding to uGeneralization
 	}
 	update {
-		deleteObject(jReference)
+		removeObject(jReference)
 		removeCorrespondenceBetween(jReference, uGeneralization)
 	}
 }
@@ -469,7 +469,7 @@ routine deleteJavaEnumConstant(uml::EnumerationLiteral uLiteral) {
 		val jConst = retrieve java::EnumConstant corresponding to uLiteral
 	}
 	update {
-		deleteObject(jConst)
+		removeObject(jConst)
 		removeCorrespondenceBetween(jConst, uLiteral)
 	}
 }
@@ -597,7 +597,7 @@ routine deleteJavaPackage(uml::Package uPackage) {
 		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).forEach[deleteJavaPackage()]
 		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Class).forEach[deleteJavaClass()]
 		jPackage.ifPresent[
-			deleteObject(it)
+			removeObject(it)
 			removeCorrespondenceBetween(uPackage, it)
 		]
 	}

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -45,52 +45,50 @@ routine createOrFindJavaClass(uml::Classifier umlClassifier) {
 		require absence of java::Class corresponding to umlClassifier
 		val javaPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
 	}
-	action {
-		call {
-		   if (javaPackage.isPresent) {
-			   createOrFindJavaClassInPackage(umlClassifier, javaPackage.get)
-		   } else {
-				createJavaClass(umlClassifier)
-		   }
+	update {
+		if (javaPackage.isPresent) {
+			createOrFindJavaClassInPackage(umlClassifier, javaPackage.get)
+		} else {
+			createJavaClass(umlClassifier)
 		}
 	}
 }
 
 routine createOrFindJavaClassInPackage(uml::Classifier umlClassifier, java::Package javaPackage) {
-	action {
-		call {
-			val foundClass = findClassifier(umlClassifier.name, javaPackage, org.emftext.language.java.classifiers.Class)
-			if(foundClass === null) {
-				createJavaClass(umlClassifier)
-			} else {
-				addMissingClassifierCorrespondence(umlClassifier, foundClass)
-			}
+	update {
+		val foundClass = findClassifier(umlClassifier.name, javaPackage, org.emftext.language.java.classifiers.Class)
+		if(foundClass === null) {
+			createJavaClass(umlClassifier)
+		} else {
+			addMissingClassifierCorrespondence(umlClassifier, foundClass)
 		}
 	}
 }
 
 routine createJavaClass(uml::Classifier umlClassifier) {
-	action {
-		val javaClassifier = create java::Class and initialize {
-			javaClassifier.name = umlClassifier.name
-			javaClassifier.makePublic
-		}
-		call createJavaCompilationUnit (umlClassifier, javaClassifier)
-		add correspondence between umlClassifier and javaClassifier
+	create {
+		val javaClassifier = new java::Class
+	}
+	update {
+		javaClassifier.name = umlClassifier.name
+		javaClassifier.makePublic
+		createJavaCompilationUnit (umlClassifier, javaClassifier)
+		addCorrespondenceBetween(umlClassifier, javaClassifier)
 	}
 }
 
 routine addMissingClassifierCorrespondence(uml::Classifier umlClassifier, java::ConcreteClassifier javaClassifier) {
-	action {
-		add correspondence between javaClassifier and umlClassifier
+	update {
+		addCorrespondenceBetween(javaClassifier, umlClassifier)
 	}
 }
 
 routine createJavaCompilationUnit(uml::Classifier umlClassifier, java::ConcreteClassifier jClassifier) {
-	action {
-		val javaCompilationUnit = create java::CompilationUnit and initialize {
-			javaCompilationUnit.classifiers += jClassifier
-		}
+	create {
+		val javaCompilationUnit = new java::CompilationUnit
+	}
+	update {
+		javaCompilationUnit.classifiers += jClassifier
 	}
 }
 
@@ -99,18 +97,15 @@ routine insertJavaClassifier(uml::Classifier umlClassifier, uml::Package umlPack
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
 		val javaPackage = retrieve optional java::Package corresponding to umlPackage
 	}
-	action {
-		update javaClassifier.containingCompilationUnit {
-		    val javaCompilationUnit = javaClassifier.containingCompilationUnit
-			var modified = javaCompilationUnit.updateNamespaces(javaPackage)
-			val newName = getCompilationUnitName(javaPackage, javaClassifier.name)
-			modified = javaCompilationUnit.updateName(newName) || modified
-			if (modified) {
-				persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit))
-			}
+	update {
+	    val javaCompilationUnit = javaClassifier.containingCompilationUnit
+		var modified = javaCompilationUnit.updateNamespaces(javaPackage)
+		val newName = getCompilationUnitName(javaPackage, javaClassifier.name)
+		modified = javaCompilationUnit.updateName(newName) || modified
+		if (modified) {
+			persistProjectRelative(umlClassifier, javaCompilationUnit, buildJavaFilePath(javaCompilationUnit))
 		}
-		call javaPackage.ifPresent [
-		    val javaCompilationUnit = javaClassifier.containingCompilationUnit
+		javaPackage.ifPresent [
 			if (!compilationUnits.contains(javaCompilationUnit)) {
 				compilationUnits += javaCompilationUnit
 			}
@@ -129,11 +124,9 @@ routine renameJavaClassifier(uml::Classifier umlClassifier) {
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
 		check umlClassifier.name != javaClassifier.name
 	}
-	action {
-		update javaClassifier {
-			javaClassifier.name = umlClassifier.name
-		}
-		call insertJavaClassifier(umlClassifier, umlClassifier.eContainer as org.eclipse.uml2.uml.Package)
+	update {
+		javaClassifier.name = umlClassifier.name
+		insertJavaClassifier(umlClassifier, umlClassifier.eContainer as org.eclipse.uml2.uml.Package)
 	}
 }
 
@@ -142,12 +135,13 @@ reaction UmlClassifierDeleted {
 	call deleteJavaClass(affectedEObject)
 }
 
-routine deleteJavaClass(uml::Classifier umlClassifer) {
+routine deleteJavaClass(uml::Classifier umlClassifier) {
 	match {
-		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifer
+		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
 	}
-	action {
-	    delete javaClassifier.containingCompilationUnit
+	update {
+	    deleteObject(javaClassifier.containingCompilationUnit)
+	    removeCorrespondenceBetween(javaClassifier.containingCompilationUnit, umlClassifier)
 	}
 }
 
@@ -160,10 +154,8 @@ routine setJavaClassFinal(uml::Class umlClass) {
 	match {
 		val jClass = retrieve java::Class corresponding to umlClass
 	}
-	action {
-		update jClass {
-			jClass.final = umlClass.finalSpecialization
-		}
+	update {
+		jClass.final = umlClass.finalSpecialization
 	}
 }
 
@@ -176,10 +168,8 @@ routine setJavaClassAbstract(uml::Class umlClass) {
 	match {
 		val jClass = retrieve java::Class corresponding to umlClass
 	}
-	action {
-		update jClass {
-			jClass.abstract = umlClass.abstract
-		}
+	update {
+		jClass.abstract = umlClass.abstract
 	}
 }
 
@@ -194,19 +184,17 @@ routine addJavaSuperClass(uml::Class uClass, uml::Generalization uGeneralization
 		val jSuperClass = retrieve java::Class corresponding to uGeneralization.general
 		require absence of java::TypeReference corresponding to uGeneralization
 	}
-	action {
-		execute {
-			if (uClass.generals.size == 1) {
-				var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null, userInteractor)
-				addJavaImport(jClass.containingCompilationUnit, typeReference)
-				jClass.extends = typeReference
-				addGeneralizationCorrespondence(uGeneralization, typeReference)
-			} else {
-				userInteractor.notificationDialogBuilder.message("Can not synchronize multiple inheritance for " + uClass)
-					.title("Warning").notificationType(NotificationType.WARNING).windowModality(WindowModality.MODAL)
-					.startInteraction()
-				logger.warn("Routine not executed: Tried to set multiple inheritance for " + uClass)
-			}
+	update {
+		if (uClass.generals.size == 1) {
+			var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null, userInteractor)
+			addJavaImport(jClass.containingCompilationUnit, typeReference)
+			jClass.extends = typeReference
+			addGeneralizationCorrespondence(uGeneralization, typeReference)
+		} else {
+			userInteractor.notificationDialogBuilder.message("Can not synchronize multiple inheritance for " + uClass)
+				.title("Warning").notificationType(NotificationType.WARNING).windowModality(WindowModality.MODAL)
+				.startInteraction
+			logger.warn("Routine not executed: Tried to set multiple inheritance for " + uClass)
 		}
 	}
 }
@@ -220,8 +208,9 @@ routine deleteJavaSuperClass(uml::Generalization uGeneralization) {
 	match {
 		val jReference = retrieve java::TypeReference corresponding to uGeneralization
 	}
-	action {
-		delete jReference
+	update {
+		deleteObject(jReference)
+		removeCorrespondenceBetween(jReference, uGeneralization)
 	}
 }
 
@@ -249,19 +238,16 @@ routine createJavaClassImplementsReference(uml::InterfaceRealization uRealizatio
 		val jInterface = retrieve java::Interface corresponding to uRealization.contract
 		require absence of java::TypeReference corresponding to uRealization
 	}
-	action {
-		execute {
-			val matchingReference = jClass.implements.filter[target == jInterface]
-			checkState(matchingReference.size <= 1, "There is more than one implementation of Java interface %s in class %s", jInterface, jClass)
-			if (matchingReference.size == 1) {
-				addImplementsCorrespondence(uRealization, matchingReference.get(0))
-			} else {
-				var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null, userInteractor)
-				addJavaImport(jClass.containingCompilationUnit, typeReference)
-				jClass.implements += typeReference
-				addImplementsCorrespondence(uRealization, typeReference)
-			}
-			
+	update {
+		val matchingReference = jClass.implements.filter[target == jInterface]
+		checkState(matchingReference.size <= 1, "There is more than one implementation of Java interface %s in class %s", jInterface, jClass)
+		if (matchingReference.size == 1) {
+			addImplementsCorrespondence(uRealization, matchingReference.get(0))
+		} else {
+			var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null, userInteractor)
+			addJavaImport(jClass.containingCompilationUnit, typeReference)
+			jClass.implements += typeReference
+			addImplementsCorrespondence(uRealization, typeReference)
 		}
 	}
 }
@@ -270,8 +256,8 @@ routine addImplementsCorrespondence(uml::InterfaceRealization uRealization, java
 	match {
 		require absence of java::TypeReference corresponding to uRealization
 	}
-	action {
-		add correspondence between uRealization and jReference
+	update {
+		addCorrespondenceBetween(uRealization, jReference)
 	}
 }
 
@@ -285,11 +271,10 @@ routine deleteJavaClassImplementsReference(uml::InterfaceRealization uRealizatio
 		val jClass = retrieve java::Class corresponding to uClass
 		val jReference = retrieve java::TypeReference corresponding to uRealization
 	}
-	action {
-		update uRealization {
-			uRealization.clients -= uClass
-		}
-		delete jReference
+	update {
+		uRealization.clients -= uClass
+		deleteObject(jReference)
+		removeCorrespondenceBetween(jReference, uRealization)
 	}
 }
 
@@ -337,26 +322,22 @@ routine createOrFindJavaInterface(uml::Interface umlInterface) {
 		require absence of java::Interface corresponding to umlInterface
 		val javaPackage = retrieve optional java::Package corresponding to umlInterface.eContainer
 	}
-	action {
-		call {
-			if (javaPackage.isPresent) {
-				createOrFindJavaInterfaceInPackage(umlInterface, javaPackage.get)
-			} else {
-				createJavaInterface(umlInterface)
-			}
+	update {
+		if (javaPackage.isPresent) {
+			createOrFindJavaInterfaceInPackage(umlInterface, javaPackage.get)
+		} else {
+			createJavaInterface(umlInterface)
 		}
 	}
 }
 
 routine createOrFindJavaInterfaceInPackage(uml::Interface umlInterface, java::Package javaPackage) {
-	action {
-		call {
-			val foundInterface = findClassifier(umlInterface.name, javaPackage, org.emftext.language.java.classifiers.Interface)
-			if(foundInterface === null) {
-				createJavaInterface(umlInterface)
-			} else {
-				addMissingClassifierCorrespondence(umlInterface, foundInterface)
-			}
+	update {
+		val foundInterface = findClassifier(umlInterface.name, javaPackage, org.emftext.language.java.classifiers.Interface)
+		if(foundInterface === null) {
+			createJavaInterface(umlInterface)
+		} else {
+			addMissingClassifierCorrespondence(umlInterface, foundInterface)
 		}
 	}
 }
@@ -365,13 +346,14 @@ routine createJavaInterface(uml::Interface umlInterface) {
 	match {
 		require absence of java::Interface corresponding to umlInterface
 	}
-	action {
-		val javaInterface = create java::Interface and initialize {
-			javaInterface.name = umlInterface.name
-			javaInterface.makePublic
-		}
-		call createJavaCompilationUnit(umlInterface, javaInterface)
-		add correspondence between umlInterface and javaInterface
+	create {
+		val javaInterface = new java::Interface
+	}
+	update {
+		javaInterface.name = umlInterface.name
+		javaInterface.makePublic
+		createJavaCompilationUnit(umlInterface, javaInterface)
+		addCorrespondenceBetween(umlInterface, javaInterface)
 	}
 }
 
@@ -386,13 +368,11 @@ routine addJavaSuperInterface(uml::Interface uInterface, uml::Generalization uGe
 		val jSuperInterface = retrieve java::Interface corresponding to uGeneralization.general
 		require absence of java::TypeReference corresponding to uGeneralization
 	}
-	action {
-		execute{
-			var typeReference = createTypeReference(uGeneralization.general as Interface, Optional.^of(jSuperInterface), null, userInteractor)
-			addJavaImport(jInterface.containingCompilationUnit, typeReference)
-			jInterface.extends += typeReference
-			addGeneralizationCorrespondence(uGeneralization, typeReference)
-		}
+	update {
+		var typeReference = createTypeReference(uGeneralization.general as Interface, Optional.^of(jSuperInterface), null, userInteractor)
+		addJavaImport(jInterface.containingCompilationUnit, typeReference)
+		jInterface.extends += typeReference
+		addGeneralizationCorrespondence(uGeneralization, typeReference)
 	}
 }
 
@@ -401,8 +381,8 @@ routine addGeneralizationCorrespondence(uml::Generalization uGeneralization, jav
 		require absence of uml::Generalization corresponding to jReference
 		require absence of java::TypeReference corresponding to uGeneralization
 	}
-	action {
-		add correspondence between uGeneralization and jReference
+	update {
+		addCorrespondenceBetween(uGeneralization, jReference)
 	}
 }
 
@@ -415,8 +395,9 @@ routine deleteJavaSuperInterface(uml::Generalization uGeneralization) {
 	match {
 		val jReference = retrieve java::TypeReference corresponding to uGeneralization
 	}
-	action {
-		delete jReference
+	update {
+		deleteObject(jReference)
+		removeCorrespondenceBetween(jReference, uGeneralization)
 	}
 }
 
@@ -447,13 +428,14 @@ routine createJavaEnum(uml::Enumeration uEnum) {
 	match {
 		require absence of java::Enumeration corresponding to uEnum
 	}
-	action {
-		val jEnum = create java::Enumeration and initialize {
-			jEnum.name = uEnum.name
-			jEnum.makePublic
-		}
-		call createJavaCompilationUnit(uEnum, jEnum)
-		add correspondence between uEnum and jEnum
+	create {
+		val jEnum = new java::Enumeration
+	}
+	update {
+		jEnum.name = uEnum.name
+		jEnum.makePublic
+		createJavaCompilationUnit(uEnum, jEnum)
+		addCorrespondenceBetween(uEnum, jEnum)
 	}
 }
 
@@ -467,14 +449,13 @@ routine createJavaEnumConstant(uml::EnumerationLiteral uLiteral, uml::Enumeratio
 		val jEnum = retrieve java::Enumeration corresponding to uEnum
 		require absence of java::EnumConstant corresponding to uLiteral
 	}
-	action {
-		val jConstant = create java::EnumConstant and initialize {
-			jConstant.name = uLiteral.name
-		}
-		update jEnum {
-			jEnum.constants += jConstant
-		}
-		add correspondence between jConstant and uLiteral
+	create {
+		val jConstant = new java::EnumConstant
+	}
+	update {
+		jConstant.name = uLiteral.name
+		jEnum.constants += jConstant
+		addCorrespondenceBetween(jConstant, uLiteral)
 	}
 }
 
@@ -487,8 +468,9 @@ routine deleteJavaEnumConstant(uml::EnumerationLiteral uLiteral) {
 	match {
 		val jConst = retrieve java::EnumConstant corresponding to uLiteral
 	}
-	action {
-		delete jConst
+	update {
+		deleteObject(jConst)
+		removeCorrespondenceBetween(jConst, uLiteral)
 	}
 }
 
@@ -505,8 +487,8 @@ routine checkIfUmlModelCorrespondenceExists(uml::Model newModel) {
 		val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
 		check !alreadyCorrespondingModels.contains(newModel)
 	}
-	action {
-		add correspondence between UMLPackage.Literals.MODEL and newModel
+	update {
+		addCorrespondenceBetween(UMLPackage.Literals.MODEL, newModel)
 	}
 }
 
@@ -516,12 +498,10 @@ reaction UmlModelRemoved {
 }
 
 routine removeUmlModel(uml::Model removedModel) {
-	action {
-		call {
-			val rootPackages = new ArrayList(removedModel.nestedPackages)
-			rootPackages.forEach[deleteJavaPackage()]
-		}
-		remove correspondence between UMLPackage.Literals.MODEL and removedModel
+	update {
+		val rootPackages = new ArrayList(removedModel.nestedPackages)
+		rootPackages.forEach[deleteJavaPackage()]
+		removeCorrespondenceBetween(UMLPackage.Literals.MODEL, removedModel)
 	}
 }
 
@@ -540,20 +520,18 @@ routine createOrFindJavaPackage(uml::Package uPackage) {
 		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
 		with matchingPackages.namespacesAsString + matchingPackages.name == getUmlNamespaceAsString(uPackage)
 	}
-	action {
-		call {
-			if(matchingPackages.empty) {
-				createJavaPackage(uPackage)
-			} else {
-				addPackageCorrespondence(uPackage, matchingPackages.head)
-			}
+	update {
+		if(matchingPackages.empty) {
+			createJavaPackage(uPackage)
+		} else {
+			addPackageCorrespondence(uPackage, matchingPackages.head)
 		}
 	}
 }
 
 routine addPackageCorrespondence(uml::Package uPackage, java::Package jPackage) {
-	action {
-		add correspondence between jPackage and uPackage
+	update {
+		addCorrespondenceBetween(jPackage, uPackage)
 	}
 }
 
@@ -561,11 +539,13 @@ routine createJavaPackage(uml::Package uPackage) {
 	match {
 		require absence of java::Package corresponding to uPackage
 	}
-	action {
-		val jPackage = create java::Package
-		add correspondence between jPackage and uPackage
+	create {
+		val jPackage = new java::Package
+	}
+	update {
+		addCorrespondenceBetween(jPackage, uPackage)
 		// Required to enable locating existing packages with missing correspondences when keeping more than two models consistent:
-		add correspondence between jPackage and ContainersPackage.Literals.PACKAGE
+		addCorrespondenceBetween(jPackage, ContainersPackage.Literals.PACKAGE)
 	}
 }
 
@@ -580,30 +560,26 @@ routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
 		val jPackage = retrieve java::Package corresponding to uPackage
 		check uPackage.name != jPackage.name || uPackage.umlParentNamespaceAsStringList != jPackage.namespaces
 	}
-	action {
-		call {
-			var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList)
-			modified = jPackage.updateName(uPackage.name) || modified
-			if (modified) {
-				persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
-				for (compUnit : copyOf(jPackage.compilationUnits)) {
-					changePackageOfJavaCompilationUnit(jPackage, compUnit, uNamespace)
-				}
-				// TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
-				for (nestedPackage : copyOf(uPackage.nestedPackages)) {
-					renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
-				}
+	update {
+		var modified = jPackage.updateNamespaces(uPackage.umlParentNamespaceAsStringList)
+		modified = jPackage.updateName(uPackage.name) || modified
+		if (modified) {
+			persistProjectRelative(uPackage, jPackage, buildJavaFilePath(jPackage))
+			for (compUnit : copyOf(jPackage.compilationUnits)) {
+				changePackageOfJavaCompilationUnit(jPackage, compUnit, uNamespace)
+			}
+			// TODO TS This should be dealt with by the java domain, as this regards model specific persistence issues:
+			for (nestedPackage : copyOf(uPackage.nestedPackages)) {
+				renameJavaPackage(nestedPackage, uNamespace) // prevents broken subpackages
 			}
 		}
 	}
 }
 
 routine changePackageOfJavaCompilationUnit(java::Package jPackage, java::CompilationUnit jCompUnit, uml::Namespace uNamespace) {
-	action {
-		update jCompUnit {
-			if (jCompUnit.updateNamespaces(jPackage)) {
-				persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))	
-			}
+	update {
+		if (jCompUnit.updateNamespaces(jPackage)) {
+			persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))	
 		}
 	}
 }
@@ -617,12 +593,13 @@ routine deleteJavaPackage(uml::Package uPackage) {
 	match {
 		val jPackage = retrieve optional java::Package corresponding to uPackage
 	}
-	action {
-		call {
-			uPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).forEach[deleteJavaPackage()]
-			uPackage.packagedElements.filter(org.eclipse.uml2.uml.Class).forEach[deleteJavaClass()]
-		} 
-		delete jPackage.orElse(null)
+	update {
+		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).forEach[deleteJavaPackage()]
+		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Class).forEach[deleteJavaClass()]
+		jPackage.ifPresent[
+			deleteObject(it)
+			removeCorrespondenceBetween(uPackage, it)
+		]
 	}
 }
 
@@ -632,18 +609,16 @@ reaction UmlPrimitiveTypeInserted {
 }
 
 routine validateSupportedPrimitiveType(uml::PrimitiveType type) {
-	action {
-		execute {
-			if (!type.isSupportedUmlPrimitiveType()) {
-				userInteractor.notificationDialogBuilder
-					.message("Only predefined uml::PrimitiveTypes will be mapped properly. "
-						+ "Please use the types defined in \"pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml\" "
-						+ "or \"pathmap://UML_LIBRARIES/JavaPrimitiveTypes.library.uml\" instead.")
-					.title("Warning")
-					.notificationType(NotificationType.WARNING)
-					.windowModality(WindowModality.MODAL)
-					.startInteraction
-			}
+	update {
+		if (!type.isSupportedUmlPrimitiveType()) {
+			userInteractor.notificationDialogBuilder
+				.message("Only predefined uml::PrimitiveTypes will be mapped properly. "
+					+ "Please use the types defined in \"pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml\" "
+					+ "or \"pathmap://UML_LIBRARIES/JavaPrimitiveTypes.library.uml\" instead.")
+				.title("Warning")
+				.notificationType(NotificationType.WARNING)
+				.windowModality(WindowModality.MODAL)
+				.startInteraction
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -64,25 +64,24 @@ routine createOrFindJavaConstructor(uml::Operation umlOperation, uml::Classifier
         require absence of java::Constructor corresponding to umlOperation
         require absence of java::Method corresponding to umlOperation
     }
-    action {
-        call {
-            val foundConstructor = javaClassifier.members.filter(Constructor).findFirst[name == umlOperation.name]
-            if (foundConstructor === null) {
-                createJavaConstructor(umlOperation)
-            } else {
-                addMethodCorrespondence(foundConstructor, umlOperation)
-            }
+    update {
+        val foundConstructor = javaClassifier.members.filter(Constructor).findFirst[name == umlOperation.name]
+        if (foundConstructor === null) {
+            createJavaConstructor(umlOperation)
+        } else {
+            addMethodCorrespondence(foundConstructor, umlOperation)
         }
     }
 }
 
 routine createJavaConstructor(uml::Operation umlOperation) {
-    action {
-        val javaConstructor = create java::Constructor and initialize {
-            javaConstructor.name = umlOperation.name
-            setJavaVisibility(javaConstructor, umlOperation.visibility)
-        }
-        add correspondence between umlOperation and javaConstructor
+	create {
+		val javaConstructor = new java::Constructor
+	}
+    update {
+    	javaConstructor.name = umlOperation.name
+		setJavaVisibility(javaConstructor, umlOperation.visibility)
+		addCorrespondenceBetween(umlOperation, javaConstructor)
     }
 }
 
@@ -93,26 +92,25 @@ routine createOrFindJavaClassMethod(uml::Operation umlOperation, uml::Classifier
         require absence of java::ClassMethod corresponding to umlOperation
         require absence of java::Constructor corresponding to umlOperation
     }
-    action {
-        call {
-            val foundMethod = javaClassifier.members.filter(ClassMethod).findFirst[name == umlOperation.name]
-            if (foundMethod === null) {
-                createJavaClassMethod(umlOperation)
-            } else {
-                addMethodCorrespondence(foundMethod, umlOperation)
-            }
+    update {
+        val foundMethod = javaClassifier.members.filter(ClassMethod).findFirst[name == umlOperation.name]
+        if (foundMethod === null) {
+            createJavaClassMethod(umlOperation)
+        } else {
+            addMethodCorrespondence(foundMethod, umlOperation)
         }
     }
 }
 
 routine createJavaClassMethod(uml::Operation umlOperation) {
-    action {
-        val javaMethod = create java::ClassMethod and initialize {
-            javaMethod.name = umlOperation.name
-            setJavaVisibility(javaMethod, umlOperation.visibility)
-        }
-        add correspondence between umlOperation and javaMethod
-        call setJavaMethodReturnType(umlOperation, umlOperation.getReturnResult)
+	create {
+		val javaMethod = new java::ClassMethod
+	}
+    update {
+		javaMethod.name = umlOperation.name
+        setJavaVisibility(javaMethod, umlOperation.visibility)
+        addCorrespondenceBetween(umlOperation, javaMethod)
+        setJavaMethodReturnType(umlOperation, umlOperation.getReturnResult)
     }
 }
 
@@ -121,32 +119,31 @@ routine createOrFindJavaInterfaceMethod(uml::Operation umlOperation, uml::Classi
         val javaClassifier = retrieve java::Interface corresponding to umlClassifier
         require absence of java::InterfaceMethod corresponding to umlOperation
     }
-    action {
-        call {
-            val foundMethod = javaClassifier.members.filter(InterfaceMethod).findFirst[name == umlOperation.name]
-            if (foundMethod === null) {
-                createJavaInterfaceMethod(umlOperation)
-            } else {
-                addMethodCorrespondence(foundMethod, umlOperation)
-            }
+    update {
+        val foundMethod = javaClassifier.members.filter(InterfaceMethod).findFirst[name == umlOperation.name]
+        if (foundMethod === null) {
+            createJavaInterfaceMethod(umlOperation)
+        } else {
+            addMethodCorrespondence(foundMethod, umlOperation)
         }
     }
 }
 
 routine createJavaInterfaceMethod(uml::Operation umlOperation) {
-    action {
-        val javaMethod = create java::InterfaceMethod and initialize {
-            javaMethod.name = umlOperation.name
-            javaMethod.makePublic
-        }
-        add correspondence between umlOperation and javaMethod
-        call setJavaMethodReturnType(umlOperation, umlOperation.getReturnResult)
+	create {
+		val javaMethod = new java::InterfaceMethod
+	}
+    update {
+		javaMethod.name = umlOperation.name
+		javaMethod.makePublic
+        addCorrespondenceBetween(umlOperation, javaMethod)
+        setJavaMethodReturnType(umlOperation, umlOperation.getReturnResult)
     }
 }
 
 routine addMethodCorrespondence(java::Member javaMethodOrConstructor, uml::Operation umlOperation) {
-     action {
-         add correspondence between umlOperation and javaMethodOrConstructor
+     update {
+         addCorrespondenceBetween(umlOperation, javaMethodOrConstructor)
      }
 }
 
@@ -156,10 +153,8 @@ routine insertJavaMethod(uml::Operation umlOperation, uml::Classifier umlClassif
             with javaMethod instanceof Constructor || javaMethod instanceof Method
         val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
     }
-    action {
-        update javaClassifier {
-            javaClassifier.members += javaMethod
-        }
+    update {
+		javaClassifier.members += javaMethod
     }
 }
 
@@ -173,8 +168,9 @@ routine deleteJavaMethod(uml::Operation umlOperation) {
         val javaMethod = retrieve java::Member corresponding to umlOperation 
             with javaMethod instanceof Constructor || javaMethod instanceof Method
     }
-    action {
-        delete javaMethod
+    update {
+        deleteObject(javaMethod)
+        removeCorrespondenceBetween(javaMethod, umlOperation)
     }
 }
 
@@ -190,14 +186,12 @@ routine setJavaMethodReturnType(uml::Operation uOperation, uml::Parameter uParam
         val jMethod = retrieve java::Method corresponding to uOperation
         val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uParam?.type
     }
-    action {
-        execute {
-            if (uParam !== null){
-                umlToJavaTypePropagation.propagateReturnParameterTypeChanged(uParam, jMethod, jCustomType.orElse(null))
-            }
-            else {
-                jMethod.typeReference = TypesFactory.eINSTANCE.createVoid
-            }
+    update {
+        if (uParam !== null){
+            umlToJavaTypePropagation.propagateReturnParameterTypeChanged(uParam, jMethod, jCustomType.orElse(null))
+        }
+        else {
+            jMethod.typeReference = TypesFactory.eINSTANCE.createVoid
         }
     }
 }
@@ -211,10 +205,8 @@ routine setStatic(uml::Operation uFeat) {
     match {
         val jMethod = retrieve java::Method corresponding to uFeat tagged with ""
     }
-    action {
-        update jMethod {
-            jMethod.static = uFeat.isStatic
-        }
+    update {
+		jMethod.static = uFeat.isStatic
     }
 }
 
@@ -228,10 +220,8 @@ routine setJavaMethodAbstract(uml::Operation uOperation) {
         val javaClass = retrieve java::Class corresponding to uOperation.class_
         val javaMethod = retrieve java::ClassMethod corresponding to uOperation
     }
-    action {
-        update javaMethod {
-            javaMethod.abstract = uOperation.abstract
-        }
+    update {
+        javaMethod.abstract = uOperation.abstract
     }    
 }
 
@@ -245,10 +235,8 @@ routine setJavaMethodFinal(uml::Operation uOperation, Boolean isFinal) {
     match {
         val jMethod = retrieve java::ClassMethod corresponding to uOperation
     }
-    action {
-        update jMethod {
-            jMethod.final = isFinal
-        }
+    update {
+        jMethod.final = isFinal
     }
 }
 
@@ -268,10 +256,8 @@ routine changeJavaElementVisibility(uml::NamedElement uElem) {
     match {
         val jElem = retrieve java::AnnotableAndModifiable corresponding to uElem tagged with ""
     }
-    action {
-        update jElem {
-            setJavaVisibility(jElem, uElem.visibility);
-        }
+    update {
+        setJavaVisibility(jElem, uElem.visibility);
     }
 }
 
@@ -287,10 +273,8 @@ routine renameJavaNamedElement(uml::NamedElement uElem, String name) {
     match {
         val jElem = retrieve java::NamedElement corresponding to uElem
     }
-    action {
-        update jElem {
-            jElem.name = name
-        }
+    update {
+        jElem.name = name
     }
 }
 
@@ -310,8 +294,8 @@ routine createMissingJavaParameter(uml::Parameter uParameter) {
     match {
         require absence of java::OrdinaryParameter corresponding to uParameter
     }
-    action {
-        call createJavaParameter(uParameter.operation, uParameter)
+    update {
+        createJavaParameter(uParameter.operation, uParameter)
     }
 }
 
@@ -328,17 +312,16 @@ routine createJavaParameter(uml::Operation uMeth, uml::Parameter umlParam) {
         val customType = retrieve optional java::ConcreteClassifier corresponding to umlParam.type
         require absence of java::Parameter corresponding to umlParam
     }
-    action {
-        val javaParam = create java::OrdinaryParameter and initialize {
-            javaParam.name = umlParam.name;
-        }
-        update javaMethod {
-            javaMethod.parameters += javaParam;
-        }
-        add correspondence between javaParam and umlParam
-        call changeJavaParameterType(umlParam, umlParam.type)
+    create {
+    	val javaParam = new java::OrdinaryParameter
+    }
+    update {
+		javaParam.name = umlParam.name
+		javaMethod.parameters += javaParam
+        addCorrespondenceBetween(javaParam, umlParam)
+        changeJavaParameterType(umlParam, umlParam.type)
         // TODO On initialization the Interfaces or DataTypes may not yet be synchronized, 
-        // because uml changes may have already been applied and Components are synchronized before Interfaces.
+        // because UML changes may have already been applied and Components are synchronized before Interfaces.
         // But the typeChanged-Change will still occur after the containment hierarchy is established and correctly propagate the type information.
     }
 }
@@ -359,8 +342,9 @@ routine deleteJavaParameter(uml::Parameter uParam) {
     match {
         val jParam = retrieve java::OrdinaryParameter corresponding to uParam
     }
-    action {
-        delete jParam
+    update {
+        deleteObject(jParam)
+        removeCorrespondenceBetween(jParam, uParam)
     }
 }
 
@@ -375,10 +359,8 @@ routine changeJavaParameterType(uml::Parameter uParam, uml::Type uType) {
         val jParam = retrieve java::OrdinaryParameter corresponding to uParam
         val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uType
     }
-    action {
-        call {
-            umlToJavaTypePropagation.propagateOrdinaryParameterTypeChanged(uParam, jParam, jCustomType.orElse(null))
-        }
+    update {
+		umlToJavaTypePropagation.propagateOrdinaryParameterTypeChanged(uParam, jParam, jCustomType.orElse(null))
     }
 }
 
@@ -407,13 +389,11 @@ reaction RegularOrReturnParameterUnlimitedBoundChanged {
 }
 
 routine adaptParameterBoundChanged(uml::Operation uOperation, uml::Parameter uParam) {
-    action {
-        execute {
-            if(uParam.direction == ParameterDirectionKind.RETURN_LITERAL) {
-                setJavaMethodReturnType(uOperation, uParam)
-            } else if (uParam.direction == ParameterDirectionKind.IN_LITERAL) {
-                changeJavaParameterType(uParam, uParam.type)
-            }
+    update {
+        if(uParam.direction == ParameterDirectionKind.RETURN_LITERAL) {
+            setJavaMethodReturnType(uOperation, uParam)
+        } else if (uParam.direction == ParameterDirectionKind.IN_LITERAL) {
+            changeJavaParameterType(uParam, uParam.type)
         }
     }
 }
@@ -434,10 +414,8 @@ routine adaptParameterDirectionChangedFromReturn(uml::Operation uOperation) {
     match {
         val jMethod = retrieve java::Method corresponding to uOperation
     }
-    action {
-        update jMethod {
-            jMethod.typeReference = TypesFactory.eINSTANCE.createVoid
-        }
+    update {
+        jMethod.typeReference = TypesFactory.eINSTANCE.createVoid
     }
 }
 
@@ -459,8 +437,8 @@ routine adaptParameterDirectionChangedToReturn(uml::Operation uOperation, uml::P
         val jParam = retrieve optional java::OrdinaryParameter corresponding to uParam
         val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uParam.type
     }
-    action {
-        execute umlToJavaTypePropagation.propagateReturnParameterTypeChanged(uParam, jMethod, jCustomType.orElse(null))
+    update {
+        umlToJavaTypePropagation.propagateReturnParameterTypeChanged(uParam, jMethod, jCustomType.orElse(null))
     }
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -169,7 +169,7 @@ routine deleteJavaMethod(uml::Operation umlOperation) {
             with javaMethod instanceof Constructor || javaMethod instanceof Method
     }
     update {
-        deleteObject(javaMethod)
+        removeObject(javaMethod)
         removeCorrespondenceBetween(javaMethod, umlOperation)
     }
 }
@@ -343,7 +343,7 @@ routine deleteJavaParameter(uml::Parameter uParam) {
         val jParam = retrieve java::OrdinaryParameter corresponding to uParam
     }
     update {
-        deleteObject(jParam)
+        removeObject(jParam)
         removeCorrespondenceBetween(jParam, uParam)
     }
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
@@ -17,37 +17,30 @@ execute actions in java
 routine propagatePropertyTypeChanged(uml::Property uProperty, java::Field jElement,
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
 ) {
-	action {
-		call {
-			propagateTypedMultiplicityElementTypeChanged_defaultObject(uProperty, uProperty, jElement, jType)
-		}
+	update {
+		propagateTypedMultiplicityElementTypeChanged_defaultObject(uProperty, uProperty, jElement, jType)
 	}
 }
 
 routine propagateReturnParameterTypeChanged(uml::Parameter uReturnParameter, java::Method jMethod,
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
 ) {
-	action {
-		call {
-			if (uReturnParameter.direction !== ParameterDirectionKind.RETURN_LITERAL) {
-				throw new IllegalStateException("An uml::Parameter with direction!=RETURN_LITERAL cannot be synchronized with a java::Method.")
-			}
-			propagateTypedMultiplicityElementTypeChanged_defaultVoid(uReturnParameter, uReturnParameter, jMethod, jType)
+	update {
+		if (uReturnParameter.direction !== ParameterDirectionKind.RETURN_LITERAL) {
+			throw new IllegalStateException("An uml::Parameter with direction!=RETURN_LITERAL cannot be synchronized with a java::Method.")
 		}
+		propagateTypedMultiplicityElementTypeChanged_defaultVoid(uReturnParameter, uReturnParameter, jMethod, jType)
 	}
 }
 
 routine propagateOrdinaryParameterTypeChanged(uml::Parameter uParameter, java::OrdinaryParameter jParameter,
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
 ) {
-	action {
-		call {
-			if (uParameter.direction === ParameterDirectionKind.RETURN_LITERAL) {
-				throw new IllegalStateException("An uml::Parameter with direction==RETURN_LITERAL cannot be synchronized with a java::Parameter.")
-			}
-			else{
-				propagateTypedMultiplicityElementTypeChanged_defaultObject(uParameter, uParameter, jParameter, jType)
-			}
+	update {
+		if (uParameter.direction === ParameterDirectionKind.RETURN_LITERAL) {
+			throw new IllegalStateException("An uml::Parameter with direction==RETURN_LITERAL cannot be synchronized with a java::Parameter.")
+		} else {
+			propagateTypedMultiplicityElementTypeChanged_defaultObject(uParameter, uParameter, jParameter, jType)
 		}
 	}
 }
@@ -67,30 +60,28 @@ routine propagateTypedMultiplicityElementTypeChanged(uml::TypedElement uElement,
 			true
 		}
 	}
-	action {
-		execute {
-			val existingJavaTypeReference = jElement.typeReference
-			var typeReference = createTypeReference(uElement.type, jType, defaultReference, userInteractor)
-			if(uMultiplicity.upper == LiteralUnlimitedNatural.UNLIMITED || uMultiplicity.upper > 1) {
-				if (typeReference === defaultReference){
-					// could not create a specific typeReference for the uElement.type
-					// default to java.lang.Object as an inner type
-					typeReference = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass)
-				}
-				if (isCollectionTypeReference(jElement.typeReference)) {
-					// reuse previously selected CollectionType
-					val collectionClassifier = getNormalizedClassifierFromTypeReference(jElement.typeReference) as ConcreteClassifier
-					typeReference = createCollectionTypeReference(collectionClassifier, typeReference)
-				} else {
-					// no previously selected CollectionType
-					val Class<?> collectionType = userSelectCollectionType(userInteractor)
-					typeReference = createCollectionTypeReference(collectionType, typeReference)
-				}
+	update {
+		val existingJavaTypeReference = jElement.typeReference
+		var typeReference = createTypeReference(uElement.type, jType, defaultReference, userInteractor)
+		if(uMultiplicity.upper == LiteralUnlimitedNatural.UNLIMITED || uMultiplicity.upper > 1) {
+			if (typeReference === defaultReference){
+				// could not create a specific typeReference for the uElement.type
+				// default to java.lang.Object as an inner type
+				typeReference = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass)
 			}
-			if (!EcoreUtil.equals(existingJavaTypeReference, typeReference)) {
-				jElement.typeReference = typeReference
-				addJavaImport(jElement.containingCompilationUnit, typeReference)				
+			if (isCollectionTypeReference(jElement.typeReference)) {
+				// reuse previously selected CollectionType
+				val collectionClassifier = getNormalizedClassifierFromTypeReference(jElement.typeReference) as ConcreteClassifier
+				typeReference = createCollectionTypeReference(collectionClassifier, typeReference)
+			} else {
+				// no previously selected CollectionType
+				val Class<?> collectionType = userSelectCollectionType(userInteractor)
+				typeReference = createCollectionTypeReference(collectionType, typeReference)
 			}
+		}
+		if (!EcoreUtil.equals(existingJavaTypeReference, typeReference)) {
+			jElement.typeReference = typeReference
+			addJavaImport(jElement.containingCompilationUnit, typeReference)				
 		}
 	}
 }
@@ -99,11 +90,9 @@ routine propagateTypedMultiplicityElementTypeChanged_defaultObject(uml::TypedEle
 		java::TypedElement jElement, // java::Field, java::Parameter, or java::Method
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
 ) {
-	action {
-		call {
-			val objectNsRef = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass) // default to java.lang.Object
-			propagateTypedMultiplicityElementTypeChanged(uElement, uMultiplicity, jElement, jType, objectNsRef)
-		}
+	update {
+		val objectNsRef = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass) // default to java.lang.Object
+		propagateTypedMultiplicityElementTypeChanged(uElement, uMultiplicity, jElement, jType, objectNsRef)
 	}
 }
 
@@ -111,11 +100,9 @@ routine propagateTypedMultiplicityElementTypeChanged_defaultVoid(uml::TypedEleme
 		java::TypedElement jElement, // java::Field, java::Parameter, or java::Method
 		java::ConcreteClassifier jType // new type retrieved from correspondences or null
 ) {
-	action {
-		call {
-			val voidRef = TypesFactory.eINSTANCE.createVoid
-			propagateTypedMultiplicityElementTypeChanged(uElement, uMultiplicity, jElement, jType, voidRef)
-		}
+	update {
+		val voidRef = TypesFactory.eINSTANCE.createVoid
+		propagateTypedMultiplicityElementTypeChanged(uElement, uMultiplicity, jElement, jType, voidRef)
 	}
 }
 	


### PR DESCRIPTION
This PR adapts the implemented Reactions in all case studies to use the internal DSL for specifying actions in Reaction routines as introduced in vitruv-tools/Vitruv-DSLs#41. It results in all `action` statements being collapsed into one block of `create` statements and one simple `update` code block.