### PR TITLE
Adaptation to cleanup of Reactions language

### DIFF
--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/AbstractTypeReferenceOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/AbstractTypeReferenceOperator.xtend
@@ -11,7 +11,6 @@ import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*
-
 import static extension tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper.getCorrespondingElements
 
 /**

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/AbstractTypeReferenceOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/AbstractTypeReferenceOperator.xtend
@@ -12,7 +12,7 @@ import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*
 
-import static extension tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper.*
+import static extension tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper.getCorrespondingElements
 
 /**
  * Abstract base class for operators mapping between a domain specific
@@ -192,8 +192,8 @@ abstract class AbstractTypeReferenceOperator<R, T> extends AbstractAttributeMapp
 		assertTrue(domainType !== null)
 		assertTrue(domainType instanceof EObject)
 		// We get the corresponding intermediate type via the correspondence model:
-		val intermediateTypes = correspondenceModel.getCorrespondingObjectsOfType(domainType as EObject, null,
-			Intermediate).toList
+		val intermediateTypes = correspondenceModel.getCorrespondingElements(domainType as EObject, Intermediate, null).
+			toList
 		checkState(intermediateTypes.size <= 1, '''Found more than one corresponding intermediate for «
 			participationDomainName» type '«domainType.asString»'!''')
 		val intermediateType = intermediateTypes.head // can be null
@@ -209,8 +209,7 @@ abstract class AbstractTypeReferenceOperator<R, T> extends AbstractAttributeMapp
 	protected def T getCorrespondingDomainType(Intermediate intermediateType) {
 		assertTrue(intermediateType !== null)
 		// We get the corresponding domain type via the correspondence model:
-		val domainTypes = correspondenceModel.getCorrespondingObjectsOfType(intermediateType, null,
-			domainTypeClass).toList
+		val domainTypes = correspondenceModel.getCorrespondingElements(intermediateType, domainTypeClass, null).toList
 		checkState(domainTypes.size <= 1, '''Found more than one corresponding «participationDomainName» type for«
 			» intermediate type '«intermediateType»': «domainTypes»''')
 		val domainType = domainTypes.head // can be null

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/AbstractTypeReferenceOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/AbstractTypeReferenceOperator.xtend
@@ -7,7 +7,7 @@ import tools.vitruv.applications.cbs.commonalities.domaincommon.CommonPrimitiveT
 import tools.vitruv.dsls.commonalities.runtime.helper.IntermediateModelHelper
 import tools.vitruv.dsls.commonalities.runtime.intermediatemodelbase.Intermediate
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/FirstUpperOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/FirstUpperOperator.xtend
@@ -4,7 +4,7 @@ import org.apache.log4j.Logger
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Converts between a String with a lower case character at the front on the

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/InverseOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/InverseOperator.xtend
@@ -4,7 +4,7 @@ import org.apache.log4j.Logger
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/PrefixOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/domaincommon/operators/PrefixOperator.xtend
@@ -4,7 +4,7 @@ import org.apache.log4j.Logger
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/AbstractJavaModifierOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/AbstractJavaModifierOperator.xtend
@@ -7,7 +7,7 @@ import org.emftext.language.java.modifiers.AnnotableAndModifiable
 import org.emftext.language.java.modifiers.AnnotationInstanceOrModifier
 import org.emftext.language.java.modifiers.Modifier
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaAbstractModifierOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaAbstractModifierOperator.xtend
@@ -7,7 +7,7 @@ import org.emftext.language.java.modifiers.Modifier
 import org.emftext.language.java.modifiers.ModifiersFactory
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 @AttributeMappingOperator(
 	name='javaAbstractModifier',

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaCompilationUnitNameOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaCompilationUnitNameOperator.xtend
@@ -6,7 +6,7 @@ import org.emftext.language.java.containers.CompilationUnit
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaFinalModifierOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaFinalModifierOperator.xtend
@@ -7,7 +7,7 @@ import org.emftext.language.java.modifiers.Modifier
 import org.emftext.language.java.modifiers.ModifiersFactory
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 @AttributeMappingOperator(
 	name='javaFinalModifier',

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaInverseAbstractModifierOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaInverseAbstractModifierOperator.xtend
@@ -5,7 +5,7 @@ import org.emftext.language.java.modifiers.AnnotableAndModifiable
 import org.emftext.language.java.modifiers.AnnotationInstanceOrModifier
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaPackageCompilationUnitsOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaPackageCompilationUnitsOperator.xtend
@@ -9,7 +9,7 @@ import org.emftext.language.java.containers.Package
 import tools.vitruv.applications.util.temporary.java.JavaPersistenceHelper
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.reference.AbstractReferenceMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.reference.ReferenceMappingOperator
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaPackageResourcePathFromNameOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaPackageResourcePathFromNameOperator.xtend
@@ -5,7 +5,7 @@ import org.emftext.language.java.containers.Package
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaStaticModifierOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaStaticModifierOperator.xtend
@@ -7,7 +7,7 @@ import org.emftext.language.java.modifiers.ModifiersFactory
 import org.emftext.language.java.modifiers.Static
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 @AttributeMappingOperator(
 	name='javaStaticModifier',

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaSubPackagesOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaSubPackagesOperator.xtend
@@ -10,7 +10,7 @@ import org.emftext.language.java.containers.Package
 import tools.vitruv.applications.util.temporary.java.JavaPersistenceHelper
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.reference.AbstractReferenceMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.reference.ReferenceMappingOperator
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 import static extension edu.kit.ipd.sdq.commons.util.org.eclipse.emf.common.util.URIUtil.createFileURI
 
 import static com.google.common.base.Preconditions.*

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaTypeReferenceOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaTypeReferenceOperator.xtend
@@ -16,7 +16,7 @@ import tools.vitruv.applications.cbs.commonalities.domaincommon.operators.Abstra
 import tools.vitruv.applications.util.temporary.java.JavaModificationUtil
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaTypeReferenceOrNullOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaTypeReferenceOrNullOperator.xtend
@@ -4,7 +4,7 @@ import org.emftext.language.java.types.TypeReference
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Similar to {@link JavaTypeReferenceOperator}, but maps to <code>null</code>

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaTypeReferencesOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaTypeReferencesOperator.xtend
@@ -6,7 +6,7 @@ import org.emftext.language.java.types.TypeReference
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Maps between multiple Java type references and multiple corresponding

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaVisibilityOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/java/operators/JavaVisibilityOperator.xtend
@@ -8,7 +8,7 @@ import tools.vitruv.applications.cbs.commonalities.oo.Visibility
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/operators/OOTypeReferenceOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/operators/OOTypeReferenceOperator.xtend
@@ -5,7 +5,7 @@ import tools.vitruv.applications.cbs.commonalities.domaincommon.operators.Abstra
 import tools.vitruv.dsls.commonalities.runtime.intermediatemodelbase.Intermediate
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/operators/OOTypeReferencesOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/oo/operators/OOTypeReferencesOperator.xtend
@@ -5,7 +5,7 @@ import org.apache.log4j.Logger
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Maps between multiple type references of the ObjectOrientedDesign concept

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/pcm/operators/PcmDataTypeReferenceOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/pcm/operators/PcmDataTypeReferenceOperator.xtend
@@ -4,7 +4,7 @@ import org.palladiosimulator.pcm.repository.DataType
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Maps between references to PCM {@link DataType}s and an intermediate

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/pcm/operators/PcmProvidedRolesOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/pcm/operators/PcmProvidedRolesOperator.xtend
@@ -9,7 +9,7 @@ import org.palladiosimulator.pcm.repository.RepositoryFactory
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Maps between PCM {@link OperationProvidedRole}s and their interfaces and

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/pcm/operators/PcmTypeReferenceOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/pcm/operators/PcmTypeReferenceOperator.xtend
@@ -10,7 +10,7 @@ import tools.vitruv.applications.cbs.commonalities.domaincommon.operators.Abstra
 import tools.vitruv.applications.cbs.commonalities.pcm.PcmPrimitiveDataType
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlGeneralizationsOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlGeneralizationsOperator.xtend
@@ -8,7 +8,7 @@ import org.eclipse.uml2.uml.UMLFactory
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Maps between UML {@link Generalization}s and intermediate type references.

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlInterfaceRealizationsOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlInterfaceRealizationsOperator.xtend
@@ -8,7 +8,7 @@ import org.eclipse.uml2.uml.UMLFactory
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Maps between UML {@link InterfaceRealization}s and intermediate type

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlReturnTypeOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlReturnTypeOperator.xtend
@@ -10,7 +10,7 @@ import org.eclipse.uml2.uml.UMLFactory
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static com.google.common.base.Preconditions.*
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlSingleGeneralizationOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlSingleGeneralizationOperator.xtend
@@ -8,7 +8,7 @@ import org.eclipse.uml2.uml.UMLFactory
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 /**
  * Similar to {@link UmlGeneralizationsOperator}, but only maps a single

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlTypeReferenceOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlTypeReferenceOperator.xtend
@@ -7,7 +7,7 @@ import tools.vitruv.applications.cbs.commonalities.domaincommon.operators.Abstra
 import tools.vitruv.applications.cbs.commonalities.uml.UmlPrimitiveType
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static tools.vitruv.dsls.commonalities.runtime.helper.XtendAssertHelper.*
 

--- a/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlVisibilityOperator.xtend
+++ b/bundles/tools.vitruv.applications.cbs.commonalities/src/tools/vitruv/applications/cbs/commonalities/uml/operators/UmlVisibilityOperator.xtend
@@ -6,7 +6,7 @@ import tools.vitruv.applications.cbs.commonalities.oo.Visibility
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AbstractAttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeMappingOperator
 import tools.vitruv.dsls.commonalities.runtime.operators.mapping.attribute.AttributeType
-import tools.vitruv.dsls.reactions.runtime.ReactionExecutionState
+import tools.vitruv.dsls.reactions.runtime.state.ReactionExecutionState
 
 import static extension tools.vitruv.applications.cbs.commonalities.uml.UmlVisibilityHelper.*
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/PcmUmlClassHelper.xtend
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/PcmUmlClassHelper.xtend
@@ -13,7 +13,7 @@ import org.palladiosimulator.pcm.repository.PrimitiveDataType
 import org.palladiosimulator.pcm.repository.PrimitiveTypeEnum
 import org.palladiosimulator.pcm.repository.Repository
 import org.palladiosimulator.pcm.repository.RepositoryFactory
-import tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper
+import static extension tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper.getCorrespondingElements
 import tools.vitruv.change.correspondence.CorrespondenceModel
 import tools.vitruv.change.interaction.UserInteractionOptions.NotificationType
 import tools.vitruv.change.interaction.UserInteractor
@@ -69,18 +69,18 @@ class PcmUmlClassHelper {
 	}
 
 	def private static boolean isRepositoryPackage(Package pkg, CorrespondenceModel corrModel) {
-		return !ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(corrModel, pkg,
-			TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE, Repository).nullOrEmpty
+		return !corrModel.getCorrespondingElements(pkg, Repository,
+			TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE).nullOrEmpty
 	}
 
 	def static getCorrespondingPcmDataType(CorrespondenceModel corrModel, Type umlType, int lower, int upper,
 		Repository pcmRepository, UserInteractor userInteractor) {
 		if(umlType === null) return null
 
-		val pcmPrimitiveType = ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(corrModel, umlType,
-			TagLiterals.DATATYPE__TYPE, PrimitiveDataType)
-		val pcmCompositeType = ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(corrModel, umlType,
-			TagLiterals.COMPOSITE_DATATYPE__CLASS, CompositeDataType)
+		val pcmPrimitiveType = corrModel.getCorrespondingElements(umlType,
+			PrimitiveDataType, TagLiterals.DATATYPE__TYPE)
+		val pcmCompositeType = corrModel.getCorrespondingElements(umlType,
+			CompositeDataType, TagLiterals.COMPOSITE_DATATYPE__CLASS)
 		val pcmSimpleType = #[pcmPrimitiveType.head, pcmCompositeType.head].findFirst[it !== null]
 
 		if (umlType !== null && pcmSimpleType === null) {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -3,7 +3,6 @@ import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.util.temporary.uml.UmlTypeUtil
-import tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper
 import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil
 import org.palladiosimulator.pcm.repository.RepositoryPackage
 
@@ -93,7 +92,7 @@ routine createUmlContractsPackage(pcm::Repository pcmRepo) {
 		if (umlContractsPkg === null) {
 			umlContractsPkg = umlRepositoryPkg.createNestedPackage(DefaultLiterals.CONTRACTS_PACKAGE_NAME)
 		}
-		ReactionsCorrespondenceHelper.addCorrespondence(correspondenceModel, pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)
+		addCorrespondenceBetween(pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)
 	}
 }
 routine createUmlDatatypesPackage(pcm::Repository pcmRepo) {
@@ -107,7 +106,7 @@ routine createUmlDatatypesPackage(pcm::Repository pcmRepo) {
 		if (umlDatatypesPkg === null) {
 			umlDatatypesPkg = umlRepositoryPkg.createNestedPackage(DefaultLiterals.DATATYPES_PACKAGE_NAME)
 		}
-		ReactionsCorrespondenceHelper.addCorrespondence(correspondenceModel, pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)
+		addCorrespondenceBetween(pcmRepo, umlDatatypesPkg, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)
 	}
 }
 
@@ -142,8 +141,8 @@ routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 	update {
 		// remove correspondences, UML model contents if desired
 		umlRepositoryPkg.ifPresent[umlRepositoryPackage |
-			ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
-				correspondenceModel, pcmRepo, umlRepositoryPackage, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
+			removeCorrespondenceBetween(
+				pcmRepo, umlRepositoryPackage, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
 			// ask if the corresponding model should also be deleted
 			val deleteCorrespondingUmlRepository = userInteractor.confirmationDialogBuilder
 					.message(DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
@@ -154,10 +153,10 @@ routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 				umlModel.packagedElements -= umlRepositoryPackage // remove parent package last to allow the recorder to notice the child package deletion
 			}
 		]
-		umlContractsPkg.ifPresent[ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
-			correspondenceModel, pcmRepo, it, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)]
-		umlDatatypesPkg.ifPresent[ReactionsCorrespondenceHelper.removeCorrespondencesBetweenElements(
-			correspondenceModel, pcmRepo, it, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)]
+		umlContractsPkg.ifPresent[removeCorrespondenceBetween(
+			pcmRepo, it, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)]
+		umlDatatypesPkg.ifPresent[removeCorrespondenceBetween(
+			pcmRepo, it, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)]
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
@@ -178,7 +178,9 @@ routine propagateTypeChange(uml::Property umlProperty) {
 	}
 	update {
 		val pcmRepository = pcmInnerDeclaration.eResource.allContents.filter(Repository).head
-		val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(correspondenceModel, umlProperty.type, umlProperty.lower, umlProperty.upper, pcmRepository, userInteractor)
+		val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(umlProperty.type, umlProperty.lower, umlProperty.upper, pcmRepository, userInteractor, [sourceElement, expectedType, tag |
+			getCorrespondingElement(sourceElement, expectedType, null, tag, false)
+		])
 		pcmInnerDeclaration.datatype_InnerDeclaration = pcmDataType
 		
 		if(pcmOldCollectionType.isPresent && pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType(umlProperty)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -64,7 +64,9 @@ routine insertCorrespondingRepositoryOrSystem(uml::Package umlPackage, uml::Pack
 		val pcmSystem = retrieve optional pcm::System corresponding to umlPackage tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
-		if(!PcmUmlClassHelper.isContainedInRepositoryHierarchy(umlPackage, correspondenceModel)) {
+		if(!PcmUmlClassHelper.isContainedInRepositoryHierarchy(umlPackage, [sourceElement, expectedType, tag |
+			getCorrespondingElement(sourceElement, expectedType, null, tag, false)
+		])) {
 			if (!pcmRepository.isPresent && !pcmSystem.isPresent)
 				userDisambiguateRepositoryOrSystemCreation(umlPackage, umlParentPackage)
 			//no move-operation necessary since both repository and system are root elements

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
@@ -64,7 +64,9 @@ routine propagateTypeChange(uml::Parameter umlParameter) {
 		if (pcmSignature.isPresent || pcmParameter.isPresent) { // limit context to synchronized uml::Parameters
 			val EObject pcmStoredElement = if (pcmSignature.isPresent) pcmSignature.get else pcmParameter.get
 			val pcmRepository = pcmStoredElement.eResource.allContents.filter(Repository).head
-			val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(correspondenceModel, umlParameter.type, umlParameter.lower, umlParameter.upper, pcmRepository, userInteractor)
+			val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(umlParameter.type, umlParameter.lower, umlParameter.upper, pcmRepository, userInteractor, [sourceElement, expectedType, tag |
+				getCorrespondingElement(sourceElement, expectedType, null, tag, false)
+			])
 			if (pcmSignature.isPresent) {pcmSignature.get.returnType__OperationSignature = pcmDataType}
 			if (pcmParameter.isPresent) {pcmParameter.get.dataType__Parameter = pcmDataType}
 			

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -11,7 +11,7 @@ import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPacka
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlEnum
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlInterface
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
-import static tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.registerPredefinedUmlPrimitiveTypes
+import static tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.getNotRegisteredPrimitiveTypesWithUnifiedNames
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static com.google.common.base.Preconditions.checkState
 import static tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
@@ -88,8 +88,19 @@ routine registerUmlModelInCorrespondenceModel(uml::Model uModel) {
 routine rootElementPreSetup(EObject alreadyPersistedEObject) {
     update {
         detectOrCreateUmlModel(alreadyPersistedEObject)
-        registerPredefinedUmlPrimitiveTypes(correspondenceModel, alreadyPersistedEObject.eResource.resourceSet)
+        registerPredefinedUmlPrimitiveTypes(alreadyPersistedEObject)
     }
+}
+
+routine registerPredefinedUmlPrimitiveTypes(EObject alreadyPersistedEObject) {
+	update {
+		getNotRegisteredPrimitiveTypesWithUnifiedNames([sourceElement, expectedType, tag |
+			getCorrespondingElement(sourceElement, expectedType, null, tag, false)
+		], alreadyPersistedEObject.eResource.resourceSet).forEach[
+			addCorrespondenceBetween(UMLPackage.Literals.PRIMITIVE_TYPE,
+				it.key, it.value)
+		]
+	}
 }
 
 //===========================================

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
@@ -60,7 +60,9 @@ routine propagateTypeChangeToTypedMultiplicityElement(uml::TypedElement uTyped, 
 		if (newJavaType !== null && newJavaType.target instanceof ConcreteClassifier && newJavaType.target.containingCompilationUnit.namespaces.head == "java") {
 			createExistingUmlClassifier(newJavaType.target as ConcreteClassifier)
 		}
-		val newUmlType = getUmlTypeFromReference(newJavaType, correspondenceModel)
+		val newUmlType = getUmlTypeFromReference(newJavaType, [sourceElement, expectedType, tag |
+			getCorrespondingElement(sourceElement, expectedType, null, tag, false)
+		])
 		if (!EcoreUtil.equals(existingUmlType, newUmlType)) {
 			uTyped.type = newUmlType
 		}

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/util/UmlJavaTypePropagationHelper.xtend
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/util/UmlJavaTypePropagationHelper.xtend
@@ -15,7 +15,8 @@ import org.emftext.language.java.types.NamespaceClassifierReference
 import org.emftext.language.java.types.TypeReference
 import org.emftext.language.java.types.TypesFactory
 import tools.vitruv.applications.util.temporary.java.JavaModificationUtil
-import tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper
+import static extension tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper.getCorrespondingElements
+import static extension tools.vitruv.dsls.reactions.runtime.helper.ReactionsCorrespondenceHelper.addCorrespondence
 import tools.vitruv.change.correspondence.CorrespondenceModel
 import tools.vitruv.change.interaction.UserInteractionOptions.WindowModality
 import tools.vitruv.change.interaction.UserInteractor
@@ -72,7 +73,7 @@ class UmlJavaTypePropagationHelper {
 
 		val classifier = getNormalizedClassifierFromTypeReference(jRef)
 		if (classifier !== null)
-			return ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(cm, classifier, null, Type).head
+			return cm.getCorrespondingElements(classifier, Type, null).head
 		else {
 			return null
 		}
@@ -237,10 +238,11 @@ class UmlJavaTypePropagationHelper {
 			for (primitive : umlPrimitiveTypes) {
 				val unifiedType = primitive.unifiedNameForUmlPrimitiveTypeName
 				if (unifiedType !== null) {
-					val alreadyRegistered = ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(correspondenceModel,
-						UMLPackage.Literals.PRIMITIVE_TYPE, unifiedType.toString, PrimitiveType).head
+					val alreadyRegistered = correspondenceModel.getCorrespondingElements(
+						UMLPackage.Literals.PRIMITIVE_TYPE, PrimitiveType, unifiedType.toString
+					).head
 					if (alreadyRegistered === null)
-						ReactionsCorrespondenceHelper.addCorrespondence(correspondenceModel, UMLPackage.Literals.PRIMITIVE_TYPE,
+						correspondenceModel.addCorrespondence(UMLPackage.Literals.PRIMITIVE_TYPE,
 							primitive, unifiedType.toString)
 				}
 			}
@@ -273,8 +275,8 @@ class UmlJavaTypePropagationHelper {
 				// check if it is of type String, which has to be mapped to an uml::PrimitiveType
 				if (getQualifiedName(classifier) == "java.lang.String" ||
 					getQualifiedName(classifier) == "java.lang.CharSequence") {
-					ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(correspondenceModel, UMLPackage.Literals.PRIMITIVE_TYPE,
-						UnifiedPrimitiveType.STRING.toString, PrimitiveType).claimOne
+					correspondenceModel.getCorrespondingElements(UMLPackage.Literals.PRIMITIVE_TYPE,
+						PrimitiveType, UnifiedPrimitiveType.STRING.toString).claimOne
 				} else {
 					return null
 				}
@@ -318,8 +320,8 @@ class UmlJavaTypePropagationHelper {
 			org.emftext.language.java.types.PrimitiveType javaTypeReference, CorrespondenceModel correspondenceModel) {
 			val unifiedPrimitiveType = javaTypeReference.unifiedNameForJavaPrimitiveTypeName
 			if (unifiedPrimitiveType !== null) {
-				ReactionsCorrespondenceHelper.getCorrespondingObjectsOfType(correspondenceModel, UMLPackage.Literals.PRIMITIVE_TYPE,
-					unifiedPrimitiveType.toString, PrimitiveType).claimOne
+				correspondenceModel.getCorrespondingElements(UMLPackage.Literals.PRIMITIVE_TYPE,
+					PrimitiveType, unifiedPrimitiveType.toString).claimOne
 			}
 		}
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/util/UmlJavaTypePropagationHelper.xtend
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/util/UmlJavaTypePropagationHelper.xtend
@@ -23,7 +23,7 @@ import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import edu.kit.ipd.sdq.activextendannotations.Utility
 import org.eclipse.emf.ecore.resource.ResourceSet
 import static tools.vitruv.applications.util.temporary.uml.UmlTypeUtil.getUmlPrimitiveTypes
-import org.eclipse.emf.ecore.EObject
+import tools.vitruv.applications.util.temporary.other.CorrespondenceRetriever
 
 /**
  * Helper class for the UML <-> Java - reactions. Contains functions for handling java::TypeReferences
@@ -152,11 +152,6 @@ class UmlJavaTypePropagationHelper {
 
 	def static isSupportedUmlPrimitiveType(PrimitiveType umlPrimitiveType) {
 		PrimitiveTypesPropagation.isSupportedUmlPrimitiveType(umlPrimitiveType)
-	}
-
-	static interface CorrespondenceRetriever {
-		def EObject retrieveCorrespondingElement(EObject sourceElement,
-			Class<? extends EObject> correspondingElementType, String tag)
 	}
 
 	def static getNotRegisteredPrimitiveTypesWithUnifiedNames(CorrespondenceRetriever correspondenceRetriever,

--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/other/CorrespondenceRetriever.java
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/other/CorrespondenceRetriever.java
@@ -1,0 +1,12 @@
+package tools.vitruv.applications.util.temporary.other;
+
+import org.eclipse.emf.ecore.EObject;
+
+/**
+ * To be used as a callback for passing correspondence access from Reactions
+ * to helper classes.
+ */
+public interface CorrespondenceRetriever {
+	public EObject retrieveCorrespondingElement(EObject sourceElement,
+			Class<? extends EObject> correspondingElementType, String tag);
+}

--- a/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/uml/UmlTypeUtil.xtend
+++ b/bundles/tools.vitruv.applications.util.temporary/src/tools/vitruv/applications/util/temporary/uml/UmlTypeUtil.xtend
@@ -8,7 +8,7 @@ import org.eclipse.uml2.uml.PrimitiveType
 import org.eclipse.emf.ecore.resource.ResourceSet
 
 @Utility
-class UmlTypeUtil { // TODO Place as central utility in UML domain
+class UmlTypeUtil {
     static val UML_JAVA_PRIMITIVE_TYPES_URI = URI.createURI("pathmap://UML_LIBRARIES/JavaPrimitiveTypes.library.uml")
     static val UML_PRIMITIVE_TYPES_URI = URI.createURI("pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml")
 


### PR DESCRIPTION
This PR only adapts to the cleanup of the Reactions language in vitruv-tools/Vitruv-DSLs#42.
It adapts imports and realizes correspondence access in helpers for Reactions by passing a callback rather than the `CorrespondenceModel` itself, such that helper code must not be aware of the correspondence model and its precise functionality.