### PR TITLE
Adaptation to fixed Reactions formatter

### DIFF
--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2Pcm.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2Pcm.reactions
@@ -7,3 +7,4 @@ execute actions in pcm
 
 import java2PcmClassifier
 import java2PcmMethod
+

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
@@ -11,7 +11,6 @@ import tools.vitruv.change.interaction.UserInteractionOptions.WindowModality
 import org.palladiosimulator.pcm.repository.CompositeDataType
 import org.palladiosimulator.pcm.repository.CollectionDataType
 import org.palladiosimulator.pcm.core.entity.Entity
-
 import static tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaPersistenceHelper.*
@@ -28,10 +27,9 @@ execute actions in pcm
 ///Repository
 reaction PackageCreated {
 	after element java::Package inserted as root
-	//This condition prevents another execution after automatically creating contracts and datatypes package.
-	//The reaction is called because every package insert is a root insert. 
+		// This condition prevents another execution after automatically creating contracts and datatypes package.
+		// The reaction is called because every package insert is a root insert. 
 	with newValue.name === null || (!newValue.name.contains("contracts") && !newValue.name.contains("datatypes"))
-		
 	call {
 		createOrFindArchitecturalElement(newValue, getLastPackageName(newValue.name))
 		createOrFindRepository(newValue, newValue.name, "package_root")
@@ -54,8 +52,8 @@ routine createPackageEClassCorrespondence(java::Package jPackage) {
 
 routine createOrFindArchitecturalElement(java::Package javaPackage, String containerName) {
 	match {
-		val containerPackage = retrieve optional java::Package corresponding to ContainersPackage.Literals.PACKAGE
-			with containerPackage.name == containerName
+		val containerPackage = retrieve optional java::Package corresponding to ContainersPackage.Literals.
+			PACKAGE with containerPackage.name == containerName
 		require absence of pcm::RepositoryComponent corresponding to javaPackage
 		// ensure that we are not the root package (happens when the root package is being moved)
 		require absence of pcm::Repository corresponding to javaPackage tagged with "package_root"
@@ -76,7 +74,9 @@ routine createOrFindArchitecturalElementInPackage(java::Package javaPackage, jav
 		require absence of pcm::RepositoryComponent corresponding to javaPackage
 	}
 	update {
-		val pcmComponentCandidate = pcmRepository.components__Repository.findFirst[entityName == javaPackage.name.toFirstUpper]
+		val pcmComponentCandidate = pcmRepository.components__Repository.findFirst [
+			entityName == javaPackage.name.toFirstUpper
+		]
 		if (pcmComponentCandidate === null) {
 			createArchitecturalElement(javaPackage, containingPackage.name, rootPackageName)
 		} else {
@@ -94,19 +94,20 @@ routine createArchitecturalElement(java::Package javaPackage, String name, Strin
 	}
 	update {
 		val String userMsg = "A package has been created. Please decide whether and which corresponding architectural element should be created"
-		val String[] selections = #[Java2PcmUserSelection.SELECT_BASIC_COMPONENT.message,
+		val String[] selections = #[
+			Java2PcmUserSelection.SELECT_BASIC_COMPONENT.message,
 			Java2PcmUserSelection.SELECT_COMPOSITE_COMPONENT.message,
 			Java2PcmUserSelection.SELECT_SYSTEM.message,
 			Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
 		]
-		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-			.windowModality(WindowModality.MODAL).startInteraction()
-		switch(selected) {
-			case Java2PcmUserSelection.SELECT_BASIC_COMPONENT.selection: 
-				createBasicComponent(javaPackage, name, rootPackageName) 
-			case Java2PcmUserSelection.SELECT_COMPOSITE_COMPONENT.selection: 
+		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections).windowModality(
+			WindowModality.MODAL).startInteraction()
+		switch (selected) {
+			case Java2PcmUserSelection.SELECT_BASIC_COMPONENT.selection:
+				createBasicComponent(javaPackage, name, rootPackageName)
+			case Java2PcmUserSelection.SELECT_COMPOSITE_COMPONENT.selection:
 				createCompositeComponent(javaPackage, name, rootPackageName)
-			case Java2PcmUserSelection.SELECT_SYSTEM.selection: 
+			case Java2PcmUserSelection.SELECT_SYSTEM.selection:
 				createOrFindSystem(javaPackage, name)
 		}
 	}
@@ -116,8 +117,8 @@ routine createOrFindRepository(java::Package javaPackage, String packageName, St
 	match {
 		require absence of pcm::Repository corresponding to javaPackage tagged with newTag
 		require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
-			with javaPackage.isPackageFor(foundRepository)
+		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.
+			REPOSITORY with javaPackage.isPackageFor(foundRepository)
 	}
 	update {
 		if (foundRepository.isPresent) {
@@ -153,12 +154,12 @@ routine createRepository(java::Package javaPackage, String packageName, String n
 		// If the package-info.java is not persisted, do it
 		val packageUri = javaPackage.eResource.URI;
 		if (!URIUtil.existsResourceAtUri(packageUri)) {
-			val projectRelativeResourcePath = packageUri.segmentsList.tail.fold("", [a, b | a + "/" + b])
+			val projectRelativeResourcePath = packageUri.segmentsList.tail.fold("", [a, b|a + "/" + b])
 			persistProjectRelative(javaPackage, javaPackage, projectRelativeResourcePath)
 		}
 		pcmRepository.entityName = packageName.toFirstUpper
 		persistProjectRelative(javaPackage, pcmRepository, "model/" + pcmRepository.entityName + ".repository")
-		
+
 		addCorrespondenceBetween(pcmRepository, javaPackage, newTag)
 		createJavaSubPackages(javaPackage)
 		addCorrespondenceBetween(pcmRepository, ContainersPackage.Literals.PACKAGE)
@@ -167,10 +168,10 @@ routine createRepository(java::Package javaPackage, String packageName, String n
 }
 
 routine createOrFindSystem(java::Package javaPackage, String name) {
-	 match {
+	match {
 		require absence of pcm::System corresponding to javaPackage
-		val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM
-			with javaPackage.isPackageFor(foundSystem)
+		val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM with javaPackage.
+			isPackageFor(foundSystem)
 	}
 	update {
 		if (foundSystem.isPresent) {
@@ -228,7 +229,7 @@ routine addCorrespondenceAndUpdateRepository(pcm::RepositoryComponent pcmCompone
 	}
 	update {
 		addCorrespondenceBetween(pcmComponent, javaPackage)
-		if(!pcmRepository.components__Repository.contains(pcmComponent)) {
+		if (!pcmRepository.components__Repository.contains(pcmComponent)) {
 			pcmRepository.components__Repository += pcmComponent
 		}
 	}
@@ -317,13 +318,14 @@ reaction InterfaceCreated {
 
 routine createOrFindPCMInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit) {
 	match {
-		val containingPackage = retrieve java::Package corresponding to ContainersPackage.Literals.PACKAGE
-			with containingPackage.namespacesAsString + containingPackage.name + "." == compilationUnit.namespacesAsString
+		val containingPackage = retrieve java::Package corresponding to ContainersPackage.Literals.
+			PACKAGE with containingPackage.namespacesAsString + containingPackage.name + "." ==
+			compilationUnit.namespacesAsString
 		val pcmRepository = retrieve optional pcm::Repository corresponding to containingPackage tagged with "contracts"
 		require absence of pcm::OperationInterface corresponding to javaInterface
 	}
 	update {
-		if(pcmRepository.isPresent) {
+		if (pcmRepository.isPresent) {
 			createOrFindContractsInterface(javaInterface, compilationUnit, containingPackage, pcmRepository.get)
 		} else {
 			createNonContractsInterface(javaInterface, compilationUnit, containingPackage)
@@ -333,7 +335,9 @@ routine createOrFindPCMInterface(java::Interface javaInterface, java::Compilatio
 
 routine createOrFindContractsInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package contractsPackage, pcm::Repository pcmRepository) {
 	update {
-		val pcmInterface = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[entityName == javaInterface.name]
+		val pcmInterface = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst [
+			entityName == javaInterface.name
+		]
 		if (pcmInterface === null) {
 			createInterface(javaInterface, compilationUnit, contractsPackage)
 		} else {
@@ -349,7 +353,8 @@ reaction JavaInterfaceRenamed {
 
 routine renameInterface(java::Interface javaInterface) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to javaInterface}
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to javaInterface
+	}
 	update {
 		pcmInterface.entityName = javaInterface.name
 	}
@@ -361,12 +366,13 @@ routine renameInterface(java::Interface javaInterface) {
 routine createNonContractsInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit, java::Package javaPackage) {
 	update {
 		val String userMsg = "The created interface is not in the contracts packages. Should an architectural interface be created for the interface " +
-				javaInterface.name + " ?"
-		val String[] selections = #[Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.message,
+			javaInterface.name + " ?"
+		val String[] selections = #[
+			Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.message,
 			Java2PcmUserSelection.SELECT_DONT_CREATE_INTERFACE_NOT_IN_CONTRACTS.message
 		]
-		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-			.windowModality(WindowModality.MODAL).startInteraction()
+		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections).windowModality(
+			WindowModality.MODAL).startInteraction()
 		if (selected == Java2PcmUserSelection.SELECT_CREATE_INTERFACE_NOT_IN_CONTRACTS.selection) {
 			createInterface(javaInterface, compilationUnit, javaPackage)
 		}
@@ -389,7 +395,7 @@ routine addInterfaceCorrespondence(pcm::OperationInterface pcmInterface, java::I
 		require absence of pcm::Interface corresponding to javaInterface
 	}
 	update {
-		addCorrespondenceBetween(pcmInterface, javaInterface) 
+		addCorrespondenceBetween(pcmInterface, javaInterface)
 	}
 }
 
@@ -417,7 +423,7 @@ routine renameComponentFromClass(java::Class javaClass) {
 	}
 	update {
 		var newName = javaClass.name.toFirstUpper
-		if (newName.endsWith("Impl")) newName = newName.substring(0, newName.length - "Impl".length)
+		if(newName.endsWith("Impl")) newName = newName.substring(0, newName.length - "Impl".length)
 		pcmComponent.entityName = newName
 	}
 }
@@ -427,7 +433,7 @@ routine renameDataTypeFromClass(java::Class javaClass) {
 		val dataType = retrieve pcm::DataType corresponding to javaClass
 	}
 	update {
-		if(dataType instanceof Entity) { // primitive data types don't have names
+		if (dataType instanceof Entity) { // primitive data types don't have names
 			dataType.entityName = javaClass.name.toFirstUpper
 		}
 	}
@@ -436,8 +442,7 @@ routine renameDataTypeFromClass(java::Class javaClass) {
 reaction ClassCreated {
 	after element java::Class inserted in java::CompilationUnit[classifiers]
 	call {
-		val javaPackage = getContainingPackageFromCorrespondenceModel(newValue,
-			correspondenceModel)
+		val javaPackage = getContainingPackageFromCorrespondenceModel(newValue, correspondenceModel)
 		classMapping(newValue, affectedEObject, javaPackage)
 	}
 }
@@ -449,7 +454,7 @@ reaction ClassCreated {
 routine classMapping(java::Class javaClass, java::CompilationUnit compilationUnit, java::Package javaPackage) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-		val datatypesPackage = retrieve java::Package corresponding to pcmRepository tagged with "datatypes" 
+		val datatypesPackage = retrieve java::Package corresponding to pcmRepository tagged with "datatypes"
 	}
 	update {
 		if (javaPackage !== null && javaPackage.name == datatypesPackage.name) {
@@ -467,17 +472,18 @@ routine classMapping(java::Class javaClass, java::CompilationUnit compilationUni
 routine createDataType(java::Class javaClass, java::CompilationUnit compilationUnit) {
 	update {
 		val String userMsg = "Class " + javaClass.name +
-					" has been created in the datatypes package. Please decide which kind of data type should be created."
-		val String[] selections = #[Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.message,
+			" has been created in the datatypes package. Please decide which kind of data type should be created."
+		val String[] selections = #[
+			Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.message,
 			Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.message,
 			Java2PcmUserSelection.SELECT_NOTHING_DECIDE_LATER.message
 		]
-		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections)
-			.windowModality(WindowModality.MODAL).startInteraction()
-		switch(selected) {
-			case Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.selection: 
+		val selected = userInteractor.singleSelectionDialogBuilder.message(userMsg).choices(selections).windowModality(
+			WindowModality.MODAL).startInteraction()
+		switch (selected) {
+			case Java2PcmUserSelection.SELECT_COMPOSITE_DATA_TYPE.selection:
 				createOrFindCompositeDataType(javaClass, compilationUnit)
-			case Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.selection: 
+			case Java2PcmUserSelection.SELECT_COLLECTION_DATA_TYPE.selection:
 				createOrFindCollectionDataType(javaClass, compilationUnit)
 		}
 	}
@@ -489,12 +495,12 @@ routine createDataType(java::Class javaClass, java::CompilationUnit compilationU
 routine createElement(java::Class javaClass, java::Package javaPackage, java::CompilationUnit compilationUnit) {
 	match {
 		require absence of pcm::DataType corresponding to javaClass
-		require absence of pcm::InterfaceProvidingRequiringEntity corresponding to javaClass 
+		require absence of pcm::InterfaceProvidingRequiringEntity corresponding to javaClass
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-		val javaRootPackage = retrieve java::Package corresponding to pcmRepository tagged with "package_root" 
+		val javaRootPackage = retrieve java::Package corresponding to pcmRepository tagged with "package_root"
 	}
 	update {
-		createArchitecturalElement(javaRootPackage, javaClass.name, compilationUnit.namespaces.head)			
+		createArchitecturalElement(javaRootPackage, javaClass.name, compilationUnit.namespaces.head)
 		checkSystemAndComponent(javaRootPackage, javaClass)
 	}
 }
@@ -505,7 +511,7 @@ routine createElement(java::Class javaClass, java::Package javaPackage, java::Co
  */
 routine checkSystemAndComponent(java::Package javaPackage, java::Class javaClass) {
 	match {
-		val componentOrSystem = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to javaPackage 
+		val componentOrSystem = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to javaPackage
 	}
 	update {
 		addCorrespondenceBetween(javaClass, componentOrSystem)
@@ -517,8 +523,9 @@ routine createOrFindCompositeDataType(java::Class javaClass, java::CompilationUn
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 	}
 	update {
-		val foundCompositeDataType = pcmRepository.dataTypes__Repository.filter(CompositeDataType)
-			.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"].claimNotMany
+		val foundCompositeDataType = pcmRepository.dataTypes__Repository.filter(CompositeDataType).filter [
+			entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"
+		].claimNotMany
 		if (foundCompositeDataType === null) {
 			createCompositeDataType(javaClass, compilationUnit)
 		} else {
@@ -544,8 +551,9 @@ routine createOrFindCollectionDataType(java::Class javaClass, java::CompilationU
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 	}
 	update {
-		val foundCollectionDataType = pcmRepository.dataTypes__Repository.filter(CollectionDataType)
-			.filter[entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"].claimNotMany
+		val foundCollectionDataType = pcmRepository.dataTypes__Repository.filter(CollectionDataType).filter [
+			entityName.toFirstUpper == javaClass.name.toFirstUpper || javaClass.name === null && entityName == "aName"
+		].claimNotMany
 		if (foundCollectionDataType === null) {
 			createCollectionDataType(javaClass, compilationUnit)
 		} else {
@@ -626,22 +634,22 @@ routine createJavaSubPackages(java::Package javaPackage) {
 		createJavaPackage(repository, javaPackage, "datatypes", "datatypes");
 		createJavaPackage(repository, javaPackage, "contracts", "contracts");
 	}
-}	
+}
 
 /**
  * Create java package and tag it.
  */
-routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag)	 { 
+routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
-	} 
+	}
 	create {
 		val javaPackage = new java::Package
 	}
 	update { // TODO FIXME find or create pattern
 		if (parentPackage !== null) {
 			javaPackage.namespaces += parentPackage.namespaces;
-			javaPackage.namespaces += parentPackage.name; 
+			javaPackage.namespaces += parentPackage.name;
 		}
 		javaPackage.name = packageName;
 		persistProjectRelative(parentPackage, javaPackage, buildJavaFilePath(javaPackage));

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
@@ -56,7 +56,7 @@ routine createOrFindArchitecturalElement(java::Package javaPackage, String conta
 			PACKAGE with containerPackage.name == containerName
 		require absence of pcm::RepositoryComponent corresponding to javaPackage
 		// ensure that we are not the root package (happens when the root package is being moved)
-		require absence of pcm::Repository corresponding to javaPackage tagged with "package_root"
+		require absence of pcm::Repository corresponding to javaPackage tagged "package_root"
 	}
 	update {
 		val rootPackageName = getRootPackageName(javaPackage.name)
@@ -70,7 +70,7 @@ routine createOrFindArchitecturalElement(java::Package javaPackage, String conta
 
 routine createOrFindArchitecturalElementInPackage(java::Package javaPackage, java::Package containingPackage, String rootPackageName) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to containingPackage tagged with "package_root"
+		val pcmRepository = retrieve pcm::Repository corresponding to containingPackage tagged "package_root"
 		require absence of pcm::RepositoryComponent corresponding to javaPackage
 	}
 	update {
@@ -115,7 +115,7 @@ routine createArchitecturalElement(java::Package javaPackage, String name, Strin
 
 routine createOrFindRepository(java::Package javaPackage, String packageName, String newTag) {
 	match {
-		require absence of pcm::Repository corresponding to javaPackage tagged with newTag
+		require absence of pcm::Repository corresponding to javaPackage tagged newTag
 		require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.
 			REPOSITORY with javaPackage.isPackageFor(foundRepository)
@@ -255,7 +255,7 @@ reaction JavaPackageRemoved {
 
 routine removeRepository(java::Package javaPackage) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged with "package_root"
+		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged "package_root"
 	}
 	update {
 		removeObject(pcmRepository)
@@ -265,7 +265,7 @@ routine removeRepository(java::Package javaPackage) {
 
 routine removeSystem(java::Package javaPackage) {
 	match {
-		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged with "root_system"
+		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged "root_system"
 	}
 	update {
 		removeObject(pcmSystem)
@@ -285,7 +285,7 @@ routine removeComponent(java::Package javaPackage) {
 
 routine renameRepository(java::Package javaPackage) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged with "package_root"
+		val pcmRepository = retrieve pcm::Repository corresponding to javaPackage tagged "package_root"
 	}
 	update {
 		pcmRepository.entityName = javaPackage.name.toFirstUpper
@@ -294,7 +294,7 @@ routine renameRepository(java::Package javaPackage) {
 
 routine renameSystem(java::Package javaPackage) {
 	match {
-		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged with "root_system"
+		val pcmSystem = retrieve pcm::System corresponding to javaPackage tagged "root_system"
 	}
 	update {
 		pcmSystem.entityName = javaPackage.name.toFirstUpper
@@ -321,7 +321,7 @@ routine createOrFindPCMInterface(java::Interface javaInterface, java::Compilatio
 		val containingPackage = retrieve java::Package corresponding to ContainersPackage.Literals.
 			PACKAGE with containingPackage.namespacesAsString + containingPackage.name + "." ==
 			compilationUnit.namespacesAsString
-		val pcmRepository = retrieve optional pcm::Repository corresponding to containingPackage tagged with "contracts"
+		val pcmRepository = retrieve optional pcm::Repository corresponding to containingPackage tagged "contracts"
 		require absence of pcm::OperationInterface corresponding to javaInterface
 	}
 	update {
@@ -454,7 +454,7 @@ reaction ClassCreated {
 routine classMapping(java::Class javaClass, java::CompilationUnit compilationUnit, java::Package javaPackage) {
 	match {
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-		val datatypesPackage = retrieve java::Package corresponding to pcmRepository tagged with "datatypes"
+		val datatypesPackage = retrieve java::Package corresponding to pcmRepository tagged "datatypes"
 	}
 	update {
 		if (javaPackage !== null && javaPackage.name == datatypesPackage.name) {
@@ -497,7 +497,7 @@ routine createElement(java::Class javaClass, java::Package javaPackage, java::Co
 		require absence of pcm::DataType corresponding to javaClass
 		require absence of pcm::InterfaceProvidingRequiringEntity corresponding to javaClass
 		val pcmRepository = retrieve pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
-		val javaRootPackage = retrieve java::Package corresponding to pcmRepository tagged with "package_root"
+		val javaRootPackage = retrieve java::Package corresponding to pcmRepository tagged "package_root"
 	}
 	update {
 		createArchitecturalElement(javaRootPackage, javaClass.name, compilationUnit.namespaces.head)
@@ -641,7 +641,7 @@ routine createJavaSubPackages(java::Package javaPackage) {
  */
 routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
-		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
+		require absence of java::Package corresponding to sourceElementMappedToPackage tagged newTag
 	}
 	create {
 		val javaPackage = new java::Package

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmMethod.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmMethod.reactions
@@ -1,20 +1,17 @@
 import org.palladiosimulator.pcm.repository.OperationProvidedRole
 import org.emftext.language.java.classifiers.ConcreteClassifier
-
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
-
 import static extension edu.kit.ipd.sdq.commons.util.org.palladiosimulator.pcm.repository.ParameterUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.hasSameSignature
 import static extension tools.vitruv.applications.pcmjava.java2pcm.TypeReferenceCorrespondenceHelper.getDataTypeFromTypeReference
 import static extension tools.vitruv.applications.pcmjava.java2pcm.TypeReferenceCorrespondenceHelper.getCorrespondingPCMDataTypeForTypeReference
 
-import "http://www.emftext.org/java" as java 
+import "http://www.emftext.org/java" as java
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: java2PcmMethod
 in reaction to changes in java
 execute actions in pcm
-
 
 // General:
 reaction MemberRenamed {
@@ -25,7 +22,8 @@ reaction MemberRenamed {
 
 routine renameMember(java::Member javaMember) {
 	match {
-		val pcmElement = retrieve pcm::NamedElement corresponding to javaMember}
+		val pcmElement = retrieve pcm::NamedElement corresponding to javaMember
+	}
 	update {
 		pcmElement.entityName = javaMember.name
 	}
@@ -58,8 +56,8 @@ routine createParameter(java::OrdinaryParameter javaParameter, java::Parametriza
 reaction ParameterDeleted {
 	after element java::OrdinaryParameter removed from java::Parametrizable[parameters]
 	call {
-		//oldValue has no correspondence element, but it should
-		//this seems to be a bug. If fixed it should have a correspondence and work.
+		// oldValue has no correspondence element, but it should
+		// this seems to be a bug. If fixed it should have a correspondence and work.
 		deleteParameter(oldValue)
 	}
 }
@@ -102,10 +100,10 @@ routine changeParameterType(java::TypeReference newType, java::Parameter javaPar
 	}
 	update {
 		pcmParameter.dataType__Parameter = if (javaParameter.typeReference !== null) {
-				javaParameter.typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
-			} else {
-				null
-			}
+			javaParameter.typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
+		} else {
+			null
+		}
 	}
 }
 
@@ -135,35 +133,39 @@ routine createInnerDeclaration(java::ConcreteClassifier classifier, java::Field 
 	update {
 		innerDeclaration.entityName = javaField.name
 		innerDeclaration.datatype_InnerDeclaration = if (javaField.typeReference !== null) {
-				javaField.typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
-			} else {
-				null
-			}
-			innerDeclaration.compositeDataType_InnerDeclaration = compositeDataType
+			javaField.typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
+		} else {
+			null
+		}
+		innerDeclaration.compositeDataType_InnerDeclaration = compositeDataType
 		addCorrespondenceBetween(innerDeclaration, javaField)
 	}
 }
 
 routine createOrFindAssemblyContext(java::ConcreteClassifier classifier, java::Field javaField) {
-    match {
-        val composedProvidingRequiringEntity = retrieve pcm::ComposedProvidingRequiringEntity corresponding to classifier
-        val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to getClassifierFromTypeReference(javaField.typeReference)
-        require absence of pcm::AssemblyContext corresponding to javaField
-    }
-    update {
-        val pcmAssemblyContextCandidate = composedProvidingRequiringEntity.assemblyContexts__ComposedStructure.findFirst[entityName === javaField.name]
-        if (pcmAssemblyContextCandidate === null) {
-            createAssemblyContext(classifier, javaField)
-        } else {
-            addAssemblyContextCorrespondence(pcmAssemblyContextCandidate, javaField)
-        }
-    }
+	match {
+		val composedProvidingRequiringEntity = retrieve pcm::ComposedProvidingRequiringEntity corresponding to classifier
+		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to getClassifierFromTypeReference(
+			javaField.typeReference)
+		require absence of pcm::AssemblyContext corresponding to javaField
+	}
+	update {
+		val pcmAssemblyContextCandidate = composedProvidingRequiringEntity.assemblyContexts__ComposedStructure.findFirst [
+			entityName === javaField.name
+		]
+		if (pcmAssemblyContextCandidate === null) {
+			createAssemblyContext(classifier, javaField)
+		} else {
+			addAssemblyContextCorrespondence(pcmAssemblyContextCandidate, javaField)
+		}
+	}
 }
 
 routine createAssemblyContext(java::ConcreteClassifier classifier, java::Field javaField) {
 	match {
 		val composedProvidingRequiringEntity = retrieve pcm::ComposedProvidingRequiringEntity corresponding to classifier
-		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to getClassifierFromTypeReference(javaField.typeReference)
+		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to getClassifierFromTypeReference(
+			javaField.typeReference)
 	}
 	create {
 		val assemblyContext = new pcm::AssemblyContext
@@ -171,35 +173,40 @@ routine createAssemblyContext(java::ConcreteClassifier classifier, java::Field j
 	update {
 		assemblyContext.entityName = javaField.name
 		assemblyContext.encapsulatedComponent__AssemblyContext = repositoryComponent
-		assemblyContext.parentStructure__AssemblyContext = composedProvidingRequiringEntity	
+		assemblyContext.parentStructure__AssemblyContext = composedProvidingRequiringEntity
 		addCorrespondenceBetween(assemblyContext, javaField)
 	}
 }
 
 routine addAssemblyContextCorrespondence(pcm::AssemblyContext assemblyContext, java::Field javaField) {
-    update {
-        addCorrespondenceBetween(assemblyContext, javaField)
-    }
+	update {
+		addCorrespondenceBetween(assemblyContext, javaField)
+	}
 }
 
 routine fieldCreatedCorrespondingToOperationInterface(java::Classifier classifier, java::Field javaField) {
 	match {
 		val correspondingInterface = retrieve pcm::OperationInterface corresponding to classifier
-		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to javaField.containingConcreteClassifier
+		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to javaField.
+			containingConcreteClassifier
 	}
 	update {
 		createOperationRequiredRoleCorrespondingToField(javaField, correspondingInterface, repositoryComponent)
 	}
 }
+
 routine fieldCreatedCorrespondingToRepositoryComponent(java::Classifier classifier, java::Field javaField) {
 	match {
 		val repositoryComponent = retrieve pcm::RepositoryComponent corresponding to classifier
-		val concreteRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to javaField.containingConcreteClassifier
+		val concreteRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to javaField.
+			containingConcreteClassifier
 	}
 	update {
-		var operationProvidedRoles = repositoryComponent.providedRoles_InterfaceProvidingEntity.filter(OperationProvidedRole)
+		var operationProvidedRoles = repositoryComponent.providedRoles_InterfaceProvidingEntity.filter(
+			OperationProvidedRole)
 		for (providedRole : operationProvidedRoles) {
-			createOperationRequiredRoleCorrespondingToField(javaField, providedRole.providedInterface__OperationProvidedRole, concreteRepositoryComponent)
+			createOperationRequiredRoleCorrespondingToField(javaField,
+				providedRole.providedInterface__OperationProvidedRole, concreteRepositoryComponent)
 		}
 	}
 }
@@ -228,10 +235,10 @@ routine changeInnerDeclarationType(java::TypeReference typeReference, java::Fiel
 	}
 	update {
 		innerDeclaration.datatype_InnerDeclaration = if (typeReference !== null) {
-				typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
-			} else {
-				null
-			}
+			typeReference.getDataTypeFromTypeReference(correspondenceModel, userInteractor, null)
+		} else {
+			null
+		}
 	}
 }
 
@@ -253,7 +260,7 @@ routine createSeffFromImplementingInterfaces(java::ClassMethod classMethod, java
 routine createSeffFromImplementingInterface(java::ClassMethod classMethod, java::Class javaClass, java::Interface javaInterface) {
 	match {
 		val operationInterface = retrieve pcm::OperationInterface corresponding to javaInterface
-	} 
+	}
 	update {
 		val methods = javaInterface.methods.filter[hasSameSignature(classMethod)]
 		for (method : methods) {
@@ -280,13 +287,14 @@ routine createSEFF(java::Method javaMethod, java::Class javaClass, java::ClassMe
 
 // Interface Method:
 reaction InterfaceMethodCreated {
-	after element java::InterfaceMethod inserted in java::Interface[members] 
+	after element java::InterfaceMethod inserted in java::Interface[members]
 	call createPCMSignature(newValue)
 }
 
 routine createPCMSignature(java::InterfaceMethod interfaceMethod) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to interfaceMethod.containingConcreteClassifier
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to interfaceMethod.
+			containingConcreteClassifier
 	}
 	create {
 		val operationSignature = new pcm::OperationSignature
@@ -308,12 +316,13 @@ routine changeReturnType(java::Method javaMethod, java::TypeReference typeRefere
 	match {
 		val operationSignature = retrieve pcm::OperationSignature corresponding to javaMethod
 	}
-	 update {
+	update {
 		val repository = operationSignature.interface__OperationSignature.repository__Interface
 		operationSignature.returnType__OperationSignature = if (typeReference !== null) {
-				typeReference.getCorrespondingPCMDataTypeForTypeReference(correspondenceModel, userInteractor, repository, javaMethod.arrayDimension)
-			} else {
-				null
-			}
-	 }
+			typeReference.getCorrespondingPCMDataTypeForTypeReference(correspondenceModel, userInteractor, repository,
+				javaMethod.arrayDimension)
+		} else {
+			null
+		}
+	}
 }

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
@@ -89,7 +89,7 @@ routine createRepositorySubPackages(pcm::Repository repository) {
 
 routine renamePackageForRepository(pcm::Repository repository) {
 	match {
-		val rootPackage = retrieve java::Package corresponding to repository tagged with "repository_root"
+		val rootPackage = retrieve java::Package corresponding to repository tagged "repository_root"
 	}
 	update {
 		rootPackage.name = repository.correspondingPackageName
@@ -330,7 +330,7 @@ reaction CreatedComponent {
 routine createComponentImplementation(pcm::RepositoryComponent component) {
 	match {
 		val repositoryPackage = retrieve java::Package corresponding to component.
-			repository__RepositoryComponent tagged with "repository_root"
+			repository__RepositoryComponent tagged "repository_root"
 	}
 	update {
 		createOrFindJavaPackage(component, repositoryPackage, component.entityName, null);
@@ -579,8 +579,8 @@ reaction RenameInnerDeclaration {
 routine renameInnerDeclarationImplementation(pcm::InnerDeclaration innerDeclaration) {
 	match {
 		val compositeTypeField = retrieve java::Field corresponding to innerDeclaration
-		val compositeTypeGetterMethod = retrieve java::ClassMethod corresponding to innerDeclaration tagged with "getter"
-		val compositeTypeSetterMethod = retrieve java::ClassMethod corresponding to innerDeclaration tagged with "setter"
+		val compositeTypeGetterMethod = retrieve java::ClassMethod corresponding to innerDeclaration tagged "getter"
+		val compositeTypeSetterMethod = retrieve java::ClassMethod corresponding to innerDeclaration tagged "setter"
 	}
 	update {
 		compositeTypeField.name = innerDeclaration.entityName;
@@ -610,8 +610,8 @@ routine changeTypeOfInnerDeclarationImplementation(pcm::InnerDeclaration innerDe
 routine changeInnerDeclarationType(pcm::InnerDeclaration innerDeclaration, java::TypeReference newTypeReference) {
 	match {
 		val compositeTypeField = retrieve java::Field corresponding to innerDeclaration
-		val compositeTypeGetterMethod = retrieve java::Method corresponding to innerDeclaration tagged with "getter"
-		val compositeTypeSetterMethod = retrieve java::Method corresponding to innerDeclaration tagged with "setter"
+		val compositeTypeGetterMethod = retrieve java::Method corresponding to innerDeclaration tagged "getter"
+		val compositeTypeSetterMethod = retrieve java::Method corresponding to innerDeclaration tagged "setter"
 	}
 	update {
 		compositeTypeField.typeReference = EcoreUtil.copy(newTypeReference);
@@ -627,7 +627,7 @@ routine changeInnerDeclarationType(pcm::InnerDeclaration innerDeclaration, java:
 // ################ JAVA PACKAGE ROUTINES ################
 routine createOrFindJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
-		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
+		require absence of java::Package corresponding to sourceElementMappedToPackage tagged newTag
 		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.
 			PACKAGE with matchingPackages.name.toLowerCase == packageName.toLowerCase && (parentPackage === null ||
 			matchingPackages.namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + ".")
@@ -649,7 +649,7 @@ routine addPackageCorrespondence(EObject sourceElementMappedToPackage, java::Pac
 
 routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
-		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
+		require absence of java::Package corresponding to sourceElementMappedToPackage tagged newTag
 	}
 	create {
 		val javaPackage = new java::Package
@@ -670,7 +670,7 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 
 routine renameJavaPackage(pcm::NamedElement sourceElementMappedToPackage, java::Package parentPackage, String packageName, String expectedTag) {
 	match {
-		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage tagged with expectedTag // move containing model to project-relative location: buildJavaFilePath(javaPackage)
+		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage tagged expectedTag // move containing model to project-relative location: buildJavaFilePath(javaPackage)
 	}
 	update {
 		val newNamespaces = newArrayList
@@ -688,7 +688,7 @@ routine renameJavaPackage(pcm::NamedElement sourceElementMappedToPackage, java::
 
 routine deleteJavaPackage(pcm::NamedElement sourceElementMappedToPackage, String expectedTag) {
 	match {
-		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage tagged with expectedTag
+		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage tagged expectedTag
 	}
 	update {
 		removeObject(javaPackage)
@@ -727,7 +727,7 @@ routine createJavaClass(pcm::NamedElement sourceElementMappedToClass, java::Pack
 routine createOrFindJavaInterface(pcm::Interface pcmInterface) {
 	match {
 		val contractsPackage = retrieve java::Package corresponding to pcmInterface.
-			repository__Interface tagged with "contracts"
+			repository__Interface tagged "contracts"
 		require absence of java::Interface corresponding to pcmInterface
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
@@ -29,12 +29,10 @@ import org.palladiosimulator.pcm.repository.OperationSignature
 import org.palladiosimulator.pcm.repository.RepositoryPackage
 import org.palladiosimulator.pcm.system.SystemPackage
 import tools.vitruv.change.interaction.UserInteractionOptions.WindowModality
-
 import static tools.vitruv.applications.pcmjava.pcm2java.Pcm2JavaHelper.*
 import static tools.vitruv.applications.util.temporary.java.JavaModificationUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaPersistenceHelper.*
 import static com.google.common.base.Preconditions.checkState
-
 import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
 import static extension tools.vitruv.applications.pcmjava.PcmJavaTransformationUtil.getCorrespondingPackageName
@@ -48,7 +46,6 @@ execute actions in java
 
 // ###################################################
 // ################ PACKAGE REACTIONS ################
-
 reaction RepositoryCreated {
 	after element pcm::Repository inserted as root
 	call {
@@ -92,8 +89,7 @@ routine createRepositorySubPackages(pcm::Repository repository) {
 
 routine renamePackageForRepository(pcm::Repository repository) {
 	match {
-		val rootPackage = retrieve java::Package corresponding to repository
-			tagged with "repository_root"
+		val rootPackage = retrieve java::Package corresponding to repository tagged with "repository_root"
 	}
 	update {
 		rootPackage.name = repository.correspondingPackageName
@@ -137,10 +133,8 @@ reaction RepositoryDeleted {
 	}
 }
 
-
 // ################################################################################
 // ############################# COMPOSED STRUCTURES ##############################
-
 reaction CreatedSystem {
 	after element pcm::System inserted as root
 	call {
@@ -198,19 +192,20 @@ reaction AddedAssemblyContextToComposedStructure {
 }
 
 routine createOrFindAssemblyContextField(pcm::AssemblyContext assemblyContext, pcm::ComposedStructure composedStructure) {
-	 match {
-		 val compositeComponentJavaClass = retrieve java::Class corresponding to composedStructure
-		 val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
-		 require absence of java::Field corresponding to assemblyContext
-	 }
-	 update {
+	match {
+		val compositeComponentJavaClass = retrieve java::Class corresponding to composedStructure
+		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.
+			encapsulatedComponent__AssemblyContext
+		require absence of java::Field corresponding to assemblyContext
+	}
+	update {
 		val foundField = compositeComponentJavaClass.members.filter(Field).findFirst[name == assemblyContext.entityName]
 		if (foundField === null) {
 			createAssemblyContextField(assemblyContext, compositeComponentJavaClass, encapsulatedComponentJavaClass)
 		} else {
 			addAssemblyContextFieldCorrespondence(assemblyContext, foundField)
 		}
-	 }
+	}
 }
 
 routine createAssemblyContextField(pcm::AssemblyContext assemblyContext, java::Class compositeComponentJavaClass, java::Class encapsulatedComponentJavaClass) {
@@ -218,7 +213,8 @@ routine createAssemblyContextField(pcm::AssemblyContext assemblyContext, java::C
 		val assemblyContextField = new java::Field
 	}
 	update {
-		createPrivateField(assemblyContextField, createNamespaceClassifierReference(encapsulatedComponentJavaClass), assemblyContext.entityName)
+		createPrivateField(assemblyContextField, createNamespaceClassifierReference(encapsulatedComponentJavaClass),
+			assemblyContext.entityName)
 		compositeComponentJavaClass.members += assemblyContextField
 		addCorrespondenceBetween(assemblyContextField, assemblyContext)
 	}
@@ -233,18 +229,22 @@ routine addAssemblyContextFieldCorrespondence(pcm::AssemblyContext assemblyConte
 routine createOrFindAssemblyContextConstructor(pcm::AssemblyContext assemblyContext, pcm::ComposedStructure composedStructure) {
 	match {
 		val compositeComponentJavaClass = retrieve java::Class corresponding to composedStructure
-		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
+		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.
+			encapsulatedComponent__AssemblyContext
 		require absence of java::Constructor corresponding to assemblyContext
 	}
 	update {
-		val foundConstructor = compositeComponentJavaClass.members.filter(Constructor).findFirst[name == compositeComponentJavaClass.name]
+		val foundConstructor = compositeComponentJavaClass.members.filter(Constructor).findFirst [
+			name == compositeComponentJavaClass.name
+		]
 		if (foundConstructor === null) {
 			createAssemblyContextConstructor(assemblyContext, compositeComponentJavaClass)
 		} else {
-			val foundCall = foundConstructor.statements.filter(ExpressionStatement).map[expression].filter(AssignmentExpression).map[value].filter(NewConstructorCall).head
+			val foundCall = foundConstructor.statements.filter(ExpressionStatement).map[expression].filter(
+				AssignmentExpression).map[value].filter(NewConstructorCall).head
 			if (foundCall === null) {
 				createAssemblyContextStatement(assemblyContext, foundConstructor, compositeComponentJavaClass)
-			} else{
+			} else {
 				addAssemblyContextConstructorCorrespondence(assemblyContext, foundConstructor, foundCall)
 			}
 		}
@@ -288,12 +288,14 @@ routine addAssemblyContextConstructorCorrespondence(pcm::AssemblyContext assembl
 routine createOrFindAssemblyContextImport(pcm::AssemblyContext assemblyContext, pcm::ComposedStructure composedStructure) {
 	match {
 		val compositeComponentJavaClass = retrieve java::Class corresponding to composedStructure
-		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.encapsulatedComponent__AssemblyContext
+		val encapsulatedComponentJavaClass = retrieve java::Class corresponding to assemblyContext.
+			encapsulatedComponent__AssemblyContext
 		require absence of java::ClassifierImport corresponding to assemblyContext
 	}
 	update {
-		val foundImport = compositeComponentJavaClass.containingCompilationUnit.imports.filter(ClassifierImport).findFirst[it.classifier == encapsulatedComponentJavaClass]
-		if(foundImport === null) {
+		val foundImport = compositeComponentJavaClass.containingCompilationUnit.imports.filter(ClassifierImport).
+			findFirst[it.classifier == encapsulatedComponentJavaClass]
+		if (foundImport === null) {
 			createAssemblyContextImport(assemblyContext, compositeComponentJavaClass, encapsulatedComponentJavaClass)
 		} else {
 			addAssemblyContextImportCorrespondence(assemblyContext, foundImport)
@@ -306,11 +308,11 @@ routine createAssemblyContextImport(pcm::AssemblyContext assemblyContext, java::
 		val contextClassImport = new java::ClassifierImport
 	}
 	update {
-		addImportToCompilationUnitOfClassifier(contextClassImport, compositeComponentJavaClass, encapsulatedComponentJavaClass)
+		addImportToCompilationUnitOfClassifier(contextClassImport, compositeComponentJavaClass,
+			encapsulatedComponentJavaClass)
 		addCorrespondenceBetween(contextClassImport, assemblyContext)
 	}
 }
-
 
 routine addAssemblyContextImportCorrespondence(pcm::AssemblyContext assemblyContext, java::ClassifierImport contextClassImport) {
 	update {
@@ -320,7 +322,6 @@ routine addAssemblyContextImportCorrespondence(pcm::AssemblyContext assemblyCont
 
 // #####################################################
 // ################ COMPONENT REACTIONS ################
-
 reaction CreatedComponent {
 	after element pcm::RepositoryComponent inserted in pcm::Repository[components__Repository]
 	call createComponentImplementation(newValue)
@@ -328,8 +329,8 @@ reaction CreatedComponent {
 
 routine createComponentImplementation(pcm::RepositoryComponent component) {
 	match {
-		val repositoryPackage = retrieve java::Package corresponding to component.repository__RepositoryComponent
-			tagged with "repository_root"
+		val repositoryPackage = retrieve java::Package corresponding to component.
+			repository__RepositoryComponent tagged with "repository_root"
 	}
 	update {
 		createOrFindJavaPackage(component, repositoryPackage, component.entityName, null);
@@ -356,8 +357,9 @@ reaction RenameComponent {
 
 routine renameComponentPackageAndClass(pcm::RepositoryComponent component) {
 	match {
-		val repositoryPackage = retrieve java::Package corresponding to component.repository__RepositoryComponent
-			with repositoryPackage.name == component.repository__RepositoryComponent.entityName
+		val repositoryPackage = retrieve java::Package corresponding to component.
+			repository__RepositoryComponent with repositoryPackage.name ==
+			component.repository__RepositoryComponent.entityName
 	}
 	update {
 		renameJavaPackage(component, repositoryPackage, component.entityName, null);
@@ -384,7 +386,6 @@ reaction DeletedComponent {
 
 // #####################################################
 // ################ INTERFACE REACTIONS ################
-
 reaction CreatedInterface {
 	after element inserted in pcm::Repository[interfaces__Repository]
 	call createOrFindJavaInterface(newValue)
@@ -397,8 +398,8 @@ reaction RenamedInterface {
 
 routine renameInterface(pcm::OperationInterface interf) {
 	match {
-		val contractsPackage = retrieve java::Package corresponding to interf.repository__Interface
-			with contractsPackage.name == "contracts"
+		val contractsPackage = retrieve java::Package corresponding to interf.
+			repository__Interface with contractsPackage.name == "contracts"
 	}
 	update {
 		renameJavaClassifier(interf, contractsPackage, interf.entityName)
@@ -407,7 +408,6 @@ routine renameInterface(pcm::OperationInterface interf) {
 
 // ######################################################
 // ################ DATA TYPES REACTIONS ################
-
 reaction CreatedCompositeDataType {
 	after element pcm::CompositeDataType inserted in pcm::Repository[dataTypes__Repository]
 	call createCompositeDataTypeImplementation(newValue)
@@ -415,8 +415,8 @@ reaction CreatedCompositeDataType {
 
 routine createCompositeDataTypeImplementation(pcm::CompositeDataType compositeDataType) {
 	match {
-		val datatypesPackage = retrieve java::Package corresponding to compositeDataType.repository__DataType
-			with datatypesPackage.name == "datatypes"
+		val datatypesPackage = retrieve java::Package corresponding to compositeDataType.
+			repository__DataType with datatypesPackage.name == "datatypes"
 	}
 	update {
 		createOrFindDataTypeClass(compositeDataType, datatypesPackage)
@@ -440,7 +440,8 @@ reaction RenamedCompositeDataType {
 
 routine renameCompositeDataType(pcm::CompositeDataType compositeDataType) {
 	match {
-		val datatypesPackage = retrieve java::Package corresponding to compositeDataType.repository__DataType with datatypesPackage.name == "datatypes"
+		val datatypesPackage = retrieve java::Package corresponding to compositeDataType.
+			repository__DataType with datatypesPackage.name == "datatypes"
 	}
 	update {
 		renameJavaClassifier(compositeDataType, datatypesPackage, compositeDataType.entityName)
@@ -460,7 +461,8 @@ reaction CreatedCollectionDataType {
 routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType) {
 	match {
 		val innerTypeClass = retrieve optional java::Class corresponding to dataType.innerType_CollectionDataType
-		val datatypesPackage = retrieve java::Package corresponding to dataType.repository__DataType with datatypesPackage.name == "datatypes"
+		val datatypesPackage = retrieve java::Package corresponding to dataType.
+			repository__DataType with datatypesPackage.name == "datatypes"
 	}
 	update {
 		// create correct (and in case of primitive types wrapped) type reference for the inner type
@@ -478,8 +480,8 @@ routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType)
 			collectionDataTypeNames += collectionDataType.name;
 		}
 		val String selectTypeMsg = "Please select type (or interface) that should be used for the type";
-		val int selectedType = userInteractor.singleSelectionDialogBuilder.message(selectTypeMsg)
-			.choices(collectionDataTypeNames).windowModality(WindowModality.MODAL).startInteraction();
+		val int selectedType = userInteractor.singleSelectionDialogBuilder.message(selectTypeMsg).choices(
+			collectionDataTypeNames).windowModality(WindowModality.MODAL).startInteraction();
 		val Class<?> selectedClass = collectionDataTypes.get(selectedType);
 
 		createOrFindDataTypeClass(dataType, datatypesPackage)
@@ -497,7 +499,8 @@ routine addSuperTypeToDataType(pcm::DataType dataType, java::TypeReference inner
 	update {
 		val collectionTypeClassImport = createJavaClassImport(superTypeQualifiedName);
 		dataTypeImplementation.containingCompilationUnit.imports += collectionTypeClassImport;
-		createNamespaceClassifierReference(namespaceClassifier, dataTypeImplementation.containingCompilationUnit.imports.filter(ClassifierImport).last.classifier);
+		createNamespaceClassifierReference(namespaceClassifier,
+			dataTypeImplementation.containingCompilationUnit.imports.filter(ClassifierImport).last.classifier);
 		val qualifiedTypeArgument = GenericsFactory.eINSTANCE.createQualifiedTypeArgument();
 		qualifiedTypeArgument.typeReference = innerTypeReference;
 		namespaceClassifier.classifierReferences.get(0).typeArguments += qualifiedTypeArgument;
@@ -513,7 +516,8 @@ reaction RenamedCollectionDataType {
 
 routine renameCollectionDataType(pcm::CollectionDataType collectionDataType) {
 	match {
-		val datatypesPackage = retrieve java::Package corresponding to collectionDataType.repository__DataType with datatypesPackage.name == "datatypes"
+		val datatypesPackage = retrieve java::Package corresponding to collectionDataType.
+			repository__DataType with datatypesPackage.name == "datatypes"
 	}
 	update {
 		renameJavaClassifier(collectionDataType, datatypesPackage, collectionDataType.entityName)
@@ -526,7 +530,6 @@ reaction DeletedCollectionDataType {
 }
 
 // ################ DATA TYPES - INNER DECLARATION REACTIONS ################
-
 reaction CreatedInnerDeclaration {
 	after element pcm::InnerDeclaration inserted in pcm::CompositeDataType[innerDeclaration_CompositeDataType]
 	call createInnerDeclarationImplementation(newValue)
@@ -534,11 +537,14 @@ reaction CreatedInnerDeclaration {
 
 routine createInnerDeclarationImplementation(pcm::InnerDeclaration innerDeclaration) {
 	match {
-		val nonPrimitiveInnerDataTypeClass = retrieve optional java::Class corresponding to innerDeclaration.datatype_InnerDeclaration
+		val nonPrimitiveInnerDataTypeClass = retrieve optional java::Class corresponding to innerDeclaration.
+			datatype_InnerDeclaration
 	}
 	update {
-		val innerDataTypeReference = createTypeReference(innerDeclaration.datatype_InnerDeclaration, nonPrimitiveInnerDataTypeClass);
-		addInnerDeclarationToCompositeDataType(innerDeclaration.compositeDataType_InnerDeclaration, innerDeclaration, innerDataTypeReference);
+		val innerDataTypeReference = createTypeReference(innerDeclaration.datatype_InnerDeclaration,
+			nonPrimitiveInnerDataTypeClass);
+		addInnerDeclarationToCompositeDataType(innerDeclaration.compositeDataType_InnerDeclaration, innerDeclaration,
+			innerDataTypeReference);
 	}
 }
 
@@ -619,16 +625,15 @@ routine changeInnerDeclarationType(pcm::InnerDeclaration innerDeclaration, java:
 
 // ######################################################
 // ################ JAVA PACKAGE ROUTINES ################
-
 routine createOrFindJavaPackage(EObject sourceElementMappedToPackage, java::Package parentPackage, String packageName, String newTag) {
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged with newTag
-		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
-		with matchingPackages.name.toLowerCase == packageName.toLowerCase && (parentPackage === null ||
+		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.
+			PACKAGE with matchingPackages.name.toLowerCase == packageName.toLowerCase && (parentPackage === null ||
 			matchingPackages.namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + ".")
 	}
 	update {
-		if(matchingPackages.empty) {
+		if (matchingPackages.empty) {
 			createJavaPackage(sourceElementMappedToPackage, parentPackage, packageName, newTag)
 		} else {
 			addPackageCorrespondence(sourceElementMappedToPackage, matchingPackages.head, newTag)
@@ -665,11 +670,10 @@ routine createJavaPackage(EObject sourceElementMappedToPackage, java::Package pa
 
 routine renameJavaPackage(pcm::NamedElement sourceElementMappedToPackage, java::Package parentPackage, String packageName, String expectedTag) {
 	match {
-		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage
-			tagged with expectedTag	//move containing model to project-relative location: buildJavaFilePath(javaPackage)
+		val javaPackage = retrieve java::Package corresponding to sourceElementMappedToPackage tagged with expectedTag // move containing model to project-relative location: buildJavaFilePath(javaPackage)
 	}
 	update {
-		val newNamespaces = newArrayList 
+		val newNamespaces = newArrayList
 		if (parentPackage !== null) {
 			newNamespaces += parentPackage.namespaces
 			newNamespaces += parentPackage.name
@@ -694,15 +698,13 @@ routine deleteJavaPackage(pcm::NamedElement sourceElementMappedToPackage, String
 
 // ######################################################
 // ################ JAVA CLASS ROUTINES ##################
-
-
 routine createOrFindJavaClass(pcm::NamedElement pcmElement, java::Package containingPackage, String className) {
 	match {
 		require absence of java::Class corresponding to pcmElement
 	}
 	update {
 		val foundClass = findClassifier(className, containingPackage, org.emftext.language.java.classifiers.Class)
-		if(foundClass === null) {
+		if (foundClass === null) {
 			createJavaClass(pcmElement, containingPackage, className)
 		} else {
 			addMissingClassifierCorrespondence(pcmElement, foundClass)
@@ -724,12 +726,13 @@ routine createJavaClass(pcm::NamedElement sourceElementMappedToClass, java::Pack
 
 routine createOrFindJavaInterface(pcm::Interface pcmInterface) {
 	match {
-		val contractsPackage = retrieve java::Package corresponding to pcmInterface.repository__Interface tagged with "contracts"
+		val contractsPackage = retrieve java::Package corresponding to pcmInterface.
+			repository__Interface tagged with "contracts"
 		require absence of java::Interface corresponding to pcmInterface
 	}
 	update {
 		val foundInterface = findClassifier(pcmInterface.entityName, contractsPackage, Interface)
-		if(foundInterface === null) {
+		if (foundInterface === null) {
 			createJavaInterface(pcmInterface, contractsPackage)
 		} else {
 			addMissingClassifierCorrespondence(pcmInterface, foundInterface)
@@ -763,7 +766,8 @@ routine createCompilationUnit(pcm::NamedElement sourceElementMappedToClass, java
 		val newNamespaces = new ArrayList(containingPackage.namespaces)
 		newNamespaces += containingPackage.name
 		compilationUnit.namespaces += newNamespaces
-		compilationUnit.name = containingPackage.namespacesAsString + containingPackage.name + "." + classifier.name.toFirstUpper + ".java"
+		compilationUnit.name = containingPackage.namespacesAsString + containingPackage.name + "." +
+			classifier.name.toFirstUpper + ".java"
 		compilationUnit.classifiers += classifier;
 		persistProjectRelative(sourceElementMappedToClass, compilationUnit, buildJavaFilePath(compilationUnit));
 		containingPackage.compilationUnits += compilationUnit
@@ -777,7 +781,7 @@ routine renameJavaClassifier(pcm::NamedElement classSourceElement, java::Package
 	}
 	update {
 		javaClassifier.updateName(className.toFirstUpper)
-	    val compilationUnit = javaClassifier.containingCompilationUnit
+		val compilationUnit = javaClassifier.containingCompilationUnit
 		val newNamespaces = new ArrayList(containingPackage.namespaces)
 		newNamespaces += containingPackage.name
 		var modified = compilationUnit.updateNamespaces(newNamespaces)
@@ -801,7 +805,6 @@ routine deleteJavaClassifier(pcm::NamedElement sourceElement) {
 
 // ####################################################
 // ################ PROVIDED ROLES ####################
-
 reaction CreatedProvidedRole {
 	after element pcm::OperationProvidedRole inserted in pcm::InterfaceProvidingEntity[providedRoles_InterfaceProvidingEntity]
 	call addProvidedRole(newValue)
@@ -809,14 +812,17 @@ reaction CreatedProvidedRole {
 
 routine findOrAddProvidedRole(pcm::OperationProvidedRole providedRole) {
 	match {
-		val operationProvidingInterface = retrieve java::Interface corresponding to providedRole.providedInterface__OperationProvidedRole
+		val operationProvidingInterface = retrieve java::Interface corresponding to providedRole.
+			providedInterface__OperationProvidedRole
 		val javaClass = retrieve java::Class corresponding to providedRole.providingEntity_ProvidedRole
 		require absence of java::NamespaceClassifierReference corresponding to providedRole
 	}
 	update {
 		val matchingReference = javaClass.implements.filter[target == operationProvidingInterface]
-		checkState(matchingReference.size <= 1, "There is more than one implementation of interface %s in Java class %s", operationProvidingInterface, javaClass)
-		if(matchingReference.size == 1) {
+		checkState(matchingReference.size <= 1,
+			"There is more than one implementation of interface %s in Java class %s", operationProvidingInterface,
+			javaClass)
+		if (matchingReference.size == 1) {
 			addProvidedRoleCorrespondence(providedRole, matchingReference.get(0))
 		} else {
 			addProvidedRole(providedRole)
@@ -835,14 +841,15 @@ routine addProvidedRoleCorrespondence(pcm::OperationProvidedRole providedRole, j
 
 routine addProvidedRole(pcm::OperationProvidedRole providedRole) {
 	match {
-		val operationProvidingInterface = retrieve java::Interface corresponding to providedRole.providedInterface__OperationProvidedRole
+		val operationProvidingInterface = retrieve java::Interface corresponding to providedRole.
+			providedInterface__OperationProvidedRole
 		val javaClass = retrieve java::Class corresponding to providedRole.providingEntity_ProvidedRole
 		require absence of java::NamespaceClassifierReference corresponding to providedRole
 	}
 	create {
 		val namespaceClassifierReference = new java::NamespaceClassifierReference
 	}
-	update { 
+	update {
 		createNamespaceClassifierReference(namespaceClassifierReference, operationProvidingInterface)
 		addCorrespondenceBetween(namespaceClassifierReference, providedRole)
 		javaClass.implements += namespaceClassifierReference
@@ -891,7 +898,6 @@ routine removeProvidedRole(pcm::ProvidedRole providedRole) {
 
 // ####################################################
 // ################ REQUIRED ROLES ####################
-
 // TODO HK implement ctor statement as correspondence (dynamic in explicit action for each ctor) to remove them easily
 // Use as example for reactions best practices chapter
 // TODO HK Implement rename correctly after having all four correspondences correctly
@@ -903,7 +909,8 @@ reaction CreatedRequiredRole {
 // TODO HK This routine is hard to read, isn't it?
 routine addRequiredRole(pcm::OperationRequiredRole requiredRole) {
 	match {
-		val requiredInterface = retrieve java::Interface corresponding to requiredRole.requiredInterface__OperationRequiredRole
+		val requiredInterface = retrieve java::Interface corresponding to requiredRole.
+			requiredInterface__OperationRequiredRole
 		val javaClass = retrieve java::Class corresponding to requiredRole.requiringEntity_RequiredRole
 	}
 	create {
@@ -924,17 +931,17 @@ routine addRequiredRole(pcm::OperationRequiredRole requiredRole) {
 			addConstructorToClass(javaClass);
 		}
 		for (ctor : javaClass.members.filter(typeof(Constructor))) {
-			addParameterAndAssignmentToConstructor(requiredRole, ctor, typeRef, requiredInterfaceField, requiredRoleName);
+			addParameterAndAssignmentToConstructor(requiredRole, ctor, typeRef, requiredInterfaceField,
+				requiredRoleName);
 		}
 	}
 }
 
-routine addParameterAndAssignmentToConstructor(pcm::NamedElement parameterCorrespondenceSource, java::Constructor constructor,
-		java::NamespaceClassifierReference typeReference, java::Field fieldToBeAssigned, String parameterName) {
+routine addParameterAndAssignmentToConstructor(pcm::NamedElement parameterCorrespondenceSource, java::Constructor constructor, java::NamespaceClassifierReference typeReference, java::Field fieldToBeAssigned, String parameterName) {
 	match {
 		val existingParameters = retrieve many java::OrdinaryParameter corresponding to parameterCorrespondenceSource
-		check !existingParameters.exists [name == parameterName] 
-	}	
+		check !existingParameters.exists[name == parameterName]
+	}
 	create {
 		val newParameter = new java::OrdinaryParameter
 	}
@@ -999,8 +1006,8 @@ routine removeParameterToFieldAssignmentFromConstructor(java::Constructor ctor, 
 
 routine removeCorrespondingParameterFromConstructor(java::Constructor ctor, pcm::NamedElement correspondenceSource) {
 	match {
-		val param = retrieve java::OrdinaryParameter corresponding to correspondenceSource
-			with ctor.parameters.contains(param)
+		val param = retrieve java::OrdinaryParameter corresponding to correspondenceSource with ctor.parameters.
+			contains(param)
 	}
 	update {
 		removeObject(param)
@@ -1027,7 +1034,6 @@ reaction ChangeOperationRequiredRoleInterface {
 
 // ##########################################################
 // ################ OPERATION SIGNATURES ####################
-
 // TODO HK Implement changing the signature interface. All components with their SEFFs have to be updated.
 // Use more reasonable correspondences than Michael
 reaction CreatedOperationSignature {
@@ -1071,8 +1077,8 @@ routine renameMethodForOperationSignature(pcm::OperationSignature operationSigna
 			]
 		]
 		val basicComponents = implementingComponents.filter(BasicComponent);
-		basicComponents.forEach[
-			it.serviceEffectSpecifications__BasicComponent.forEach[
+		basicComponents.forEach [
+			it.serviceEffectSpecifications__BasicComponent.forEach [
 				updateSEFFImplementingMethodName(it);
 			]
 		]
@@ -1120,7 +1126,6 @@ routine deleteMethodForOperationSignature(pcm::OperationSignature operationSigna
 
 // ################################################################################
 // ################################## PARAMETERS ##################################
-
 reaction CreatedParameter {
 	after element pcm::Parameter inserted in pcm::OperationSignature[parameters__OperationSignature]
 	call createParameter(newValue)
@@ -1196,7 +1201,6 @@ routine deleteParameter(pcm::OperationSignature signature, pcm::Parameter parame
 
 // ################################################################################
 // #################################### SEFFS #####################################
-
 reaction CreatedSEFF {
 	after element pcm::ServiceEffectSpecification inserted in pcm::BasicComponent[serviceEffectSpecifications__BasicComponent]
 	call createSEFF(newValue)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
@@ -1,7 +1,7 @@
 import org.eclipse.uml2.uml.Property
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::AssemblyContext in a pcm::ComposedProvidingRequiringEntity (CPRE)
@@ -13,7 +13,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		UmlAssemblyContextProperty.reactions
 //		AssemblyContextConceptTest
-
 reactions: pcmAssemblyContextReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -33,13 +32,16 @@ routine insertCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 
 routine detectOrCreateCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
-		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 		require absence of uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		val umlComponentImplementation = retrieve optional uml::Class 
-			corresponding to pcmAssembly.encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmAssembly.
+			encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
 	update {
-		val Property umlPropertyCandidate = umlCompositeImplementation.ownedAttributes.findFirst[name == pcmAssembly.entityName]
+		val Property umlPropertyCandidate = umlCompositeImplementation.ownedAttributes.findFirst [
+			name == pcmAssembly.entityName
+		]
 		if (umlPropertyCandidate === null) {
 			createCorrespondingAssemblyContextProperty(pcmAssembly, pcmComposite)
 		} else {
@@ -51,7 +53,8 @@ routine detectOrCreateCorrespondingAssemblyContextProperty(pcm::AssemblyContext 
 routine addCorrespondenceForExistingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, uml::Property umlProperty) {
 	match {
 		require absence of uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		addCorrespondenceBetween(pcmAssembly, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
@@ -60,10 +63,11 @@ routine addCorrespondenceForExistingAssemblyContextProperty(pcm::AssemblyContext
 
 routine createCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
-		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 		require absence of uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		val umlInnerComponent = retrieve optional uml::Class 
-				corresponding to pcmAssembly.encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlInnerComponent = retrieve optional uml::Class corresponding to pcmAssembly.
+			encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
 	create {
 		val umlProperty = new uml::Property
@@ -71,14 +75,17 @@ routine createCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 	update {
 		umlProperty.name = pcmAssembly.entityName
 		addCorrespondenceBetween(pcmAssembly, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
-		changeTypeOfCorrespondingAssemblyContextProperty(pcmAssembly, pcmAssembly.encapsulatedComponent__AssemblyContext)
+		changeTypeOfCorrespondingAssemblyContextProperty(pcmAssembly,
+			pcmAssembly.encapsulatedComponent__AssemblyContext)
 	}
 }
 
 routine moveCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
-		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		umlCompositeImplementation.ownedAttributes += umlProperty
@@ -93,8 +100,10 @@ reaction AssemblyContextRemoved {
 
 routine removeCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
-		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		umlCompositeImplementation.ownedAttributes -= umlProperty
@@ -108,7 +117,8 @@ reaction AssemblyContextDeleted {
 
 routine deleteCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly) {
 	match {
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		removeObject(umlProperty)
@@ -124,7 +134,8 @@ reaction AssemblyContextNameChanged {
 
 routine changeNameOfCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, String newName) {
 	match {
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		umlProperty.name = newName
@@ -133,14 +144,18 @@ routine changeNameOfCorrespondingAssemblyContextProperty(pcm::AssemblyContext pc
 
 reaction AssemblyContextComponentChanged {
 	after element pcm::RepositoryComponent replaced at pcm::AssemblyContext[encapsulatedComponent__AssemblyContext]
-	with {affectedEObject.encapsulatedComponent__AssemblyContext === newValue}
+	with {
+		affectedEObject.encapsulatedComponent__AssemblyContext === newValue
+	}
 	call changeTypeOfCorrespondingAssemblyContextProperty(affectedEObject, newValue)
 }
 
 routine changeTypeOfCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::RepositoryComponent pcmComonent) {
 	match {
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComonent tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
+		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComonent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 	}
 	update {
 		umlProperty.type = umlComponentImplementation.orElse(null)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmAssemblyContext.reactions
@@ -32,11 +32,11 @@ routine insertCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 
 routine detectOrCreateCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
-		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		require absence of uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		require absence of uml::Property corresponding to pcmAssembly tagged TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmAssembly.
-			encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
+			encapsulatedComponent__AssemblyContext tagged TagLiterals.IPRE__IMPLEMENTATION
 	}
 	update {
 		val Property umlPropertyCandidate = umlCompositeImplementation.ownedAttributes.findFirst [
@@ -52,8 +52,8 @@ routine detectOrCreateCorrespondingAssemblyContextProperty(pcm::AssemblyContext 
 
 routine addCorrespondenceForExistingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, uml::Property umlProperty) {
 	match {
-		require absence of uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+		require absence of uml::Property corresponding to pcmAssembly tagged TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -63,11 +63,11 @@ routine addCorrespondenceForExistingAssemblyContextProperty(pcm::AssemblyContext
 
 routine createCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
-		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		require absence of uml::Property corresponding to pcmAssembly tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		require absence of uml::Property corresponding to pcmAssembly tagged TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
 		val umlInnerComponent = retrieve optional uml::Class corresponding to pcmAssembly.
-			encapsulatedComponent__AssemblyContext tagged with TagLiterals.IPRE__IMPLEMENTATION
+			encapsulatedComponent__AssemblyContext tagged TagLiterals.IPRE__IMPLEMENTATION
 	}
 	create {
 		val umlProperty = new uml::Property
@@ -82,9 +82,9 @@ routine createCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssem
 
 routine moveCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
-		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -100,9 +100,9 @@ reaction AssemblyContextRemoved {
 
 routine removeCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::ComposedProvidingRequiringEntity pcmComposite) {
 	match {
-		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+		val umlCompositeImplementation = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -117,7 +117,7 @@ reaction AssemblyContextDeleted {
 
 routine deleteCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly) {
 	match {
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -134,7 +134,7 @@ reaction AssemblyContextNameChanged {
 
 routine changeNameOfCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, String newName) {
 	match {
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -152,9 +152,9 @@ reaction AssemblyContextComponentChanged {
 
 routine changeTypeOfCorrespondingAssemblyContextProperty(pcm::AssemblyContext pcmAssembly, pcm::RepositoryComponent pcmComonent) {
 	match {
-		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged with TagLiterals.
+		val umlProperty = retrieve uml::Property corresponding to pcmAssembly tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
-		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComonent tagged with TagLiterals.
+		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComonent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
@@ -40,13 +40,13 @@ reaction CollectionDataTypeInnerTypeChanged {
  */
 routine changeTypeOfCorrespondingPropertyOrParameter(pcm::CollectionDataType pcmCollection, pcm::DataType newInnerType) {
 	match {
-		val umlParameterList = retrieve many uml::Parameter corresponding to pcmCollection tagged with TagLiterals.
+		val umlParameterList = retrieve many uml::Parameter corresponding to pcmCollection tagged TagLiterals.
 			COLLECTION_DATATYPE__PARAMETER
-		val umlPropertyList = retrieve many uml::Property corresponding to pcmCollection tagged with TagLiterals.
+		val umlPropertyList = retrieve many uml::Property corresponding to pcmCollection tagged TagLiterals.
 			COLLECTION_DATATYPE__PROPERTY
-		val umlPrimitiveType = retrieve many uml::Type corresponding to newInnerType tagged with TagLiterals.
+		val umlPrimitiveType = retrieve many uml::Type corresponding to newInnerType tagged TagLiterals.
 			DATATYPE__TYPE
-		val umlCompositeType = retrieve optional uml::Type corresponding to newInnerType tagged with TagLiterals.
+		val umlCompositeType = retrieve optional uml::Type corresponding to newInnerType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
@@ -44,8 +44,7 @@ routine changeTypeOfCorrespondingPropertyOrParameter(pcm::CollectionDataType pcm
 			COLLECTION_DATATYPE__PARAMETER
 		val umlPropertyList = retrieve many uml::Property corresponding to pcmCollection tagged TagLiterals.
 			COLLECTION_DATATYPE__PROPERTY
-		val umlPrimitiveType = retrieve many uml::Type corresponding to newInnerType tagged TagLiterals.
-			DATATYPE__TYPE
+		val umlPrimitiveType = retrieve many uml::Type corresponding to newInnerType tagged TagLiterals.DATATYPE__TYPE
 		val umlCompositeType = retrieve optional uml::Type corresponding to newInnerType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCollectionDataType.reactions
@@ -2,7 +2,7 @@ import tools.vitruv.applications.pcmumlclass.TagLiterals
 import org.palladiosimulator.pcm.repository.CollectionDataType
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reaction and routine synchronize the inner type of a pcm::CollectionDataType 
@@ -23,7 +23,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmSignature.reactions, PcmParameter.reactions, PcmInnerDeclaration.reactions
 //		UmlReturnAndRegularParameterType.reactions, UmlInnerDeclarationProperty.reactions
 //		SignatureConceptTest, ParameterConceptTest, AttributeConceptTest
-
 reactions: pcmCollectionDataTypeReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -41,15 +40,18 @@ reaction CollectionDataTypeInnerTypeChanged {
  */
 routine changeTypeOfCorrespondingPropertyOrParameter(pcm::CollectionDataType pcmCollection, pcm::DataType newInnerType) {
 	match {
-		val umlParameterList = retrieve many uml::Parameter corresponding to pcmCollection tagged with TagLiterals.COLLECTION_DATATYPE__PARAMETER
-		val umlPropertyList = retrieve many uml::Property corresponding to pcmCollection tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
-		
-		val umlPrimitiveType = retrieve many uml::Type corresponding to newInnerType tagged with TagLiterals.DATATYPE__TYPE
-		val umlCompositeType = retrieve optional uml::Type corresponding to newInnerType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlParameterList = retrieve many uml::Parameter corresponding to pcmCollection tagged with TagLiterals.
+			COLLECTION_DATATYPE__PARAMETER
+		val umlPropertyList = retrieve many uml::Property corresponding to pcmCollection tagged with TagLiterals.
+			COLLECTION_DATATYPE__PROPERTY
+		val umlPrimitiveType = retrieve many uml::Type corresponding to newInnerType tagged with TagLiterals.
+			DATATYPE__TYPE
+		val umlCompositeType = retrieve optional uml::Type corresponding to newInnerType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
-		if (newInnerType instanceof CollectionDataType) logger.warn(DefaultLiterals.WARNING_NESTED_COLLECTION_DATA_TYPE)
-		
+		if(newInnerType instanceof CollectionDataType) logger.warn(DefaultLiterals.WARNING_NESTED_COLLECTION_DATA_TYPE)
+
 		// if the newInnerType is null or a CollectionDataType, this synchronizes the corresponding element's type to null
 		val umlType = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
 		for (umlParameter : umlParameterList) {
@@ -57,7 +59,7 @@ routine changeTypeOfCorrespondingPropertyOrParameter(pcm::CollectionDataType pcm
 		}
 		for (umlProperty : umlPropertyList) {
 			umlProperty.type = umlType
-	}
+		}
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
@@ -32,9 +32,9 @@ routine insertCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pc
 
 routine detectOrCreateCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
-		val umlCompositeClass = retrieve optional uml::Class corresponding to pcmType tagged with TagLiterals.
+		val umlCompositeClass = retrieve optional uml::Class corresponding to pcmType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -53,9 +53,9 @@ routine detectOrCreateCorrespondingCompositeTypeClass(pcm::CompositeDataType pcm
 
 routine addCorrespondenceForExistingCompositeTypeClass(pcm::CompositeDataType pcmType, uml::Class umlCompositeClass) {
 	match {
-		require absence of pcm::CompositeDataType corresponding to umlCompositeClass tagged with TagLiterals.
+		require absence of pcm::CompositeDataType corresponding to umlCompositeClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		require absence of uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		require absence of uml::Class corresponding to pcmType tagged TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		addCorrespondenceBetween(pcmType, umlCompositeClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
@@ -64,9 +64,9 @@ routine addCorrespondenceForExistingCompositeTypeClass(pcm::CompositeDataType pc
 
 routine createCorrespondingCompositetypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
-		require absence of uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		require absence of uml::Class corresponding to pcmType tagged TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	create {
 		val umlCompositeClass = new uml::Class
@@ -79,9 +79,9 @@ routine createCorrespondingCompositetypeClass(pcm::CompositeDataType pcmType, pc
 
 routine moveCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -97,9 +97,9 @@ reaction CompositeDataTypeRemovedFromRepository {
 
 routine removeCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -114,7 +114,7 @@ reaction CompositeDataTypeDeleted {
 
 routine deleteCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType) {
 	match {
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -131,7 +131,7 @@ reaction CompositeDataTypeNameChanged {
 
 routine changeNameOfCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, String newName) {
 	match {
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -147,9 +147,9 @@ reaction CompositeDataTypeParentAdded {
 
 routine addParentTypeToCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::CompositeDataType pcmParentType) {
 	match {
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged with TagLiterals.
+		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 		check {
 			!umlCompositeClass.generalizations.exists[it.general === umlParentCompositeClass]
@@ -172,9 +172,9 @@ reaction CompositeDataTypeParentRemoved {
 
 routine removeParentTypeFromCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::CompositeDataType pcmParentType) {
 	match {
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged with TagLiterals.
+		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmCompositeDataType.reactions
@@ -1,7 +1,7 @@
 import org.eclipse.uml2.uml.Class
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::CompositeDataType in a pcm::Repository
@@ -13,7 +13,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		UmlCompositeDataTypeClass.reactions, UmlCompositeDataTypeGeneralization.reactions
 //		CompositeDataTypeConceptTest
-
 reactions: pcmCompositeDataTypeReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -33,13 +32,16 @@ routine insertCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pc
 
 routine detectOrCreateCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
-		val umlCompositeClass = retrieve optional uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
+		val umlCompositeClass = retrieve optional uml::Class corresponding to pcmType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		if (!umlCompositeClass.isPresent) {
-			val umlCompositeCandidate = umlDatatypesPackage.packagedElements
-				.filter(Class).findFirst[it.name == pcmType.entityName]
+			val umlCompositeCandidate = umlDatatypesPackage.packagedElements.filter(Class).findFirst [
+				it.name == pcmType.entityName
+			]
 			if (umlCompositeCandidate !== null) {
 				addCorrespondenceForExistingCompositeTypeClass(pcmType, umlCompositeCandidate)
 			} else {
@@ -51,7 +53,8 @@ routine detectOrCreateCorrespondingCompositeTypeClass(pcm::CompositeDataType pcm
 
 routine addCorrespondenceForExistingCompositeTypeClass(pcm::CompositeDataType pcmType, uml::Class umlCompositeClass) {
 	match {
-		require absence of pcm::CompositeDataType corresponding to umlCompositeClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		require absence of pcm::CompositeDataType corresponding to umlCompositeClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 		require absence of uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -61,22 +64,25 @@ routine addCorrespondenceForExistingCompositeTypeClass(pcm::CompositeDataType pc
 
 routine createCorrespondingCompositetypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
 		require absence of uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	create {
 		val umlCompositeClass = new uml::Class
 	}
 	update {
-		umlCompositeClass.name = pcmType.entityName	
-		addCorrespondenceBetween(pcmType, umlCompositeClass, TagLiterals.COMPOSITE_DATATYPE__CLASS) 
+		umlCompositeClass.name = pcmType.entityName
+		addCorrespondenceBetween(pcmType, umlCompositeClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
 	}
 }
 
 routine moveCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		umlDatatypesPackage.packagedElements += umlCompositeClass
@@ -91,8 +97,10 @@ reaction CompositeDataTypeRemovedFromRepository {
 
 routine removeCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlDatatypesPackage = retrieve uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		umlDatatypesPackage.packagedElements -= umlCompositeClass
@@ -106,7 +114,8 @@ reaction CompositeDataTypeDeleted {
 
 routine deleteCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType) {
 	match {
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		removeObject(umlCompositeClass)
@@ -122,7 +131,8 @@ reaction CompositeDataTypeNameChanged {
 
 routine changeNameOfCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, String newName) {
 	match {
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		umlCompositeClass.name = newName
@@ -137,9 +147,13 @@ reaction CompositeDataTypeParentAdded {
 
 routine addParentTypeToCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::CompositeDataType pcmParentType) {
 	match {
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		check {!umlCompositeClass.generalizations.exists[it.general === umlParentCompositeClass]}
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		check {
+			!umlCompositeClass.generalizations.exists[it.general === umlParentCompositeClass]
+		}
 	}
 	create {
 		val generalization = new uml::Generalization
@@ -158,8 +172,10 @@ reaction CompositeDataTypeParentRemoved {
 
 routine removeParentTypeFromCorrespondingCompositeTypeClass(pcm::CompositeDataType pcmType, pcm::CompositeDataType pcmParentType) {
 	match {
-		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlCompositeClass = retrieve uml::Class corresponding to pcmType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val umlParentCompositeClass = retrieve uml::Class corresponding to pcmParentType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		val generalization = umlCompositeClass.generalizations.findFirst[it.general == umlParentCompositeClass]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmDataTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmDataTypePropagation.reactions
@@ -52,8 +52,8 @@ routine setTypeOfUmlParameterOrProperty(pcm::DataType pcmType, uml::TypedElement
 
 routine setTypeOfUmlParameterOrProperty_NonCollection(pcm::DataType pcmType, uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, String tag) { // same element; Parameter or Property
 	match {
-		val umlPrimitiveType = retrieve many uml::Type corresponding to pcmType tagged with TagLiterals.DATATYPE__TYPE
-		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType tagged with TagLiterals.
+		val umlPrimitiveType = retrieve many uml::Type corresponding to pcmType tagged TagLiterals.DATATYPE__TYPE
+		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -67,9 +67,9 @@ routine setTypeOfUmlParameterOrProperty_NonCollection(pcm::DataType pcmType, uml
 routine setTypeOfUmlParameterOrProperty_Collection(pcm::CollectionDataType pcmType, uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, String tag) { // same element; Parameter or Property
 	match {
 		val umlPrimitiveType = retrieve many uml::Type corresponding to pcmType.
-			innerType_CollectionDataType tagged with TagLiterals.DATATYPE__TYPE
+			innerType_CollectionDataType tagged TagLiterals.DATATYPE__TYPE
 		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType.
-			innerType_CollectionDataType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+			innerType_CollectionDataType tagged TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		umlElement.type = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
@@ -82,7 +82,7 @@ routine setTypeOfUmlParameterOrProperty_Collection(pcm::CollectionDataType pcmTy
 
 routine removeOldCollectionDataTypeCorrespondence(uml::TypedElement umlElement, String tag) { // Parameter or Property
 	match {
-		val oldCollectionType = retrieve pcm::CollectionDataType corresponding to umlElement tagged with tag
+		val oldCollectionType = retrieve pcm::CollectionDataType corresponding to umlElement tagged tag
 	}
 	update {
 		removeCorrespondenceBetween(oldCollectionType, umlElement, tag)
@@ -91,7 +91,7 @@ routine removeOldCollectionDataTypeCorrespondence(uml::TypedElement umlElement, 
 
 routine addCollectionDataTypeCorrespondence(pcm::CollectionDataType pcmType, uml::TypedElement umlElement, String tag) { // Parameter or Property
 	match {
-		require absence of pcm::CollectionDataType corresponding to umlElement tagged with tag
+		require absence of pcm::CollectionDataType corresponding to umlElement tagged tag
 	}
 	update {
 		addCorrespondenceBetween(pcmType, umlElement, tag)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmDataTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmDataTypePropagation.reactions
@@ -4,7 +4,7 @@ import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.change.interaction.UserInteractionOptions.NotificationType
 import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following routines define how a pcm::DataType change is propagated to the relevant uml::Parameter or uml::Property.
@@ -16,41 +16,32 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmSignature.reactions,
 //		PcmInnerDeclaration.reactions,
 //		PcmParameter.reactions
-
 reactions: pcmDataTypePropagationReactions
 in reaction to changes in pcm
 execute actions in uml
 
-routine setUmlParameterType(
-		pcm::DataType pcmType, 
-		uml::Parameter umlParameter) {
+routine setUmlParameterType(pcm::DataType pcmType, uml::Parameter umlParameter) {
 	update {
 		setTypeOfUmlParameterOrProperty(pcmType, umlParameter, umlParameter, TagLiterals.COLLECTION_DATATYPE__PARAMETER)
 	}
 }
 
-routine setUmlPropertyType(
-		pcm::DataType pcmType, 
-		uml::Property umlProperty) {
+routine setUmlPropertyType(pcm::DataType pcmType, uml::Property umlProperty) {
 	update {
 		setTypeOfUmlParameterOrProperty(pcmType, umlProperty, umlProperty, TagLiterals.COLLECTION_DATATYPE__PROPERTY)
 	}
 }
 
-
 // ******** general variants to reduce code duplication. If possible please use the facade routines above
-
-routine setTypeOfUmlParameterOrProperty(
-		pcm::DataType pcmType, 
-		uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, // same element; Parameter or Property
-		String tag) {
+routine setTypeOfUmlParameterOrProperty(pcm::DataType pcmType, uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, String tag) { // same element; Parameter or Property
 	update {
-		if(umlElement !== umlMultiplicity) {
-			throw new IllegalStateException("uml::TypedElement umlElement, uml::MultiplicityElement uMultiplicity"
-				+ "have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
+		if (umlElement !== umlMultiplicity) {
+			throw new IllegalStateException(
+				"uml::TypedElement umlElement, uml::MultiplicityElement uMultiplicity" +
+					"have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
 			)
 		}
-		
+
 		if (pcmType !== null && pcmType instanceof CollectionDataType) {
 			setTypeOfUmlParameterOrProperty_Collection(pcmType as CollectionDataType, umlElement, umlMultiplicity, tag)
 		} else {
@@ -59,13 +50,11 @@ routine setTypeOfUmlParameterOrProperty(
 	}
 }
 
-routine setTypeOfUmlParameterOrProperty_NonCollection(
-		pcm::DataType pcmType, 
-		uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, // same element; Parameter or Property
-		String tag) {
+routine setTypeOfUmlParameterOrProperty_NonCollection(pcm::DataType pcmType, uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, String tag) { // same element; Parameter or Property
 	match {
 		val umlPrimitiveType = retrieve many uml::Type corresponding to pcmType tagged with TagLiterals.DATATYPE__TYPE
-		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		umlElement.type = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
@@ -75,13 +64,12 @@ routine setTypeOfUmlParameterOrProperty_NonCollection(
 	}
 }
 
-routine setTypeOfUmlParameterOrProperty_Collection(
-		pcm::CollectionDataType pcmType, 
-		uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, // same element; Parameter or Property
-		String tag) {
+routine setTypeOfUmlParameterOrProperty_Collection(pcm::CollectionDataType pcmType, uml::TypedElement umlElement, uml::MultiplicityElement umlMultiplicity, String tag) { // same element; Parameter or Property
 	match {
-		val umlPrimitiveType = retrieve many uml::Type corresponding to pcmType.innerType_CollectionDataType tagged with TagLiterals.DATATYPE__TYPE
-		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType.innerType_CollectionDataType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val umlPrimitiveType = retrieve many uml::Type corresponding to pcmType.
+			innerType_CollectionDataType tagged with TagLiterals.DATATYPE__TYPE
+		val umlCompositeType = retrieve optional uml::Type corresponding to pcmType.
+			innerType_CollectionDataType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		umlElement.type = umlPrimitiveType.head ?: umlCompositeType.orElse(null)
@@ -92,10 +80,7 @@ routine setTypeOfUmlParameterOrProperty_Collection(
 	}
 }
 
-
-routine removeOldCollectionDataTypeCorrespondence(
-		uml::TypedElement umlElement, // Parameter or Property
-		String tag) {
+routine removeOldCollectionDataTypeCorrespondence(uml::TypedElement umlElement, String tag) { // Parameter or Property
 	match {
 		val oldCollectionType = retrieve pcm::CollectionDataType corresponding to umlElement tagged with tag
 	}
@@ -104,10 +89,7 @@ routine removeOldCollectionDataTypeCorrespondence(
 	}
 }
 
-routine addCollectionDataTypeCorrespondence(
-		pcm::CollectionDataType pcmType, 
-		uml::TypedElement umlElement, // Parameter or Property
-		String tag) {
+routine addCollectionDataTypeCorrespondence(pcm::CollectionDataType pcmType, uml::TypedElement umlElement, String tag) { // Parameter or Property
 	match {
 		require absence of pcm::CollectionDataType corresponding to umlElement tagged with tag
 	}
@@ -119,33 +101,31 @@ routine addCollectionDataTypeCorrespondence(
 // UNSUPPORTED WARNING - unsupported/unmapped PrimitiveType has been set warning
 reaction UnsupportedPrimitiveTypeSetAtInnerDeclaration {
 	after element pcm::PrimitiveDataType replaced at pcm::InnerDeclaration[datatype_InnerDeclaration]
-	with affectedEObject.datatype_InnerDeclaration === newValue
-		&& !PcmDataTypeUtil.isSupportedPcmPrimitiveType(newValue) 
+	with affectedEObject.datatype_InnerDeclaration === newValue &&
+		!PcmDataTypeUtil.isSupportedPcmPrimitiveType(newValue)
 	call unsupportedPrimitiveTypeSetWarning(newValue, affectedEObject)
 }
 
 reaction UnsupportedPrimitiveTypeSetAtParameter {
 	after element pcm::PrimitiveDataType replaced at pcm::Parameter[dataType__Parameter]
-	with affectedEObject.dataType__Parameter === newValue
-		&& !PcmDataTypeUtil.isSupportedPcmPrimitiveType(newValue) 
+	with affectedEObject.dataType__Parameter === newValue && !PcmDataTypeUtil.isSupportedPcmPrimitiveType(newValue)
 	call unsupportedPrimitiveTypeSetWarning(newValue, affectedEObject)
 }
 
 reaction UnsupportedPrimitiveTypeSetAtSignature {
 	after element pcm::PrimitiveDataType replaced at pcm::OperationSignature[returnType__OperationSignature]
-	with affectedEObject.returnType__OperationSignature === newValue
-		&& !PcmDataTypeUtil.isSupportedPcmPrimitiveType(newValue) 
+	with affectedEObject.returnType__OperationSignature === newValue &&
+		!PcmDataTypeUtil.isSupportedPcmPrimitiveType(newValue)
 	call unsupportedPrimitiveTypeSetWarning(newValue, affectedEObject)
 }
 
 routine unsupportedPrimitiveTypeSetWarning(pcm::PrimitiveDataType primitive, EObject entity) {
 	update {
-		userInteractor.notificationDialogBuilder
-			.message("The pcm::PrimitiveDataType " + primitive + " set at the pcm element " + entity 
-				+ " has no good match in the predefined set of uml::PrimitiveTypes "
-				+ " used by these transformations, is therefore not supported.")
-			.notificationType(NotificationType.WARNING)
-			.startInteraction
+		userInteractor.notificationDialogBuilder.message(
+			"The pcm::PrimitiveDataType " + primitive + " set at the pcm element " + entity +
+				" has no good match in the predefined set of uml::PrimitiveTypes " +
+				" used by these transformations, is therefore not supported.").notificationType(
+			NotificationType.WARNING).startInteraction
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
@@ -1,6 +1,6 @@
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::InnerDeclaration with its corresponding uml::Property.
@@ -9,11 +9,10 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmDataTypePropagation.reactions,
 //		UmlInnerDeclarationProperty.reactions
 //		AttributeConceptTest
-
 reactions: pcmInnerDeclarationReactions
 in reaction to changes in pcm
 execute actions in uml
- 
+
 import routines pcmDataTypePropagationReactions using qualified names
 
 reaction InnerDeclarationInserted {
@@ -30,9 +29,11 @@ routine insertCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::Co
 }
 
 routine detectOrCreateCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
-	match{
-		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val umlAttribute = retrieve optional uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+	match {
+		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val umlAttribute = retrieve optional uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		if (!umlAttribute.isPresent) {
@@ -48,8 +49,10 @@ routine detectOrCreateCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute,
 
 routine addCorrespondenceForExistingAttribute(pcm::InnerDeclaration pcmAttribute, uml::Property umlAttribute) {
 	match {
-		require absence of uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
-		require absence of pcm::InnerDeclaration corresponding to umlAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		require absence of uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
+		require absence of pcm::InnerDeclaration corresponding to umlAttribute tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		addCorrespondenceBetween(pcmAttribute, umlAttribute, TagLiterals.INNER_DECLARATION__PROPERTY)
@@ -58,8 +61,10 @@ routine addCorrespondenceForExistingAttribute(pcm::InnerDeclaration pcmAttribute
 
 routine createCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
 	match {
-		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		require absence of uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		require absence of uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	create {
 		val umlAttribute = new uml::Property
@@ -73,8 +78,10 @@ routine createCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::Co
 
 routine moveCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
 	match {
-		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		umlComposite.ownedAttributes += umlAttribute
@@ -89,8 +96,10 @@ reaction InnerDeclarationRemoved {
 
 routine removeCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
 	match {
-		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		umlComposite.ownedAttributes -= umlAttribute
@@ -104,7 +113,8 @@ reaction InnerDeclarationDeleted {
 
 routine deleteCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute) {
 	match {
-		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		removeObject(umlAttribute)
@@ -120,7 +130,8 @@ reaction InnerDeclarationNameChanged {
 
 routine changeNameOfCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, String newName) {
 	match {
-		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		umlAttribute.name = newName
@@ -129,14 +140,14 @@ routine changeNameOfCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, S
 
 reaction InnerDeclarationTypeChanged {
 	after element pcm::DataType replaced at pcm::InnerDeclaration[datatype_InnerDeclaration]
-	with affectedEObject.datatype_InnerDeclaration === newValue 
-		&& newValue != oldValue
+	with affectedEObject.datatype_InnerDeclaration === newValue && newValue != oldValue
 	call changeTypeOfCorrespondingAttribute(affectedEObject, newValue)
 }
 
 routine changeTypeOfCorrespondingAttribute(pcm::InnerDeclaration pcmInnerDeclaration, pcm::DataType pcmDataType) {
 	match {
-		val umlProperty = retrieve uml::Property corresponding to pcmInnerDeclaration tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val umlProperty = retrieve uml::Property corresponding to pcmInnerDeclaration tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		pcmDataTypePropagationReactions.setUmlPropertyType(pcmDataType, umlProperty)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
@@ -30,9 +30,9 @@ routine insertCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::Co
 
 routine detectOrCreateCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
 	match {
-		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val umlAttribute = retrieve optional uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+		val umlAttribute = retrieve optional uml::Property corresponding to pcmAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -49,9 +49,9 @@ routine detectOrCreateCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute,
 
 routine addCorrespondenceForExistingAttribute(pcm::InnerDeclaration pcmAttribute, uml::Property umlAttribute) {
 	match {
-		require absence of uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+		require absence of uml::Property corresponding to pcmAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
-		require absence of pcm::InnerDeclaration corresponding to umlAttribute tagged with TagLiterals.
+		require absence of pcm::InnerDeclaration corresponding to umlAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -61,9 +61,9 @@ routine addCorrespondenceForExistingAttribute(pcm::InnerDeclaration pcmAttribute
 
 routine createCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
 	match {
-		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		require absence of uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+		require absence of uml::Property corresponding to pcmAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	create {
@@ -78,9 +78,9 @@ routine createCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::Co
 
 routine moveCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
 	match {
-		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -96,9 +96,9 @@ reaction InnerDeclarationRemoved {
 
 routine removeCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::CompositeDataType pcmComposite) {
 	match {
-		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged with TagLiterals.
+		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -113,7 +113,7 @@ reaction InnerDeclarationDeleted {
 
 routine deleteCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute) {
 	match {
-		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -130,7 +130,7 @@ reaction InnerDeclarationNameChanged {
 
 routine changeNameOfCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, String newName) {
 	match {
-		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged with TagLiterals.
+		val umlAttribute = retrieve uml::Property corresponding to pcmAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -146,7 +146,7 @@ reaction InnerDeclarationTypeChanged {
 
 routine changeTypeOfCorrespondingAttribute(pcm::InnerDeclaration pcmInnerDeclaration, pcm::DataType pcmDataType) {
 	match {
-		val umlProperty = retrieve uml::Property corresponding to pcmInnerDeclaration tagged with TagLiterals.
+		val umlProperty = retrieve uml::Property corresponding to pcmInnerDeclaration tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInnerDeclaration.reactions
@@ -49,8 +49,7 @@ routine detectOrCreateCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute,
 
 routine addCorrespondenceForExistingAttribute(pcm::InnerDeclaration pcmAttribute, uml::Property umlAttribute) {
 	match {
-		require absence of uml::Property corresponding to pcmAttribute tagged TagLiterals.
-			INNER_DECLARATION__PROPERTY
+		require absence of uml::Property corresponding to pcmAttribute tagged TagLiterals.INNER_DECLARATION__PROPERTY
 		require absence of pcm::InnerDeclaration corresponding to umlAttribute tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
@@ -63,8 +62,7 @@ routine createCorrespondingAttribute(pcm::InnerDeclaration pcmAttribute, pcm::Co
 	match {
 		val umlComposite = retrieve uml::Class corresponding to pcmComposite tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		require absence of uml::Property corresponding to pcmAttribute tagged TagLiterals.
-			INNER_DECLARATION__PROPERTY
+		require absence of uml::Property corresponding to pcmAttribute tagged TagLiterals.INNER_DECLARATION__PROPERTY
 	}
 	create {
 		val umlAttribute = new uml::Property

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
@@ -1,7 +1,7 @@
 import org.eclipse.uml2.uml.Interface
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationInterface
@@ -11,7 +11,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmInterface.reactions
 //		UmlInterface.reactions, UmlInterfaceGeneralization.reactions
 //		InterfaceConceptTest
-
 reactions: pcmInterfaceReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -31,14 +30,19 @@ routine insertCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::
 
 routine detectOrCreateInterfaceCandidate(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
 	match {
-		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
+		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		if (!umlInterface.isPresent) {
-			val umlInterfaceCandidate = umlContractsPackage.packagedElements.filter(Interface).findFirst[it.name == pcmInterface.entityName]
+			val umlInterfaceCandidate = umlContractsPackage.packagedElements.filter(Interface).findFirst [
+				it.name == pcmInterface.entityName
+			]
 			if (umlInterfaceCandidate !== null) {
-				attemptAddingCorrespondenceForExistingInterfaceCandidate(pcmInterface, pcmRepository, umlInterfaceCandidate)
+				attemptAddingCorrespondenceForExistingInterfaceCandidate(pcmInterface, pcmRepository,
+					umlInterfaceCandidate)
 			} else {
 				createInterfaceCorrespondence(pcmInterface, pcmRepository)
 			}
@@ -46,23 +50,21 @@ routine detectOrCreateInterfaceCandidate(pcm::OperationInterface pcmInterface, p
 	}
 }
 
-routine attemptAddingCorrespondenceForExistingInterfaceCandidate(
-	pcm::OperationInterface pcmInterface, 
-	pcm::Repository pcmRepository, 
-	uml::Interface umlInterfaceCandidate) {
-	match {  
-		require absence of pcm::OperationInterface corresponding to umlInterfaceCandidate tagged with TagLiterals.INTERFACE_TO_INTERFACE
+routine attemptAddingCorrespondenceForExistingInterfaceCandidate(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository, uml::Interface umlInterfaceCandidate) {
+	match {
+		require absence of pcm::OperationInterface corresponding to umlInterfaceCandidate tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		addCorrespondenceBetween(pcmInterface, umlInterfaceCandidate, TagLiterals.INTERFACE_TO_INTERFACE)
 	}
 }
 
-
 routine createInterfaceCorrespondence(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
 	match {
-		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		require absence of uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
+		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		require absence of uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	create {
 		val umlInterface = new uml::Interface
@@ -75,16 +77,17 @@ routine createInterfaceCorrespondence(pcm::OperationInterface pcmInterface, pcm:
 
 routine moveCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
 	match {
-		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
+		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		umlContractsPackage.packagedElements += umlInterface
 	}
 }
 
-
-reaction InterfaceRemovedFromRepository{
+reaction InterfaceRemovedFromRepository {
 	after element pcm::OperationInterface removed from pcm::Repository[interfaces__Repository]
 	with !affectedEObject.interfaces__Repository.contains(oldValue)
 	call removeCorrespondingInterface(oldValue, affectedEObject)
@@ -92,22 +95,25 @@ reaction InterfaceRemovedFromRepository{
 
 routine removeCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
 	match {
-		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
+		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		umlContractsPackage.packagedElements -= umlInterface
 	}
 }
 
-reaction InterfaceDeleted{
+reaction InterfaceDeleted {
 	after element pcm::OperationInterface deleted
 	call deleteCorrespondingInterface(affectedEObject)
 }
 
 routine deleteCorrespondingInterface(pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		removeObject(umlInterface)
@@ -123,7 +129,8 @@ reaction InterfaceRenamed {
 
 routine renameCorrespondingInterface(pcm::OperationInterface pcmInterface, String newName) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		umlInterface.name = newName
@@ -138,8 +145,10 @@ reaction ParentInterfaceAdded {
 
 routine addParentInterfaceToCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::OperationInterface pcmParentInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE 
-		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	create {
 		val generalization = new uml::Generalization
@@ -158,8 +167,10 @@ reaction ParentInterfaceRemoved {
 
 routine removeParentInterfaceFromCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::OperationInterface pcmParentInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE 
-		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE  
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		umlInterface.generalizations.findFirst[it.general === umlParentInterface]?.destroy

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmInterface.reactions
@@ -30,9 +30,9 @@ routine insertCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::
 
 routine detectOrCreateInterfaceCandidate(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
 	match {
-		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -52,7 +52,7 @@ routine detectOrCreateInterfaceCandidate(pcm::OperationInterface pcmInterface, p
 
 routine attemptAddingCorrespondenceForExistingInterfaceCandidate(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository, uml::Interface umlInterfaceCandidate) {
 	match {
-		require absence of pcm::OperationInterface corresponding to umlInterfaceCandidate tagged with TagLiterals.
+		require absence of pcm::OperationInterface corresponding to umlInterfaceCandidate tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -62,9 +62,9 @@ routine attemptAddingCorrespondenceForExistingInterfaceCandidate(pcm::OperationI
 
 routine createInterfaceCorrespondence(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
 	match {
-		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		require absence of uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of uml::Interface corresponding to pcmInterface tagged TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	create {
 		val umlInterface = new uml::Interface
@@ -77,9 +77,9 @@ routine createInterfaceCorrespondence(pcm::OperationInterface pcmInterface, pcm:
 
 routine moveCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
 	match {
-		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -95,9 +95,9 @@ reaction InterfaceRemovedFromRepository {
 
 routine removeCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::Repository pcmRepository) {
 	match {
-		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+		val umlContractsPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -112,7 +112,7 @@ reaction InterfaceDeleted {
 
 routine deleteCorrespondingInterface(pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -129,7 +129,7 @@ reaction InterfaceRenamed {
 
 routine renameCorrespondingInterface(pcm::OperationInterface pcmInterface, String newName) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -145,9 +145,9 @@ reaction ParentInterfaceAdded {
 
 routine addParentInterfaceToCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::OperationInterface pcmParentInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged with TagLiterals.
+		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	create {
@@ -167,9 +167,9 @@ reaction ParentInterfaceRemoved {
 
 routine removeParentInterfaceFromCorrespondingInterface(pcm::OperationInterface pcmInterface, pcm::OperationInterface pcmParentInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged with TagLiterals.
+		val umlParentInterface = retrieve uml::Interface corresponding to pcmParentInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
@@ -33,8 +33,7 @@ routine insertCorrespondingRegularParameter(pcm::Parameter pcmParameter, pcm::Op
 
 routine detectOrCreateRegularParameterCandidate(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 		val umlParam = retrieve optional uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
@@ -62,8 +61,7 @@ routine addCorrespondenceForExistingRegularParameter(pcm::Parameter pcmParam, um
 
 routine createCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 		require absence of uml::Parameter corresponding to pcmParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	create {
@@ -97,8 +95,7 @@ reaction ParameterRemovedFromSignature {
 
 routine removeCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
@@ -131,8 +128,7 @@ reaction ParameterRenamed {
 
 routine renameCorrespondingRegularParameter(pcm::Parameter pcmParam, String newName) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		umlParam.name = newName
@@ -148,8 +144,7 @@ reaction ParameterModifierChanged {
 // pcm::ParameterModifier import can't be resolved for some reason -> retrieve from element
 routine changeDirectionOfCorrespondingRegularParameter(pcm::Parameter pcmParam) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		umlParam.direction = PcmUmlClassHelper.getMatchingParameterDirection(pcmParam.modifier__Parameter)
@@ -164,8 +159,7 @@ reaction ParameterTypeChanged {
 
 routine changeTypeOfCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::DataType pcmDataType) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		pcmDataTypePropagationReactions.setUmlParameterType(pcmDataType, umlParam)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
@@ -1,7 +1,7 @@
 import tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::Parameter in an pcm::OperationSignature (regular Parameter)
@@ -11,11 +11,10 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmDataTypePropagation.reactions,
 //		UmlRegularParameter.reactions, UmlReturnAndRegularParameterType.reactions
 //		ParameterConceptTest
-
 reactions: pcmParameterReactions
 in reaction to changes in pcm
 execute actions in uml
-  
+
 import routines pcmDataTypePropagationReactions using qualified names
 
 reaction ParameterInsertedInSignature {
@@ -28,14 +27,16 @@ routine insertCorrespondingRegularParameter(pcm::Parameter pcmParameter, pcm::Op
 	update {
 		detectOrCreateRegularParameterCandidate(pcmParameter, pcmSignature)
 		moveCorrespondingRegularParameter(pcmParameter, pcmSignature)
-		
+
 	}
 }
 
 routine detectOrCreateRegularParameterCandidate(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		val umlParam = retrieve optional uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		val umlParam = retrieve optional uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		if (!umlParam.isPresent) {
@@ -61,7 +62,8 @@ routine addCorrespondenceForExistingRegularParameter(pcm::Parameter pcmParam, um
 
 routine createCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
 		require absence of uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	create {
@@ -77,8 +79,10 @@ routine createCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::Operat
 
 routine moveCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		val umlParameter = retrieve asserted uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		val umlParameter = retrieve asserted uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		umlOperation.ownedParameters += umlParameter
@@ -93,8 +97,10 @@ reaction ParameterRemovedFromSignature {
 
 routine removeCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		umlOperation.ownedParameters -= umlParameter
@@ -108,7 +114,8 @@ reaction ParameterDeletedFromSignature {
 
 routine deleteCorrespondingRegularParameter(pcm::Parameter pcmParam) {
 	match {
-		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		removeObject(umlParameter)
@@ -124,7 +131,8 @@ reaction ParameterRenamed {
 
 routine renameCorrespondingRegularParameter(pcm::Parameter pcmParam, String newName) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		umlParam.name = newName
@@ -140,7 +148,8 @@ reaction ParameterModifierChanged {
 // pcm::ParameterModifier import can't be resolved for some reason -> retrieve from element
 routine changeDirectionOfCorrespondingRegularParameter(pcm::Parameter pcmParam) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		umlParam.direction = PcmUmlClassHelper.getMatchingParameterDirection(pcmParam.modifier__Parameter)
@@ -155,7 +164,8 @@ reaction ParameterTypeChanged {
 
 routine changeTypeOfCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::DataType pcmDataType) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		pcmDataTypePropagationReactions.setUmlParameterType(pcmDataType, umlParam)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmParameter.reactions
@@ -33,9 +33,9 @@ routine insertCorrespondingRegularParameter(pcm::Parameter pcmParameter, pcm::Op
 
 routine detectOrCreateRegularParameterCandidate(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		val umlParam = retrieve optional uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+		val umlParam = retrieve optional uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -52,8 +52,8 @@ routine detectOrCreateRegularParameterCandidate(pcm::Parameter pcmParam, pcm::Op
 
 routine addCorrespondenceForExistingRegularParameter(pcm::Parameter pcmParam, uml::Parameter umlParam) {
 	match {
-		require absence of uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
-		require absence of pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		require absence of uml::Parameter corresponding to pcmParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
+		require absence of pcm::Parameter corresponding to umlParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		addCorrespondenceBetween(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER)
@@ -62,9 +62,9 @@ routine addCorrespondenceForExistingRegularParameter(pcm::Parameter pcmParam, um
 
 routine createCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of uml::Parameter corresponding to pcmParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		require absence of uml::Parameter corresponding to pcmParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	create {
 		val umlParam = new uml::Parameter
@@ -79,9 +79,9 @@ routine createCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::Operat
 
 routine moveCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		val umlParameter = retrieve asserted uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+		val umlParameter = retrieve asserted uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -97,9 +97,9 @@ reaction ParameterRemovedFromSignature {
 
 routine removeCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -114,7 +114,7 @@ reaction ParameterDeletedFromSignature {
 
 routine deleteCorrespondingRegularParameter(pcm::Parameter pcmParam) {
 	match {
-		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+		val umlParameter = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -131,7 +131,7 @@ reaction ParameterRenamed {
 
 routine renameCorrespondingRegularParameter(pcm::Parameter pcmParam, String newName) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -148,7 +148,7 @@ reaction ParameterModifierChanged {
 // pcm::ParameterModifier import can't be resolved for some reason -> retrieve from element
 routine changeDirectionOfCorrespondingRegularParameter(pcm::Parameter pcmParam) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -164,7 +164,7 @@ reaction ParameterTypeChanged {
 
 routine changeTypeOfCorrespondingRegularParameter(pcm::Parameter pcmParam, pcm::DataType pcmDataType) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged with TagLiterals.
+		val umlParam = retrieve uml::Parameter corresponding to pcmParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
@@ -28,10 +28,10 @@ routine insertCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 
 routine detectOrCreateCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged TagLiterals.IPRE__IMPLEMENTATION
 		val umlInterface = retrieve uml::Interface corresponding to pcmProvided.
-			providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			providedInterface__OperationProvidedRole tagged TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -48,9 +48,9 @@ routine detectOrCreateCorrespondingProvidedRealization(pcm::OperationProvidedRol
 
 routine addCorrespondenceForExistingRealization(pcm::OperationProvidedRole pcmProvided, uml::InterfaceRealization umlRealization) {
 	match {
-		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
-		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -60,11 +60,11 @@ routine addCorrespondenceForExistingRealization(pcm::OperationProvidedRole pcmPr
 
 routine createCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged TagLiterals.IPRE__IMPLEMENTATION
+		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 		val umlInterface = retrieve optional uml::Interface corresponding to pcmProvided.
-			providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
+			providedInterface__OperationProvidedRole tagged TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	create {
 		val umlRealization = new uml::InterfaceRealization
@@ -79,8 +79,8 @@ routine createCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 
 routine moveCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged TagLiterals.IPRE__IMPLEMENTATION
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -96,8 +96,8 @@ reaction ProvidedRoleRemoved {
 
 routine removeCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged TagLiterals.IPRE__IMPLEMENTATION
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -113,7 +113,7 @@ reaction ProvidedRoleDeleted {
 
 routine deleteCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided) {
 	match {
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -130,7 +130,7 @@ reaction ProvidedRoleNameChanged {
 
 routine changeNameOfCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, String newName) {
 	match {
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -146,9 +146,9 @@ reaction ProvidedRoleInterfaceChanged {
 
 routine changeInterfaceOfCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
-		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmProvidedRole.reactions
@@ -1,6 +1,6 @@
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationProvidedRole in an pcm::InterfaceProvidingRequiringEntity (IPRE)
@@ -9,7 +9,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		UmlProvidedRoleRealization.reactions,
 //		ProvidedRoleTest
-
 reactions: pcmProvidedRoleReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -30,11 +29,15 @@ routine insertCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 routine detectOrCreateCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlInterface = retrieve uml::Interface corresponding to pcmProvided.providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE 
-	    require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val umlInterface = retrieve uml::Interface corresponding to pcmProvided.
+			providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
-		var umlRealizationCandidate = umlComponentImpl.interfaceRealizations.findFirst[it.name == pcmProvided.entityName && it.contract === umlInterface]
+		var umlRealizationCandidate = umlComponentImpl.interfaceRealizations.findFirst [
+			it.name == pcmProvided.entityName && it.contract === umlInterface
+		]
 		if (umlRealizationCandidate !== null) {
 			addCorrespondenceForExistingRealization(pcmProvided, umlRealizationCandidate)
 		} else {
@@ -45,8 +48,10 @@ routine detectOrCreateCorrespondingProvidedRealization(pcm::OperationProvidedRol
 
 routine addCorrespondenceForExistingRealization(pcm::OperationProvidedRole pcmProvided, uml::InterfaceRealization umlRealization) {
 	match {
-		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
-		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION 
+		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		addCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
@@ -56,9 +61,10 @@ routine addCorrespondenceForExistingRealization(pcm::OperationProvidedRole pcmPr
 routine createCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
-		val umlInterface = retrieve optional uml::Interface 
-			corresponding to pcmProvided.providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE 
+		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
+		val umlInterface = retrieve optional uml::Interface corresponding to pcmProvided.
+			providedInterface__OperationProvidedRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	create {
 		val umlRealization = new uml::InterfaceRealization
@@ -74,7 +80,8 @@ routine createCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmPro
 routine moveCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION 
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		umlComponentImpl.interfaceRealizations += umlRealization
@@ -90,7 +97,8 @@ reaction ProvidedRoleRemoved {
 routine removeCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		umlComponentImpl.interfaceRealizations -= umlRealization
@@ -105,7 +113,8 @@ reaction ProvidedRoleDeleted {
 
 routine deleteCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided) {
 	match {
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		removeObject(umlRealization)
@@ -121,7 +130,8 @@ reaction ProvidedRoleNameChanged {
 
 routine changeNameOfCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, String newName) {
 	match {
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		umlRealization.name = newName
@@ -136,9 +146,10 @@ reaction ProvidedRoleInterfaceChanged {
 
 routine changeInterfaceOfCorrespondingProvidedRealization(pcm::OperationProvidedRole pcmProvided, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
-		val umlInterface = retrieve optional uml::Interface 
-			corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE 
+		val umlRealization = retrieve uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
+		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		umlRealization.contract = umlInterface.orElse(null)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -47,7 +47,7 @@ routine addRepositoryCorrespondence(pcm::Repository pcmRepository) {
 routine createOrFindUmlRepositoryPackage(pcm::Repository pcmRepo) {
 	match {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		require absence of uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
@@ -82,9 +82,9 @@ routine createUmlRepositoryPackage(pcm::Repository pcmRepo) {
 
 routine createUmlContractsPackage(pcm::Repository pcmRepo) {
 	match {
-		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
+		require absence of uml::Package corresponding to pcmRepo tagged TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 	}
 	update {
 		// look for candidate before creating a new Package
@@ -100,9 +100,9 @@ routine createUmlContractsPackage(pcm::Repository pcmRepo) {
 
 routine createUmlDatatypesPackage(pcm::Repository pcmRepo) {
 	match {
-		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		require absence of uml::Package corresponding to pcmRepo tagged TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
 		// look for candidate before creating a new Package
@@ -124,7 +124,7 @@ reaction RepositoryNameChanged {
 
 routine changeNameOfCorrespondingRepositoryPackage(pcm::Repository pcmRepo) {
 	match {
-		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
@@ -141,11 +141,11 @@ reaction RepositoryDeleted {
 routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 	match {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-		val umlRepositoryPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlRepositoryPkg = retrieve optional uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val umlContractsPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlContractsPkg = retrieve optional uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		val umlDatatypesPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlDatatypesPkg = retrieve optional uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
@@ -170,7 +170,7 @@ routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 //Primitive Datatypes are bootstraped in
 routine bootstrapPrimitiveDatatypes(pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.
+		val umlDatatypesPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
@@ -187,8 +187,8 @@ routine bootstrapPrimitiveDatatypes(pcm::Repository pcmRepo) {
 
 routine addPrimitiveDatatypeCorrespondence(pcm::PrimitiveDataType pcmPrimitiveType, uml::PrimitiveType umlPrimitiveType) {
 	match {
-	require absence of uml::PrimitiveType corresponding to pcmPrimitiveType tagged with TagLiterals.DATATYPE__TYPE with potentialTarget == umlPrimitiveType
-		require absence of pcm::PrimitiveDataType corresponding to umlPrimitiveType tagged with TagLiterals.DATATYPE__TYPE with potentialTarget == pcmPrimitiveType
+	require absence of uml::PrimitiveType corresponding to pcmPrimitiveType tagged TagLiterals.DATATYPE__TYPE with potentialTarget == umlPrimitiveType
+		require absence of pcm::PrimitiveDataType corresponding to umlPrimitiveType tagged TagLiterals.DATATYPE__TYPE with potentialTarget == pcmPrimitiveType
 }
 	update {
 		addCorrespondenceBetween(pcmPrimitiveType, umlPrimitiveType, TagLiterals.DATATYPE__TYPE)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -47,8 +47,7 @@ routine addRepositoryCorrespondence(pcm::Repository pcmRepository) {
 routine createOrFindUmlRepositoryPackage(pcm::Repository pcmRepo) {
 	match {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-		require absence of uml::Package corresponding to pcmRepo tagged TagLiterals.
-			REPOSITORY_TO_REPOSITORY_PACKAGE
+		require absence of uml::Package corresponding to pcmRepo tagged TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
 		var umlPackage = findUmlPackage(umlModel, pcmRepo.correspondingPackageName)
@@ -187,9 +186,11 @@ routine bootstrapPrimitiveDatatypes(pcm::Repository pcmRepo) {
 
 routine addPrimitiveDatatypeCorrespondence(pcm::PrimitiveDataType pcmPrimitiveType, uml::PrimitiveType umlPrimitiveType) {
 	match {
-	require absence of uml::PrimitiveType corresponding to pcmPrimitiveType tagged TagLiterals.DATATYPE__TYPE with potentialTarget == umlPrimitiveType
-		require absence of pcm::PrimitiveDataType corresponding to umlPrimitiveType tagged TagLiterals.DATATYPE__TYPE with potentialTarget == pcmPrimitiveType
-}
+		require absence of uml::PrimitiveType corresponding to pcmPrimitiveType tagged TagLiterals.
+			DATATYPE__TYPE with potentialTarget == umlPrimitiveType
+		require absence of pcm::PrimitiveDataType corresponding to umlPrimitiveType tagged TagLiterals.
+			DATATYPE__TYPE with potentialTarget == pcmPrimitiveType
+	}
 	update {
 		addCorrespondenceBetween(pcmPrimitiveType, umlPrimitiveType, TagLiterals.DATATYPE__TYPE)
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -5,7 +5,6 @@ import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.util.temporary.uml.UmlTypeUtil
 import tools.vitruv.applications.util.temporary.pcm.PcmDataTypeUtil
 import org.palladiosimulator.pcm.repository.RepositoryPackage
-
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlPackage
 import static extension tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper.isPackageFor
 import static extension tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper.getCorrespondingPackageName
@@ -21,7 +20,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 // Related files:
 // UmlRepositoryAndSystemPackage.reactions
 // RepositoryConceptTest
-
 reactions: pcmRepositoryReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -49,11 +47,12 @@ routine addRepositoryCorrespondence(pcm::Repository pcmRepository) {
 routine createOrFindUmlRepositoryPackage(pcm::Repository pcmRepo) {
 	match {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
 		var umlPackage = findUmlPackage(umlModel, pcmRepo.correspondingPackageName)
-		if(umlPackage === null) {
+		if (umlPackage === null) {
 			createUmlRepositoryPackage(pcmRepo)
 		} else {
 			addPackageCorrespondence(pcmRepo, umlPackage)
@@ -83,26 +82,33 @@ routine createUmlRepositoryPackage(pcm::Repository pcmRepo) {
 
 routine createUmlContractsPackage(pcm::Repository pcmRepo) {
 	match {
-		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
 		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
 	}
 	update {
-		//look for candidate before creating a new Package
-		var umlContractsPkg = umlRepositoryPkg.nestedPackages.findFirst[pkg | pkg.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME]
+		// look for candidate before creating a new Package
+		var umlContractsPkg = umlRepositoryPkg.nestedPackages.findFirst [ pkg |
+			pkg.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME
+		]
 		if (umlContractsPkg === null) {
 			umlContractsPkg = umlRepositoryPkg.createNestedPackage(DefaultLiterals.CONTRACTS_PACKAGE_NAME)
 		}
 		addCorrespondenceBetween(pcmRepo, umlContractsPkg, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)
 	}
 }
+
 routine createUmlDatatypesPackage(pcm::Repository pcmRepo) {
 	match {
-		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
 		require absence of uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
-		//look for candidate before creating a new Package
-		var umlDatatypesPkg = umlRepositoryPkg.nestedPackages.findFirst[pkg | pkg.name == DefaultLiterals.DATATYPES_PACKAGE_NAME]
+		// look for candidate before creating a new Package
+		var umlDatatypesPkg = umlRepositoryPkg.nestedPackages.findFirst [ pkg |
+			pkg.name == DefaultLiterals.DATATYPES_PACKAGE_NAME
+		]
 		if (umlDatatypesPkg === null) {
 			umlDatatypesPkg = umlRepositoryPkg.createNestedPackage(DefaultLiterals.DATATYPES_PACKAGE_NAME)
 		}
@@ -118,7 +124,8 @@ reaction RepositoryNameChanged {
 
 routine changeNameOfCorrespondingRepositoryPackage(pcm::Repository pcmRepo) {
 	match {
-		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		val umlRepositoryPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
 		if (!umlRepositoryPkg.isPackageFor(pcmRepo))
@@ -134,37 +141,37 @@ reaction RepositoryDeleted {
 routine deleteCorrespondingRepositoryPackages(pcm::Repository pcmRepo) {
 	match {
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-		val umlRepositoryPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val umlContractsPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		val umlDatatypesPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		val umlRepositoryPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val umlContractsPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		val umlDatatypesPkg = retrieve optional uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
 		// remove correspondences, UML model contents if desired
-		umlRepositoryPkg.ifPresent[umlRepositoryPackage |
-			removeCorrespondenceBetween(
-				pcmRepo, umlRepositoryPackage, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
+		umlRepositoryPkg.ifPresent [ umlRepositoryPackage |
+			removeCorrespondenceBetween(pcmRepo, umlRepositoryPackage, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
 			// ask if the corresponding model should also be deleted
-			val deleteCorrespondingUmlRepository = userInteractor.confirmationDialogBuilder
-					.message(DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
+			val deleteCorrespondingUmlRepository = userInteractor.confirmationDialogBuilder.message(
+				DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL).startInteraction
 
-			if (deleteCorrespondingUmlRepository) {// DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL_YES
+			if (deleteCorrespondingUmlRepository) { // DefaultLiterals.INPUT_REQUEST_DELETE_CORRESPONDING_UML_MODEL_YES
 				umlContractsPkg.ifPresent[umlRepositoryPackage.packagedElements -= it]
 				umlDatatypesPkg.ifPresent[umlRepositoryPackage.packagedElements -= it]
 				umlModel.packagedElements -= umlRepositoryPackage // remove parent package last to allow the recorder to notice the child package deletion
 			}
 		]
-		umlContractsPkg.ifPresent[removeCorrespondenceBetween(
-			pcmRepo, it, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)]
-		umlDatatypesPkg.ifPresent[removeCorrespondenceBetween(
-			pcmRepo, it, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)]
+		umlContractsPkg.ifPresent[removeCorrespondenceBetween(pcmRepo, it, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)]
+		umlDatatypesPkg.ifPresent[removeCorrespondenceBetween(pcmRepo, it, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)]
 	}
 }
-
 
 //Primitive Datatypes are bootstraped in
 routine bootstrapPrimitiveDatatypes(pcm::Repository pcmRepo) {
 	match {
-		val umlDatatypesPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		val umlDatatypesPkg = retrieve asserted uml::Package corresponding to pcmRepo tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
 		val pcmPrimitiveTypes = PcmDataTypeUtil.getPcmPrimitiveTypes(pcmRepo)
@@ -180,9 +187,9 @@ routine bootstrapPrimitiveDatatypes(pcm::Repository pcmRepo) {
 
 routine addPrimitiveDatatypeCorrespondence(pcm::PrimitiveDataType pcmPrimitiveType, uml::PrimitiveType umlPrimitiveType) {
 	match {
-		require absence of uml::PrimitiveType corresponding to pcmPrimitiveType tagged with TagLiterals.DATATYPE__TYPE with potentialTarget == umlPrimitiveType
+	require absence of uml::PrimitiveType corresponding to pcmPrimitiveType tagged with TagLiterals.DATATYPE__TYPE with potentialTarget == umlPrimitiveType
 		require absence of pcm::PrimitiveDataType corresponding to umlPrimitiveType tagged with TagLiterals.DATATYPE__TYPE with potentialTarget == pcmPrimitiveType
-	}
+}
 	update {
 		addCorrespondenceBetween(pcmPrimitiveType, umlPrimitiveType, TagLiterals.DATATYPE__TYPE)
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
@@ -4,7 +4,7 @@ import tools.vitruv.applications.pcmumlclass.TagLiterals
 import static extension tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper.isPackageFor
 import static extension tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper.getCorrespondingPackageName
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::RepositoryComponent 
@@ -18,7 +18,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		UmlIPREClassReactions.reactions
 //		UmlIPREConstructorOperation.reactions
 //		RepositoryComponentConceptTest
-
 reactions: pcmRepositoryComponentReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -40,15 +39,17 @@ routine insertCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 
 routine detectOrCreateCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
 	match {
-		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		if (!umlComponentPackage.isPresent) {
 			val umlComponentPackageCandidate = umlRepositoryPackage.nestedPackages.findFirst[isPackageFor(pcmComponent)]
 			if (umlComponentPackageCandidate !== null) {
 				addCorrespondenceForExistingComponentPackage(pcmComponent, umlComponentPackageCandidate)
-			} else { 
+			} else {
 				createCorrespondingComponentPackage(pcmComponent, pcmRepository)
 			}
 		}
@@ -57,8 +58,10 @@ routine detectOrCreateCorrespondingComponentPackage(pcm::RepositoryComponent pcm
 
 routine addCorrespondenceForExistingComponentPackage(pcm::RepositoryComponent pcmComponent, uml::Package umlComponentPackage) {
 	match {
-		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
-		require absence of pcm::RepositoryComponent corresponding to umlComponentPackage tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
+		require absence of pcm::RepositoryComponent corresponding to umlComponentPackage tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		addCorrespondenceBetween(pcmComponent, umlComponentPackage, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
@@ -67,8 +70,10 @@ routine addCorrespondenceForExistingComponentPackage(pcm::RepositoryComponent pc
 
 routine createCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
 	match {
-		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	create {
 		val umlComponentPackage = new uml::Package
@@ -80,16 +85,18 @@ routine createCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 	}
 }
 
-
 routine detectOrCreateCorrespondingComponentImplementation(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
-		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
+		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 	}
 	update {
 		if (!umlComponentImplementation.isPresent) {
-			val umlComponentImplementationCandidate = umlComponentPackage.packagedElements
-					.filter(Class).findFirst[it.name == pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+			val umlComponentImplementationCandidate = umlComponentPackage.packagedElements.filter(Class).findFirst [
+				it.name == pcmComponent.entityName + DefaultLiterals.IMPLEMENTATION_SUFFIX
+			]
 			if (umlComponentImplementationCandidate !== null) {
 				addCorrespondenceForExistingComponentImplementation(pcmComponent, umlComponentImplementationCandidate)
 			} else {
@@ -102,7 +109,8 @@ routine detectOrCreateCorrespondingComponentImplementation(pcm::RepositoryCompon
 routine addCorrespondenceForExistingComponentImplementation(pcm::RepositoryComponent pcmComponent, uml::Class umlComponentImplementation) {
 	match {
 		require absence of uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::RepositoryComponent corresponding to umlComponentImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
+		require absence of pcm::RepositoryComponent corresponding to umlComponentImplementation tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 	}
 	update {
 		addCorrespondenceBetween(pcmComponent, umlComponentImplementation, TagLiterals.IPRE__IMPLEMENTATION)
@@ -111,7 +119,8 @@ routine addCorrespondenceForExistingComponentImplementation(pcm::RepositoryCompo
 
 routine createCorrespondingComponentImplementation(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 		require absence of uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
 	create {
@@ -127,13 +136,16 @@ routine createCorrespondingComponentImplementation(pcm::RepositoryComponent pcmC
 
 routine detectOrCreateCorrespondingComponentConstructor(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
+		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
 	}
 	update {
 		if (!umlComponentConstructor.isPresent) {
-			val umlComponentConstructorCandidate = umlComponentImplementation.ownedOperations
-					.findFirst[it.name == pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+			val umlComponentConstructorCandidate = umlComponentImplementation.ownedOperations.findFirst [
+				it.name == pcmComponent.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+			]
 			if (umlComponentConstructorCandidate !== null) {
 				addCorrespondenceForExistingComponentConstructor(pcmComponent, umlComponentConstructorCandidate)
 			} else {
@@ -146,7 +158,8 @@ routine detectOrCreateCorrespondingComponentConstructor(pcm::RepositoryComponent
 routine addCorrespondenceForExistingComponentConstructor(pcm::RepositoryComponent pcmComponent, uml::Operation umlComponentConstructor) {
 	match {
 		require absence of uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
-		require absence of pcm::RepositoryComponent corresponding to umlComponentConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
+		require absence of pcm::RepositoryComponent corresponding to umlComponentConstructor tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
 	}
 	update {
 		addCorrespondenceBetween(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR)
@@ -155,10 +168,11 @@ routine addCorrespondenceForExistingComponentConstructor(pcm::RepositoryComponen
 
 routine createCorrespondingComponentConstructor(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 		require absence of uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
-	create { 
+	create {
 		val umlComponentConstructor = new uml::Operation
 	}
 	update {
@@ -170,8 +184,10 @@ routine createCorrespondingComponentConstructor(pcm::RepositoryComponent pcmComp
 
 routine moveCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
 	match {
-		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		umlRepositoryPackage.packagedElements += umlComponentPackage
@@ -186,8 +202,10 @@ reaction RepositoryComponentRemoved {
 
 routine removeCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
 	match {
-		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		umlRepositoryPackage.packagedElements -= umlComponentPackage
@@ -201,16 +219,19 @@ reaction RepositoryComponentDeleted {
 
 routine deleteCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
-		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
+		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmComponent tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
 	}
 	update {
 		removeObject(umlComponentPackage)
-		removeCorrespondenceBetween(pcmComponent, umlComponentPackage,TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
+		removeCorrespondenceBetween(pcmComponent, umlComponentPackage, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
 		removeCorrespondenceBetween(pcmComponent, umlComponentImplementation, TagLiterals.IPRE__IMPLEMENTATION)
 		removeCorrespondenceBetween(pcmComponent, umlComponentConstructor, TagLiterals.IPRE__CONSTRUCTOR)
-		
+
 	}
 }
 
@@ -222,14 +243,19 @@ reaction RepositoryComponentNameChanged {
 
 routine changeNameOfComponentCorrespondences(pcm::RepositoryComponent pcmComponent, String newName) {
 	match {
-		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
-		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
+		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
+		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
 	}
 	update {
-		if (umlComponentPackage.isPresent) umlComponentPackage.get.name = pcmComponent.correspondingPackageName
-		if (umlComponentImplementation.isPresent) umlComponentImplementation.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
-		if (umlComponentConstructor.isPresent) umlComponentConstructor.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		if(umlComponentPackage.isPresent) umlComponentPackage.get.name = pcmComponent.correspondingPackageName
+		if(umlComponentImplementation.isPresent) umlComponentImplementation.get.name = newName.toFirstUpper +
+			DefaultLiterals.IMPLEMENTATION_SUFFIX
+		if(umlComponentConstructor.isPresent) umlComponentConstructor.get.name = newName.toFirstUpper +
+			DefaultLiterals.IMPLEMENTATION_SUFFIX
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
@@ -58,8 +58,7 @@ routine detectOrCreateCorrespondingComponentPackage(pcm::RepositoryComponent pcm
 
 routine addCorrespondenceForExistingComponentPackage(pcm::RepositoryComponent pcmComponent, uml::Package umlComponentPackage) {
 	match {
-		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.
-			REPOSITORY_COMPONENT__PACKAGE
+		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 		require absence of pcm::RepositoryComponent corresponding to umlComponentPackage tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
@@ -72,8 +71,7 @@ routine createCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 	match {
 		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.
-			REPOSITORY_COMPONENT__PACKAGE
+		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
 	create {
 		val umlComponentPackage = new uml::Package
@@ -252,10 +250,10 @@ routine changeNameOfComponentCorrespondences(pcm::RepositoryComponent pcmCompone
 	}
 	update {
 		if(umlComponentPackage.isPresent) umlComponentPackage.get.name = pcmComponent.correspondingPackageName
-		if(umlComponentImplementation.isPresent) umlComponentImplementation.get.name = newName.toFirstUpper +
-			DefaultLiterals.IMPLEMENTATION_SUFFIX
-		if(umlComponentConstructor.isPresent) umlComponentConstructor.get.name = newName.toFirstUpper +
-			DefaultLiterals.IMPLEMENTATION_SUFFIX
+		if (umlComponentImplementation.isPresent)
+			umlComponentImplementation.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		if (umlComponentConstructor.isPresent)
+			umlComponentConstructor.get.name = newName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
 	}
 }
 

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepositoryComponent.reactions
@@ -39,9 +39,9 @@ routine insertCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 
 routine detectOrCreateCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
 	match {
-		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -58,9 +58,9 @@ routine detectOrCreateCorrespondingComponentPackage(pcm::RepositoryComponent pcm
 
 routine addCorrespondenceForExistingComponentPackage(pcm::RepositoryComponent pcmComponent, uml::Package umlComponentPackage) {
 	match {
-		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
-		require absence of pcm::RepositoryComponent corresponding to umlComponentPackage tagged with TagLiterals.
+		require absence of pcm::RepositoryComponent corresponding to umlComponentPackage tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -70,9 +70,9 @@ routine addCorrespondenceForExistingComponentPackage(pcm::RepositoryComponent pc
 
 routine createCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
 	match {
-		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	create {
@@ -87,9 +87,9 @@ routine createCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponen
 
 routine detectOrCreateCorrespondingComponentImplementation(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
-		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 	}
 	update {
@@ -108,8 +108,8 @@ routine detectOrCreateCorrespondingComponentImplementation(pcm::RepositoryCompon
 
 routine addCorrespondenceForExistingComponentImplementation(pcm::RepositoryComponent pcmComponent, uml::Class umlComponentImplementation) {
 	match {
-		require absence of uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::RepositoryComponent corresponding to umlComponentImplementation tagged with TagLiterals.
+		require absence of uml::Class corresponding to pcmComponent tagged TagLiterals.IPRE__IMPLEMENTATION
+		require absence of pcm::RepositoryComponent corresponding to umlComponentImplementation tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 	}
 	update {
@@ -119,9 +119,9 @@ routine addCorrespondenceForExistingComponentImplementation(pcm::RepositoryCompo
 
 routine createCorrespondingComponentImplementation(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
-		require absence of uml::Class corresponding to pcmComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
+		require absence of uml::Class corresponding to pcmComponent tagged TagLiterals.IPRE__IMPLEMENTATION
 	}
 	create {
 		val umlComponentImplementation = new uml::Class
@@ -136,9 +136,9 @@ routine createCorrespondingComponentImplementation(pcm::RepositoryComponent pcmC
 
 routine detectOrCreateCorrespondingComponentConstructor(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged TagLiterals.
 			IPRE__CONSTRUCTOR
 	}
 	update {
@@ -157,8 +157,8 @@ routine detectOrCreateCorrespondingComponentConstructor(pcm::RepositoryComponent
 
 routine addCorrespondenceForExistingComponentConstructor(pcm::RepositoryComponent pcmComponent, uml::Operation umlComponentConstructor) {
 	match {
-		require absence of uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
-		require absence of pcm::RepositoryComponent corresponding to umlComponentConstructor tagged with TagLiterals.
+		require absence of uml::Operation corresponding to pcmComponent tagged TagLiterals.IPRE__CONSTRUCTOR
+		require absence of pcm::RepositoryComponent corresponding to umlComponentConstructor tagged TagLiterals.
 			IPRE__CONSTRUCTOR
 	}
 	update {
@@ -168,9 +168,9 @@ routine addCorrespondenceForExistingComponentConstructor(pcm::RepositoryComponen
 
 routine createCorrespondingComponentConstructor(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		require absence of uml::Operation corresponding to pcmComponent tagged with TagLiterals.IPRE__CONSTRUCTOR
+		require absence of uml::Operation corresponding to pcmComponent tagged TagLiterals.IPRE__CONSTRUCTOR
 	}
 	create {
 		val umlComponentConstructor = new uml::Operation
@@ -184,9 +184,9 @@ routine createCorrespondingComponentConstructor(pcm::RepositoryComponent pcmComp
 
 routine moveCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
 	match {
-		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -202,9 +202,9 @@ reaction RepositoryComponentRemoved {
 
 routine removeCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent, pcm::Repository pcmRepository) {
 	match {
-		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged with TagLiterals.
+		val umlRepositoryPackage = retrieve uml::Package corresponding to pcmRepository tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -219,11 +219,11 @@ reaction RepositoryComponentDeleted {
 
 routine deleteCorrespondingComponentPackage(pcm::RepositoryComponent pcmComponent) {
 	match {
-		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentPackage = retrieve uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
-		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentImplementation = retrieve uml::Class corresponding to pcmComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmComponent tagged TagLiterals.
 			IPRE__CONSTRUCTOR
 	}
 	update {
@@ -243,11 +243,11 @@ reaction RepositoryComponentNameChanged {
 
 routine changeNameOfComponentCorrespondences(pcm::RepositoryComponent pcmComponent, String newName) {
 	match {
-		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentPackage = retrieve optional uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
-		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentImplementation = retrieve optional uml::Class corresponding to pcmComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged with TagLiterals.
+		val umlComponentConstructor = retrieve optional uml::Operation corresponding to pcmComponent tagged TagLiterals.
 			IPRE__CONSTRUCTOR
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
@@ -30,9 +30,9 @@ routine insertCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequir
 
 routine detectOrCreateCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged TagLiterals.
 			IPRE__CONSTRUCTOR
-		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -45,11 +45,11 @@ routine detectOrCreateCorrespondingRequiredConstructorParameter(pcm::OperationRe
 
 routine createCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged TagLiterals.
 			IPRE__CONSTRUCTOR
-		require absence of uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+		require absence of uml::Parameter corresponding to pcmRequired tagged TagLiterals.REQUIRED_ROLE__PARAMETER
 		val umlRequiredInterface = retrieve optional uml::Interface corresponding to pcmRequired.
-			requiredInterface__OperationRequiredRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
+			requiredInterface__OperationRequiredRole tagged TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	create {
 		val umlConstructorParameter = new uml::Parameter
@@ -63,8 +63,8 @@ routine createCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRo
 
 routine detectOrCreateCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged with TagLiterals.
+		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged TagLiterals.IPRE__IMPLEMENTATION
+		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -77,10 +77,10 @@ routine detectOrCreateCorrespondingRequiredField(pcm::OperationRequiredRole pcmR
 
 routine createCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged TagLiterals.IPRE__IMPLEMENTATION
+		require absence of uml::Property corresponding to pcmRequired tagged TagLiterals.REQUIRED_ROLE__PROPERTY
 		val umlRequiredInterface = retrieve optional uml::Interface corresponding to pcmRequired.
-			requiredInterface__OperationRequiredRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
+			requiredInterface__OperationRequiredRole tagged TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	create {
 		val umlRequiredField = new uml::Property
@@ -94,12 +94,12 @@ routine createCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired,
 
 routine moveCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged TagLiterals.
 			IPRE__CONSTRUCTOR
-		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
-		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.
+		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged TagLiterals.IPRE__IMPLEMENTATION
+		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -116,12 +116,12 @@ reaction RequiredRoleRemoved {
 
 routine removeCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged TagLiterals.
 			IPRE__CONSTRUCTOR
-		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
-		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged with TagLiterals.
+		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged TagLiterals.IPRE__IMPLEMENTATION
+		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -146,7 +146,7 @@ routine deleteCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequir
 
 routine deleteCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRole pcmRequired) {
 	match {
-		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -157,7 +157,7 @@ routine deleteCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRo
 
 routine deleteCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired) {
 	match {
-		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.
+		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -174,9 +174,9 @@ reaction RequiredRoleNameChanged {
 
 routine changeNameOfCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, String newName) {
 	match {
-		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
-		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.
+		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -193,11 +193,11 @@ reaction RequiredRoleInterfaceChanged {
 
 routine changeTypeOfCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
-		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.
+		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
-		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRequiredRole.reactions
@@ -1,6 +1,6 @@
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationRequiredRole of a pcm::InterfaceProvidingRequiringEntity (IPRE)
@@ -10,7 +10,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		UmlRequiredRoleParameter.reactions, UmlRequiredRoleProperty.reactions,
 //		RequiredRoleConceptTest
-
 reactions: pcmRequiredRoleReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -31,8 +30,10 @@ routine insertCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequir
 
 routine detectOrCreateCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
+		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
 		if (!umlConstructorParameter.isPresent) {
@@ -44,17 +45,18 @@ routine detectOrCreateCorrespondingRequiredConstructorParameter(pcm::OperationRe
 
 routine createCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.IPRE__CONSTRUCTOR
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
 		require absence of uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		val umlRequiredInterface = retrieve optional uml::Interface 
-			corresponding to pcmRequired.requiredInterface__OperationRequiredRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val umlRequiredInterface = retrieve optional uml::Interface corresponding to pcmRequired.
+			requiredInterface__OperationRequiredRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	create {
 		val umlConstructorParameter = new uml::Parameter
 	}
 	update {
 		umlConstructorParameter.name = pcmRequired.entityName
-		umlConstructorParameter.type = umlRequiredInterface.orElse(null) 
+		umlConstructorParameter.type = umlRequiredInterface.orElse(null)
 		addCorrespondenceBetween(pcmRequired, umlConstructorParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
 	}
 }
@@ -62,7 +64,8 @@ routine createCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRo
 routine detectOrCreateCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		if (!umlRequiredField.isPresent) {
@@ -76,26 +79,28 @@ routine createCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired,
 	match {
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
 		require absence of uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
-		val umlRequiredInterface = retrieve optional uml::Interface 
-			corresponding to pcmRequired.requiredInterface__OperationRequiredRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val umlRequiredInterface = retrieve optional uml::Interface corresponding to pcmRequired.
+			requiredInterface__OperationRequiredRole tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	create {
 		val umlRequiredField = new uml::Property
 	}
 	update {
 		umlRequiredField.name = pcmRequired.entityName
-		umlRequiredField.type = umlRequiredInterface.orElse(null) 
+		umlRequiredField.type = umlRequiredInterface.orElse(null)
 		addCorrespondenceBetween(pcmRequired, umlRequiredField, TagLiterals.REQUIRED_ROLE__PROPERTY)
 	}
 }
 
 routine moveCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
+		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		umlComponentConstructor.ownedParameters += umlConstructorParameter
@@ -111,14 +116,16 @@ reaction RequiredRoleRemoved {
 
 routine removeCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, pcm::InterfaceProvidingRequiringEntity pcmIPRE) {
 	match {
-		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		
+		val umlComponentConstructor = retrieve uml::Operation corresponding to pcmIPRE tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
+		val umlConstructorParameter = retrieve optional uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 		val umlComponentImpl = retrieve uml::Class corresponding to pcmIPRE tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val umlRequiredField = retrieve optional uml::Property corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
-		if (umlConstructorParameter.isPresent) 	
+		if (umlConstructorParameter.isPresent)
 			umlComponentConstructor.ownedParameters -= umlConstructorParameter.get
 		if (umlRequiredField.isPresent)
 			umlComponentImpl.ownedAttributes -= umlRequiredField.get
@@ -139,7 +146,8 @@ routine deleteCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequir
 
 routine deleteCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRole pcmRequired) {
 	match {
-		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
 		removeObject(umlConstructorParameter)
@@ -149,7 +157,8 @@ routine deleteCorrespondingRequiredConstructorParameter(pcm::OperationRequiredRo
 
 routine deleteCorrespondingRequiredField(pcm::OperationRequiredRole pcmRequired) {
 	match {
-		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		removeObject(umlRequiredField)
@@ -165,8 +174,10 @@ reaction RequiredRoleNameChanged {
 
 routine changeNameOfCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, String newName) {
 	match {
-		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
+		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		umlConstructorParameter.name = newName
@@ -182,10 +193,12 @@ reaction RequiredRoleInterfaceChanged {
 
 routine changeTypeOfCorrespondingRequiredElements(pcm::OperationRequiredRole pcmRequired, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
-		
-		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val umlConstructorParameter = retrieve uml::Parameter corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
+		val umlRequiredField = retrieve uml::Property corresponding to pcmRequired tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
+		val umlInterface = retrieve optional uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		umlConstructorParameter.type = umlInterface.orElse(null)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
@@ -2,7 +2,7 @@ import org.eclipse.uml2.uml.ParameterDirectionKind
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationSignature with its corresponding uml::Operation
@@ -12,7 +12,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmDataTypePropagation.reactions,
 //		UmlSignatureOperation.reactions, UmlReturnAndRegularParameterType.reactions,
 //		SignatureConceptTest
-
 reactions: pcmSignatureReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -29,15 +28,18 @@ routine insertCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::
 	update {
 		detectOrCreateOperationCandidate(pcmSignature, pcmInterface)
 		moveCorrespondingOperation(pcmSignature, pcmInterface)
-		
+
 	}
 }
 
 routine detectOrCreateOperationCandidate(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val umlOperation = retrieve optional uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val umlOperation = retrieve optional uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
 		if (umlOperation.isPresent) {
@@ -45,7 +47,8 @@ routine detectOrCreateOperationCandidate(pcm::OperationSignature pcmSignature, p
 		} else {
 			val umlOperationCandidate = umlInterface.ownedOperations.findFirst[it.name == pcmSignature.entityName]
 			if (umlOperationCandidate !== null) {
-				attemptAddingCorrespondenceForExistingOperationCandidate(pcmSignature, pcmInterface, umlOperationCandidate)
+				attemptAddingCorrespondenceForExistingOperationCandidate(pcmSignature, pcmInterface,
+					umlOperationCandidate)
 				detectOrCreateReturnParameterCandidate(pcmSignature)
 			} else {
 				createCorrespondingOperation(pcmSignature, pcmInterface)
@@ -56,14 +59,18 @@ routine detectOrCreateOperationCandidate(pcm::OperationSignature pcmSignature, p
 
 routine detectOrCreateReturnParameterCandidate(pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
+		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
 		if (umlReturnParam.isPresent) {
 			return // do nothing, because the correspondences are already established
 		} else {
-			val umlReturnParamCandidate = umlOperation.ownedParameters.findFirst[it.direction === ParameterDirectionKind.RETURN_LITERAL]
+			val umlReturnParamCandidate = umlOperation.ownedParameters.findFirst [
+				it.direction === ParameterDirectionKind.RETURN_LITERAL
+			]
 			if (umlReturnParamCandidate !== null) {
 				attemptAddingCorrespondenceForExistingReturnParamCandidate(pcmSignature, umlReturnParamCandidate)
 			} else {
@@ -73,29 +80,27 @@ routine detectOrCreateReturnParameterCandidate(pcm::OperationSignature pcmSignat
 	}
 }
 
-routine attemptAddingCorrespondenceForExistingOperationCandidate(
-	pcm::OperationSignature pcmSignature, 
-	pcm::OperationInterface pcmInterface,
-	uml::Operation umlOperationCandidate
-) {
+routine attemptAddingCorrespondenceForExistingOperationCandidate(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface, uml::Operation umlOperationCandidate) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		require absence of pcm::OperationSignature corresponding to umlOperationCandidate tagged with TagLiterals.SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlOperationCandidate tagged with TagLiterals.
+			SIGNATURE__OPERATION
 	}
 	update {
 		addCorrespondenceBetween(pcmSignature, umlOperationCandidate, TagLiterals.SIGNATURE__OPERATION)
 	}
 }
 
-routine attemptAddingCorrespondenceForExistingReturnParamCandidate(
-	pcm::OperationSignature pcmSignature,
-	uml::Parameter umlReturnParamCandidate
-) {
+routine attemptAddingCorrespondenceForExistingReturnParamCandidate(pcm::OperationSignature pcmSignature, uml::Parameter umlReturnParamCandidate) {
 	match {
-		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		require absence of uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
-		require absence of pcm::OperationSignature corresponding to umlReturnParamCandidate tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
+		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		require absence of uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		require absence of pcm::OperationSignature corresponding to umlReturnParamCandidate tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
 		umlReturnParamCandidate.name = DefaultLiterals.RETURN_PARAM_NAME
@@ -105,7 +110,8 @@ routine attemptAddingCorrespondenceForExistingReturnParamCandidate(
 
 routine createCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 	}
 	create {
@@ -120,8 +126,10 @@ routine createCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::
 
 routine createCorrespondingReturnParameter(pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		require absence of uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
+		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		require absence of uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
 	}
 	create {
 		val umlReturnParam = new uml::Parameter
@@ -137,8 +145,10 @@ routine createCorrespondingReturnParameter(pcm::OperationSignature pcmSignature)
 
 routine moveCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
 	}
 	update {
 		umlInterface.ownedOperations += umlOperation
@@ -153,8 +163,10 @@ reaction SignatureRemovedFromInterface {
 
 routine removeCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
 	}
 	update {
 		umlInterface.ownedOperations -= umlOperation
@@ -168,8 +180,10 @@ reaction SignatureDeleted {
 
 routine deleteCorrespondingOperation(pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		val umlReturnParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		val umlReturnParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
 		removeObject(umlOperation)
@@ -186,7 +200,8 @@ reaction SignatureRenamed {
 
 routine renameCorrespondingOperation(pcm::OperationSignature pcmSignature, String newName) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__OPERATION
 	}
 	update {
 		umlOperation.name = newName
@@ -201,7 +216,8 @@ reaction SignatureReturnTypeChanged {
 
 routine changeTypeOfCorrespondingReturnParameter(pcm::OperationSignature pcmSignature, pcm::DataType pcmDataType) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
+		val umlParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
 		pcmDataTypePropagationReactions.setUmlParameterType(pcmDataType, umlParam)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
@@ -34,11 +34,11 @@ routine insertCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::
 
 routine detectOrCreateOperationCandidate(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val umlOperation = retrieve optional uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve optional uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
@@ -59,9 +59,9 @@ routine detectOrCreateOperationCandidate(pcm::OperationSignature pcmSignature, p
 
 routine detectOrCreateReturnParameterCandidate(pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+		val umlReturnParam = retrieve optional uml::Parameter corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
@@ -82,10 +82,10 @@ routine detectOrCreateReturnParameterCandidate(pcm::OperationSignature pcmSignat
 
 routine attemptAddingCorrespondenceForExistingOperationCandidate(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface, uml::Operation umlOperationCandidate) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
-		require absence of pcm::OperationSignature corresponding to umlOperationCandidate tagged with TagLiterals.
+		require absence of uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlOperationCandidate tagged TagLiterals.
 			SIGNATURE__OPERATION
 	}
 	update {
@@ -95,11 +95,11 @@ routine attemptAddingCorrespondenceForExistingOperationCandidate(pcm::OperationS
 
 routine attemptAddingCorrespondenceForExistingReturnParamCandidate(pcm::OperationSignature pcmSignature, uml::Parameter umlReturnParamCandidate) {
 	match {
-		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+		require absence of uml::Parameter corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		require absence of pcm::OperationSignature corresponding to umlReturnParamCandidate tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlReturnParamCandidate tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
@@ -110,9 +110,9 @@ routine attemptAddingCorrespondenceForExistingReturnParamCandidate(pcm::Operatio
 
 routine createCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
+		require absence of uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 	}
 	create {
 		val umlOperation = new uml::Operation
@@ -126,9 +126,9 @@ routine createCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::
 
 routine createCorrespondingReturnParameter(pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+		require absence of uml::Parameter corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
 	}
 	create {
@@ -145,9 +145,9 @@ routine createCorrespondingReturnParameter(pcm::OperationSignature pcmSignature)
 
 routine moveCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
 	}
 	update {
@@ -163,9 +163,9 @@ reaction SignatureRemovedFromInterface {
 
 routine removeCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::OperationInterface pcmInterface) {
 	match {
-		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged with TagLiterals.
+		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
 	}
 	update {
@@ -180,9 +180,9 @@ reaction SignatureDeleted {
 
 routine deleteCorrespondingOperation(pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		val umlReturnParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+		val umlReturnParam = retrieve uml::Parameter corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
 	}
 	update {
@@ -200,7 +200,7 @@ reaction SignatureRenamed {
 
 routine renameCorrespondingOperation(pcm::OperationSignature pcmSignature, String newName) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged with TagLiterals.
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
 	}
 	update {
@@ -216,7 +216,7 @@ reaction SignatureReturnTypeChanged {
 
 routine changeTypeOfCorrespondingReturnParameter(pcm::OperationSignature pcmSignature, pcm::DataType pcmDataType) {
 	match {
-		val umlParam = retrieve uml::Parameter corresponding to pcmSignature tagged with TagLiterals.
+		val umlParam = retrieve uml::Parameter corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSignature.reactions
@@ -97,8 +97,7 @@ routine attemptAddingCorrespondenceForExistingReturnParamCandidate(pcm::Operatio
 	match {
 		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of uml::Parameter corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__RETURN_PARAMETER
+		require absence of uml::Parameter corresponding to pcmSignature tagged TagLiterals.SIGNATURE__RETURN_PARAMETER
 		require absence of pcm::OperationSignature corresponding to umlReturnParamCandidate tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
 	}
@@ -128,8 +127,7 @@ routine createCorrespondingReturnParameter(pcm::OperationSignature pcmSignature)
 	match {
 		val umlOperation = retrieve asserted uml::Operation corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of uml::Parameter corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__RETURN_PARAMETER
+		require absence of uml::Parameter corresponding to pcmSignature tagged TagLiterals.SIGNATURE__RETURN_PARAMETER
 	}
 	create {
 		val umlReturnParam = new uml::Parameter
@@ -147,8 +145,7 @@ routine moveCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::Op
 	match {
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 	}
 	update {
 		umlInterface.ownedOperations += umlOperation
@@ -165,8 +162,7 @@ routine removeCorrespondingOperation(pcm::OperationSignature pcmSignature, pcm::
 	match {
 		val umlInterface = retrieve uml::Interface corresponding to pcmInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 	}
 	update {
 		umlInterface.ownedOperations -= umlOperation
@@ -180,8 +176,7 @@ reaction SignatureDeleted {
 
 routine deleteCorrespondingOperation(pcm::OperationSignature pcmSignature) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 		val umlReturnParam = retrieve uml::Parameter corresponding to pcmSignature tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
 	}
@@ -200,8 +195,7 @@ reaction SignatureRenamed {
 
 routine renameCorrespondingOperation(pcm::OperationSignature pcmSignature, String newName) {
 	match {
-		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.
-			SIGNATURE__OPERATION
+		val umlOperation = retrieve uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 	}
 	update {
 		umlOperation.name = newName

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
@@ -96,8 +96,7 @@ routine detectOrCreateCorrespondingSystemImplementation(pcm::System pcmSystem) {
 routine addCorrespondenceForExistingSystemImplementation(pcm::System pcmSystem, uml::Class umlSystemImplementation) {
 	match {
 		require absence of uml::Class corresponding to pcmSystem tagged TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::System corresponding to umlSystemImplementation tagged TagLiterals.
-			IPRE__IMPLEMENTATION
+		require absence of pcm::System corresponding to umlSystemImplementation tagged TagLiterals.IPRE__IMPLEMENTATION
 	}
 	update {
 		addCorrespondenceBetween(pcmSystem, umlSystemImplementation, TagLiterals.IPRE__IMPLEMENTATION)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
@@ -42,7 +42,7 @@ routine addSystemCorrespondence(pcm::System pcmSystem) {
 
 routine createOrFindCorrespondingSystemPackage(pcm::System pcmSystem) {
 	match {
-		require absence of uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		require absence of uml::Package corresponding to pcmSystem tagged TagLiterals.SYSTEM__SYSTEM_PACKAGE
 		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 	}
 	update {
@@ -63,7 +63,7 @@ routine addSystemPackageCorrespondence(pcm::System pcmSystem, uml::Package umlPa
 
 routine createCorrespondingSystemPackage(pcm::System pcmSystem, uml::Model umlRootModel) {
 	match {
-		require absence of uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		require absence of uml::Package corresponding to pcmSystem tagged TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
 	create {
 		val umlSystemPackage = new uml::Package
@@ -77,9 +77,9 @@ routine createCorrespondingSystemPackage(pcm::System pcmSystem, uml::Model umlRo
 
 routine detectOrCreateCorrespondingSystemImplementation(pcm::System pcmSystem) {
 	match {
-		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged TagLiterals.
 			SYSTEM__SYSTEM_PACKAGE
-		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
+		require absence of uml::Class corresponding to pcmSystem tagged TagLiterals.IPRE__IMPLEMENTATION
 	}
 	update {
 		val umlSystemImplementationCandidate = umlSystemPackage.packagedElements.filter(Class).findFirst [
@@ -95,8 +95,8 @@ routine detectOrCreateCorrespondingSystemImplementation(pcm::System pcmSystem) {
 
 routine addCorrespondenceForExistingSystemImplementation(pcm::System pcmSystem, uml::Class umlSystemImplementation) {
 	match {
-		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::System corresponding to umlSystemImplementation tagged with TagLiterals.
+		require absence of uml::Class corresponding to pcmSystem tagged TagLiterals.IPRE__IMPLEMENTATION
+		require absence of pcm::System corresponding to umlSystemImplementation tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 	}
 	update {
@@ -106,9 +106,9 @@ routine addCorrespondenceForExistingSystemImplementation(pcm::System pcmSystem, 
 
 routine createCorrespondingSystemImplementation(pcm::System pcmSystem) {
 	match {
-		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged TagLiterals.
 			SYSTEM__SYSTEM_PACKAGE
-		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
+		require absence of uml::Class corresponding to pcmSystem tagged TagLiterals.IPRE__IMPLEMENTATION
 	}
 	create {
 		val umlSystemImplementation = new uml::Class
@@ -123,9 +123,9 @@ routine createCorrespondingSystemImplementation(pcm::System pcmSystem) {
 
 routine detectOrCreateCorrespondingSystemConstructor(pcm::System pcmSystem) {
 	match {
-		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		require absence of uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
+		require absence of uml::Operation corresponding to pcmSystem tagged TagLiterals.IPRE__CONSTRUCTOR
 	}
 	update {
 		val umlSystemConstructorCandidate = umlSystemImplementation.ownedOperations.findFirst [
@@ -141,8 +141,8 @@ routine detectOrCreateCorrespondingSystemConstructor(pcm::System pcmSystem) {
 
 routine addCorrespondenceForExistingSystemConstructor(pcm::System pcmSystem, uml::Operation umlSystemConstructor) {
 	match {
-		require absence of uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
-		require absence of pcm::System corresponding to umlSystemConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
+		require absence of uml::Operation corresponding to pcmSystem tagged TagLiterals.IPRE__CONSTRUCTOR
+		require absence of pcm::System corresponding to umlSystemConstructor tagged TagLiterals.IPRE__CONSTRUCTOR
 	}
 	update {
 		addCorrespondenceBetween(pcmSystem, umlSystemConstructor, TagLiterals.IPRE__CONSTRUCTOR)
@@ -151,9 +151,9 @@ routine addCorrespondenceForExistingSystemConstructor(pcm::System pcmSystem, uml
 
 routine createCorrespondingSystemConstructor(pcm::System pcmSystem) {
 	match {
-		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		require absence of uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
+		require absence of uml::Operation corresponding to pcmSystem tagged TagLiterals.IPRE__CONSTRUCTOR
 	}
 	create {
 		val umlSystemConstructor = new uml::Operation
@@ -176,7 +176,7 @@ reaction SystemDeleted {
 
 routine deleteCorrespondenceToSystemPackage(pcm::System pcmSystem) {
 	match {
-		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged TagLiterals.
 			SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
@@ -187,7 +187,7 @@ routine deleteCorrespondenceToSystemPackage(pcm::System pcmSystem) {
 
 routine deleteCorrespondenceToSystemImplementation(pcm::System pcmSystem) {
 	match {
-		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 	}
 	update {
@@ -197,7 +197,7 @@ routine deleteCorrespondenceToSystemImplementation(pcm::System pcmSystem) {
 
 routine deleteCorrespondenceToSystemConstructor(pcm::System pcmSystem) {
 	match {
-		val umlSystemConstructor = retrieve uml::Operation corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemConstructor = retrieve uml::Operation corresponding to pcmSystem tagged TagLiterals.
 			IPRE__CONSTRUCTOR
 	}
 	update {
@@ -213,11 +213,11 @@ reaction SystemNameChanged {
 
 routine changeNameOfSystemCorrespondences(pcm::System pcmSystem, String newName) {
 	match {
-		val umlSystemPackage = retrieve optional uml::Package corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemPackage = retrieve optional uml::Package corresponding to pcmSystem tagged TagLiterals.
 			SYSTEM__SYSTEM_PACKAGE
-		val umlSystemImplementation = retrieve optional uml::Class corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemImplementation = retrieve optional uml::Class corresponding to pcmSystem tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val umlSystemConstructor = retrieve optional uml::Operation corresponding to pcmSystem tagged with TagLiterals.
+		val umlSystemConstructor = retrieve optional uml::Operation corresponding to pcmSystem tagged TagLiterals.
 			IPRE__CONSTRUCTOR
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmSystem.reactions
@@ -3,7 +3,6 @@ import org.eclipse.uml2.uml.UMLPackage
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import org.palladiosimulator.pcm.system.SystemPackage
-
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlPackage
 import static extension tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper.getCorrespondingPackageName
 
@@ -18,7 +17,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 // UmlIPREClass.reactions,
 // UmlIPREConstructorOperation.reactions,
 // RepositoryConceptTest
-
 reactions: pcmSystemReactions
 in reaction to changes in pcm
 execute actions in uml
@@ -28,7 +26,7 @@ import routines sharedRoutines // for UML model handling
 reaction SystemCreated {
 	after element pcm::System inserted as root
 	call {
-	    addSystemCorrespondence(newValue)
+		addSystemCorrespondence(newValue)
 		ensureUmlModelExists(newValue)
 		createOrFindCorrespondingSystemPackage(newValue)
 		detectOrCreateCorrespondingSystemImplementation(newValue)
@@ -37,19 +35,19 @@ reaction SystemCreated {
 }
 
 routine addSystemCorrespondence(pcm::System pcmSystem) {
-    update { // required to enable find-or-create-pattern:
-        addCorrespondenceBetween(pcmSystem, SystemPackage.Literals.SYSTEM)
-    }
+	update { // required to enable find-or-create-pattern:
+		addCorrespondenceBetween(pcmSystem, SystemPackage.Literals.SYSTEM)
+	}
 }
 
 routine createOrFindCorrespondingSystemPackage(pcm::System pcmSystem) {
 	match {
 		require absence of uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
-		 val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
+		val umlModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
 	}
 	update {
 		var foundPackage = findUmlPackage(umlModel, pcmSystem.correspondingPackageName)
-		if(foundPackage === null) {
+		if (foundPackage === null) {
 			createCorrespondingSystemPackage(pcmSystem, umlModel)
 		} else {
 			addSystemPackageCorrespondence(pcmSystem, foundPackage)
@@ -77,15 +75,16 @@ routine createCorrespondingSystemPackage(pcm::System pcmSystem, uml::Model umlRo
 	}
 }
 
-
 routine detectOrCreateCorrespondingSystemImplementation(pcm::System pcmSystem) {
 	match {
-		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.
+			SYSTEM__SYSTEM_PACKAGE
 		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
 	update {
-		val umlSystemImplementationCandidate = umlSystemPackage.packagedElements
-				.filter(Class).findFirst[it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+		val umlSystemImplementationCandidate = umlSystemPackage.packagedElements.filter(Class).findFirst [
+			it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		]
 		if (umlSystemImplementationCandidate !== null) {
 			addCorrespondenceForExistingSystemImplementation(pcmSystem, umlSystemImplementationCandidate)
 		} else {
@@ -97,7 +96,8 @@ routine detectOrCreateCorrespondingSystemImplementation(pcm::System pcmSystem) {
 routine addCorrespondenceForExistingSystemImplementation(pcm::System pcmSystem, uml::Class umlSystemImplementation) {
 	match {
 		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::System corresponding to umlSystemImplementation tagged with TagLiterals.IPRE__IMPLEMENTATION
+		require absence of pcm::System corresponding to umlSystemImplementation tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 	}
 	update {
 		addCorrespondenceBetween(pcmSystem, umlSystemImplementation, TagLiterals.IPRE__IMPLEMENTATION)
@@ -106,7 +106,8 @@ routine addCorrespondenceForExistingSystemImplementation(pcm::System pcmSystem, 
 
 routine createCorrespondingSystemImplementation(pcm::System pcmSystem) {
 	match {
-		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.
+			SYSTEM__SYSTEM_PACKAGE
 		require absence of uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
 	create {
@@ -122,12 +123,14 @@ routine createCorrespondingSystemImplementation(pcm::System pcmSystem) {
 
 routine detectOrCreateCorrespondingSystemConstructor(pcm::System pcmSystem) {
 	match {
-		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 		require absence of uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
 	update {
-		val umlSystemConstructorCandidate = umlSystemImplementation.ownedOperations
-				.findFirst[it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX]
+		val umlSystemConstructorCandidate = umlSystemImplementation.ownedOperations.findFirst [
+			it.name == pcmSystem.entityName.toFirstUpper + DefaultLiterals.IMPLEMENTATION_SUFFIX
+		]
 		if (umlSystemConstructorCandidate !== null) {
 			addCorrespondenceForExistingSystemConstructor(pcmSystem, umlSystemConstructorCandidate)
 		} else {
@@ -148,7 +151,8 @@ routine addCorrespondenceForExistingSystemConstructor(pcm::System pcmSystem, uml
 
 routine createCorrespondingSystemConstructor(pcm::System pcmSystem) {
 	match {
-		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 		require absence of uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
 	}
 	create {
@@ -172,7 +176,8 @@ reaction SystemDeleted {
 
 routine deleteCorrespondenceToSystemPackage(pcm::System pcmSystem) {
 	match {
-		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		val umlSystemPackage = retrieve uml::Package corresponding to pcmSystem tagged with TagLiterals.
+			SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
 		removeObject(umlSystemPackage)
@@ -182,7 +187,8 @@ routine deleteCorrespondenceToSystemPackage(pcm::System pcmSystem) {
 
 routine deleteCorrespondenceToSystemImplementation(pcm::System pcmSystem) {
 	match {
-		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val umlSystemImplementation = retrieve uml::Class corresponding to pcmSystem tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 	}
 	update {
 		removeCorrespondenceBetween(pcmSystem, umlSystemImplementation, TagLiterals.IPRE__IMPLEMENTATION)
@@ -191,7 +197,8 @@ routine deleteCorrespondenceToSystemImplementation(pcm::System pcmSystem) {
 
 routine deleteCorrespondenceToSystemConstructor(pcm::System pcmSystem) {
 	match {
-		val umlSystemConstructor = retrieve uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
+		val umlSystemConstructor = retrieve uml::Operation corresponding to pcmSystem tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
 	}
 	update {
 		removeCorrespondenceBetween(pcmSystem, umlSystemConstructor, TagLiterals.IPRE__CONSTRUCTOR)
@@ -206,9 +213,12 @@ reaction SystemNameChanged {
 
 routine changeNameOfSystemCorrespondences(pcm::System pcmSystem, String newName) {
 	match {
-		val umlSystemPackage = retrieve optional uml::Package corresponding to pcmSystem tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
-		val umlSystemImplementation = retrieve optional uml::Class corresponding to pcmSystem tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val umlSystemConstructor = retrieve optional uml::Operation corresponding to pcmSystem tagged with TagLiterals.IPRE__CONSTRUCTOR
+		val umlSystemPackage = retrieve optional uml::Package corresponding to pcmSystem tagged with TagLiterals.
+			SYSTEM__SYSTEM_PACKAGE
+		val umlSystemImplementation = retrieve optional uml::Class corresponding to pcmSystem tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val umlSystemConstructor = retrieve optional uml::Operation corresponding to pcmSystem tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
 	}
 	update {
 		umlSystemPackage.ifPresent[name = pcmSystem.correspondingPackageName]

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/SharedRoutines.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/SharedRoutines.reactions
@@ -1,10 +1,9 @@
 import org.eclipse.uml2.uml.UMLPackage
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.change.interaction.UserInteractionOptions.WindowModality
-
 import static tools.vitruv.applications.util.temporary.uml.UmlModelUtil.*
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: sharedRoutines
@@ -12,41 +11,43 @@ in reaction to changes in pcm
 execute actions in uml
 
 routine ensureUmlModelExists(EObject source) {
-    match {
-        require absence of uml::Model corresponding to UMLPackage.Literals.MODEL
-    }
-    update {
-        var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_MODEL_PATH).windowModality(WindowModality.MODAL).startInteraction
-        if (relativeModelPath.nullOrEmpty) {
-            relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.UML_MODEL_FILE_NAME + DefaultLiterals.UML_EXTENSION
-        } else if (!relativeModelPath.endsWith(DefaultLiterals.UML_EXTENSION)) {
-            relativeModelPath += DefaultLiterals.UML_EXTENSION
-        }
-        var umlRootModel = loadPersistedModelFromSource(relativeModelPath, source)
-        umlRootModel.ifPresent[ensureUmlModelCorrespondenceExists]
-        if(umlRootModel.isEmpty) {
-            createUmlModel(source, relativeModelPath)
-        }
-    }
+	match {
+		require absence of uml::Model corresponding to UMLPackage.Literals.MODEL
+	}
+	update {
+		var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_MODEL_PATH).
+			windowModality(WindowModality.MODAL).startInteraction
+		if (relativeModelPath.nullOrEmpty) {
+			relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.UML_MODEL_FILE_NAME +
+				DefaultLiterals.UML_EXTENSION
+		} else if (!relativeModelPath.endsWith(DefaultLiterals.UML_EXTENSION)) {
+			relativeModelPath += DefaultLiterals.UML_EXTENSION
+		}
+		var umlRootModel = loadPersistedModelFromSource(relativeModelPath, source)
+		umlRootModel.ifPresent[ensureUmlModelCorrespondenceExists]
+		if (umlRootModel.isEmpty) {
+			createUmlModel(source, relativeModelPath)
+		}
+	}
 }
 
 routine createUmlModel(EObject source, String relativeModelPath) {
 	create {
 		val umlRootModel = new uml::Model
-	} 
-    update {
-    	umlRootModel.name = DefaultLiterals.ROOT_MODEL_NAME;
+	}
+	update {
+		umlRootModel.name = DefaultLiterals.ROOT_MODEL_NAME;
 		persistProjectRelative(source, umlRootModel, relativeModelPath)
-        ensureUmlModelCorrespondenceExists(umlRootModel)
-    }
+		ensureUmlModelCorrespondenceExists(umlRootModel)
+	}
 }
 
 routine ensureUmlModelCorrespondenceExists(uml::Model newModel) {
-    match {
-        val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
-        check !alreadyCorrespondingModels.contains(newModel)
-    }
-    update {
-        addCorrespondenceBetween(UMLPackage.Literals.MODEL, newModel)
-    }
+	match {
+		val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
+		check !alreadyCorrespondingModels.contains(newModel)
+	}
+	update {
+		addCorrespondenceBetween(UMLPackage.Literals.MODEL, newModel)
+	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
@@ -48,8 +48,8 @@ routine detectOrCreateCorrespondingAssemblyContext(uml::Property umlProperty, um
 	match {
 		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.
-			type tagged TagLiterals.IPRE__IMPLEMENTATION
+		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.type tagged TagLiterals.
+			IPRE__IMPLEMENTATION
 		require absence of pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
@@ -81,8 +81,8 @@ routine createCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 	match {
 		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.
-			type tagged TagLiterals.IPRE__IMPLEMENTATION
+		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.type tagged TagLiterals.
+			IPRE__IMPLEMENTATION
 		require absence of pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
@@ -27,10 +27,10 @@ reaction AssemblyContextPropertyInserted {
 
 routine insertCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve optional pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmCompositeComponent = retrieve optional pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 		val pcmInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlProperty.
-			type tagged with TagLiterals.IPRE__IMPLEMENTATION
+			type tagged TagLiterals.IPRE__IMPLEMENTATION
 	}
 	update {
 		if (pcmCompositeComponent.isPresent && (pcmInnerComponent.isPresent || umlProperty.type === null) // allow 'null' for uninitialized references
@@ -46,11 +46,11 @@ routine insertCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 
 routine detectOrCreateCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.
-			type tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			type tagged TagLiterals.IPRE__IMPLEMENTATION
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -67,9 +67,9 @@ routine detectOrCreateCorrespondingAssemblyContext(uml::Property umlProperty, um
 
 routine addCorrespondenceForExistingAssemblyContext(uml::Property umlProperty, pcm::AssemblyContext pcmAssemblyContext) {
 	match {
-		require absence of uml::Property corresponding to pcmAssemblyContext tagged with TagLiterals.
+		require absence of uml::Property corresponding to pcmAssemblyContext tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
-		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -79,11 +79,11 @@ routine addCorrespondenceForExistingAssemblyContext(uml::Property umlProperty, p
 
 routine createCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.
-			type tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			type tagged TagLiterals.IPRE__IMPLEMENTATION
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	create {
@@ -99,9 +99,9 @@ routine createCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 
 routine moveCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -117,9 +117,9 @@ reaction AssemblyContextPropertyRemoved {
 
 routine removeCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -134,7 +134,7 @@ reaction AssemblyContextPropertyDeleted {
 
 routine deleteCorrespondingAssemblyContext(uml::Property umlProperty) {
 	match {
-		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -151,7 +151,7 @@ reaction AssemblyContextPropertyNameChanged {
 
 routine changeNameOfCorrespondingAssemblyContext(uml::Property umlProperty, String newName) {
 	match {
-		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
@@ -168,10 +168,10 @@ reaction AssemblyContextPropertyTypeChanged {
 routine changeTypeOfCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlNewInnerComponent) {
 	match {
 		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlProperty.
-			owner tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmAssemblyContext = retrieve optional pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			owner tagged TagLiterals.IPRE__IMPLEMENTATION
+		val pcmAssemblyContext = retrieve optional pcm::AssemblyContext corresponding to umlProperty tagged TagLiterals.
 			ASSEMBLY_CONTEXT__PROPERTY
-		val pcmNewInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlNewInnerComponent tagged with TagLiterals.
+		val pcmNewInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlNewInnerComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlAssemblyContextProperty.reactions
@@ -1,7 +1,7 @@
 import org.eclipse.uml2.uml.Class
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::AssemblyContext in a pcm::ComposedProvidingRequiringEntity (CPRE)
@@ -15,11 +15,9 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		PcmAssemblyContext.reactions
 //		AssemblyContextConceptTest
-
 reactions: umlAssemblyContextPropertyReactions
 in reaction to changes in uml
 execute actions in pcm
-
 
 reaction AssemblyContextPropertyInserted {
 	after element uml::Property inserted in uml::Class[ownedAttribute]
@@ -29,8 +27,10 @@ reaction AssemblyContextPropertyInserted {
 
 routine insertCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve optional pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlProperty.type tagged with TagLiterals.IPRE__IMPLEMENTATION 
+		val pcmCompositeComponent = retrieve optional pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlProperty.
+			type tagged with TagLiterals.IPRE__IMPLEMENTATION
 	}
 	update {
 		if (pcmCompositeComponent.isPresent && (pcmInnerComponent.isPresent || umlProperty.type === null) // allow 'null' for uninitialized references
@@ -46,12 +46,17 @@ routine insertCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 
 routine detectOrCreateCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.type tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.
+			type tagged with TagLiterals.IPRE__IMPLEMENTATION
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
-		val pcmAssemblyContextCandidate = pcmCompositeComponent.assemblyContexts__ComposedStructure.findFirst[entityName == umlProperty.name]
+		val pcmAssemblyContextCandidate = pcmCompositeComponent.assemblyContexts__ComposedStructure.findFirst [
+			entityName == umlProperty.name
+		]
 		if (pcmAssemblyContextCandidate === null) {
 			createCorrespondingAssemblyContext(umlProperty, umlComponent)
 		} else {
@@ -62,8 +67,10 @@ routine detectOrCreateCorrespondingAssemblyContext(uml::Property umlProperty, um
 
 routine addCorrespondenceForExistingAssemblyContext(uml::Property umlProperty, pcm::AssemblyContext pcmAssemblyContext) {
 	match {
-		require absence of uml::Property corresponding to pcmAssemblyContext tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		require absence of uml::Property corresponding to pcmAssemblyContext tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		addCorrespondenceBetween(pcmAssemblyContext, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
@@ -72,9 +79,12 @@ routine addCorrespondenceForExistingAssemblyContext(uml::Property umlProperty, p
 
 routine createCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.type tagged with TagLiterals.IPRE__IMPLEMENTATION
-		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInnerComponent = retrieve pcm::RepositoryComponent corresponding to umlProperty.
+			type tagged with TagLiterals.IPRE__IMPLEMENTATION
+		require absence of pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	create {
 		val pcmAssemblyContext = new pcm::AssemblyContext
@@ -89,8 +99,10 @@ routine createCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class
 
 routine moveCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		pcmCompositeComponent.assemblyContexts__ComposedStructure += pcmAssemblyContext
@@ -99,14 +111,16 @@ routine moveCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class u
 
 reaction AssemblyContextPropertyRemoved {
 	after element uml::Property removed from uml::Class[ownedAttribute]
-	with !affectedEObject.ownedAttributes.contains(oldValue) //validity check
+	with !affectedEObject.ownedAttributes.contains(oldValue) // validity check
 	call removeCorrespondingAssemblyContext(oldValue, affectedEObject)
 }
 
 routine removeCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		pcmCompositeComponent.assemblyContexts__ComposedStructure -= pcmAssemblyContext
@@ -120,7 +134,8 @@ reaction AssemblyContextPropertyDeleted {
 
 routine deleteCorrespondingAssemblyContext(uml::Property umlProperty) {
 	match {
-		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		removeCorrespondenceBetween(pcmAssemblyContext, umlProperty, TagLiterals.ASSEMBLY_CONTEXT__PROPERTY)
@@ -136,7 +151,8 @@ reaction AssemblyContextPropertyNameChanged {
 
 routine changeNameOfCorrespondingAssemblyContext(uml::Property umlProperty, String newName) {
 	match {
-		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
+		val pcmAssemblyContext = retrieve pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
 	}
 	update {
 		pcmAssemblyContext.entityName = newName
@@ -151,21 +167,24 @@ reaction AssemblyContextPropertyTypeChanged {
 
 routine changeTypeOfCorrespondingAssemblyContext(uml::Property umlProperty, uml::Class umlNewInnerComponent) {
 	match {
-		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlProperty.owner tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmAssemblyContext = retrieve optional pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.ASSEMBLY_CONTEXT__PROPERTY
-		val pcmNewInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlNewInnerComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val pcmCompositeComponent = retrieve pcm::ComposedProvidingRequiringEntity corresponding to umlProperty.
+			owner tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val pcmAssemblyContext = retrieve optional pcm::AssemblyContext corresponding to umlProperty tagged with TagLiterals.
+			ASSEMBLY_CONTEXT__PROPERTY
+		val pcmNewInnerComponent = retrieve optional pcm::RepositoryComponent corresponding to umlNewInnerComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 	}
 	update {
 		if (!pcmAssemblyContext.isPresent && pcmNewInnerComponent.isPresent) {
 			createCorrespondingAssemblyContext(umlProperty, umlProperty.owner as Class)
 		} else if (pcmAssemblyContext.isPresent && pcmNewInnerComponent.isPresent) {
 			pcmAssemblyContext.get.encapsulatedComponent__AssemblyContext = pcmNewInnerComponent.get
-		} else if(pcmAssemblyContext.isPresent && pcmNewInnerComponent === null) {
-			//might be a transitional state -> keep correspondence, but synchronize 'null'
+		} else if (pcmAssemblyContext.isPresent && pcmNewInnerComponent === null) {
+			// might be a transitional state -> keep correspondence, but synchronize 'null'
 			pcmAssemblyContext.get.encapsulatedComponent__AssemblyContext = null
 		} else {
-			logger.warn("The type of a uml::Property in a pcm::AssemblyContext ~ uml::Property correspondence"
-						+ "has been set to a non-RepositoryComponent type. This is against convention and the corresponding AssemblyContext will be deleted.")
+			logger.warn("The type of a uml::Property in a pcm::AssemblyContext ~ uml::Property correspondence" +
+				"has been set to a non-RepositoryComponent type. This is against convention and the corresponding AssemblyContext will be deleted.")
 			deleteCorrespondingAssemblyContext(umlProperty)
 		}
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
@@ -27,7 +27,7 @@ reaction CompositeDatyTypeClassInserted {
 
 routine insertCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
@@ -42,9 +42,9 @@ routine insertCorrespondingCompositeDataType(uml::Class umlClass, uml::Package u
 
 routine detectOrCreateCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
-		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+		require absence of pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -66,7 +66,7 @@ routine detectOrCreateCorrespondingCompositeDataType(uml::Class umlClass, uml::P
 
 routine createCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	create {
@@ -80,9 +80,9 @@ routine createCorrespondingCompositeDataType(uml::Class umlClass, uml::Package u
 
 routine addCorrespondenceForExistingCompositeDataType(pcm::CompositeDataType pcmCompositeType, uml::Class umlClass) {
 	match {
-		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+		require absence of pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		require absence of uml::Class corresponding to pcmCompositeType tagged with TagLiterals.
+		require absence of uml::Class corresponding to pcmCompositeType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -92,9 +92,9 @@ routine addCorrespondenceForExistingCompositeDataType(pcm::CompositeDataType pcm
 
 routine moveCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmCompositeType = retrieve asserted pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+		val pcmCompositeType = retrieve asserted pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
@@ -110,9 +110,9 @@ reaction CompositeDataTypeClassRemoved {
 
 routine removeCorrespondingCompositeType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
@@ -127,7 +127,7 @@ reaction CompositeDataTypeClassDeleted {
 
 routine deleteCorrespondingCompositeDataType(uml::Class umlClass) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -144,7 +144,7 @@ reaction CompositeDataTypeClassNameChanged {
 
 routine changeNameOfCorrespondingCompositeDataType(uml::Class umlClass, String newName) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
@@ -2,7 +2,7 @@ import org.palladiosimulator.pcm.repository.CompositeDataType
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 reactions: umlCompositeDataTypeClassReactions
@@ -19,7 +19,6 @@ execute actions in pcm
 //		PcmCompositeDataType.reactions
 //		UmlCompositeDataTypeGeneralization.reactions
 //		CompositeDataTypeConceptTest
-
 reaction CompositeDatyTypeClassInserted {
 	after element uml::Class inserted in uml::Package[packagedElement]
 	with newValue.package === affectedEObject
@@ -28,7 +27,8 @@ reaction CompositeDatyTypeClassInserted {
 
 routine insertCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
 		if (pcmRepository.isPresent) {
@@ -41,15 +41,21 @@ routine insertCorrespondingCompositeDataType(uml::Class umlClass, uml::Package u
 }
 
 routine detectOrCreateCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
-	match{
-		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
-		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+	match {
+		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
+		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
-		val candidates = pcmRepository.dataTypes__Repository.filter(CompositeDataType).filter[type | type.entityName == umlClass.name]
+		val candidates = pcmRepository.dataTypes__Repository.filter(CompositeDataType).filter [ type |
+			type.entityName == umlClass.name
+		]
 		switch (candidates.size) {
-			case 0: createCorrespondingCompositeDataType(umlClass, umlPackage)
-			case 1: addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
+			case 0:
+				createCorrespondingCompositeDataType(umlClass, umlPackage)
+			case 1:
+				addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
 			default: {
 				logger.warn(DefaultLiterals.WARNING_MULTIPLE_COMPOSITE_DATA_TYPE_CANDIDATES + umlClass)
 				addCorrespondenceForExistingCompositeDataType(candidates.head, umlClass)
@@ -60,7 +66,8 @@ routine detectOrCreateCorrespondingCompositeDataType(uml::Class umlClass, uml::P
 
 routine createCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	create {
 		val pcmCompositeType = new pcm::CompositeDataType
@@ -73,8 +80,10 @@ routine createCorrespondingCompositeDataType(uml::Class umlClass, uml::Package u
 
 routine addCorrespondenceForExistingCompositeDataType(pcm::CompositeDataType pcmCompositeType, uml::Class umlClass) {
 	match {
-		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		require absence of uml::Class corresponding to pcmCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		require absence of pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		require absence of uml::Class corresponding to pcmCompositeType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		addCorrespondenceBetween(pcmCompositeType, umlClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
@@ -83,8 +92,10 @@ routine addCorrespondenceForExistingCompositeDataType(pcm::CompositeDataType pcm
 
 routine moveCorrespondingCompositeDataType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmCompositeType = retrieve asserted pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		val pcmCompositeType = retrieve asserted pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
 		pcmRepository.dataTypes__Repository += pcmCompositeType
@@ -99,8 +110,10 @@ reaction CompositeDataTypeClassRemoved {
 
 routine removeCorrespondingCompositeType(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
 		pcmRepository.dataTypes__Repository -= pcmCompositeType
@@ -114,7 +127,8 @@ reaction CompositeDataTypeClassDeleted {
 
 routine deleteCorrespondingCompositeDataType(uml::Class umlClass) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		removeCorrespondenceBetween(pcmCompositeType, umlClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)
@@ -130,7 +144,8 @@ reaction CompositeDataTypeClassNameChanged {
 
 routine changeNameOfCorrespondingCompositeDataType(uml::Class umlClass, String newName) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		pcmCompositeType.entityName = newName

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeClass.reactions
@@ -44,8 +44,7 @@ routine detectOrCreateCorrespondingCompositeDataType(uml::Class umlClass, uml::P
 	match {
 		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
-		require absence of pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
-			COMPOSITE_DATATYPE__CLASS
+		require absence of pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		val candidates = pcmRepository.dataTypes__Repository.filter(CompositeDataType).filter [ type |
@@ -80,10 +79,8 @@ routine createCorrespondingCompositeDataType(uml::Class umlClass, uml::Package u
 
 routine addCorrespondenceForExistingCompositeDataType(pcm::CompositeDataType pcmCompositeType, uml::Class umlClass) {
 	match {
-		require absence of pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
-			COMPOSITE_DATATYPE__CLASS
-		require absence of uml::Class corresponding to pcmCompositeType tagged TagLiterals.
-			COMPOSITE_DATATYPE__CLASS
+		require absence of pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.COMPOSITE_DATATYPE__CLASS
+		require absence of uml::Class corresponding to pcmCompositeType tagged TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		addCorrespondenceBetween(pcmCompositeType, umlClass, TagLiterals.COMPOSITE_DATATYPE__CLASS)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
@@ -1,7 +1,7 @@
 import org.eclipse.uml2.uml.Class
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize the parent-references of a pcm::CompositeDataType 
@@ -11,21 +11,22 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmCompositeDataType.reactions
 //		UmlCompositeDataTypeClass.reactions
 //		CompositeDataTypeConceptTest
-
 reactions: umlCompositeDataTypeGeneralizationReactions
 in reaction to changes in uml
 execute actions in pcm
 
 reaction CompositeDataTypeGeneralizationAdded {
 	after element uml::Generalization inserted in uml::Class[generalization]
-	with affectedEObject.generalizations.contains(newValue) //validity check
+	with affectedEObject.generalizations.contains(newValue) // validity check
 	call addCompositeDatatypeParent(affectedEObject, newValue.general)
 }
 
 routine addCompositeDatatypeParent(uml::Class umlClass, uml::Classifier umlNewParent) {
 	match {
-		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlNewParent tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlNewParent tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		if (!pcmCompositeDataType.parentType_CompositeDataType.contains(pcmParentCompositeDataType)) {
@@ -36,14 +37,16 @@ routine addCompositeDatatypeParent(uml::Class umlClass, uml::Classifier umlNewPa
 
 reaction CompositeDataTypeGeneralizationRemoved {
 	after element uml::Generalization removed from uml::Class[generalization]
-	with !affectedEObject.generalizations.contains(oldValue) //validity check
+	with !affectedEObject.generalizations.contains(oldValue) // validity check
 	call removeCompositeDatatypeParent(affectedEObject, oldValue.general)
 }
 
 routine removeCompositeDatatypeParent(uml::Class umlClass, uml::Classifier umlOldParent) {
 	match {
-		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlOldParent tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlOldParent tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		if (pcmCompositeDataType.parentType_CompositeDataType.contains(pcmParentCompositeDataType)) {
@@ -61,7 +64,8 @@ reaction CompositeDataTypeGeneralizationTypeChanged {
 
 routine replaceCollectionDatatypeParent(uml::Generalization gen, uml::Classifier umlNewParent, uml::Classifier umlOldParent) {
 	match {
-		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to gen.specific tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to gen.
+			specific tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		removeCompositeDatatypeParent(gen.specific as Class, umlOldParent)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
@@ -64,8 +64,8 @@ reaction CompositeDataTypeGeneralizationTypeChanged {
 
 routine replaceCollectionDatatypeParent(uml::Generalization gen, uml::Classifier umlNewParent, uml::Classifier umlOldParent) {
 	match {
-		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to gen.
-			specific tagged TagLiterals.COMPOSITE_DATATYPE__CLASS
+		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to gen.specific tagged TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		removeCompositeDatatypeParent(gen.specific as Class, umlOldParent)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlCompositeDataTypeGeneralization.reactions
@@ -23,9 +23,9 @@ reaction CompositeDataTypeGeneralizationAdded {
 
 routine addCompositeDatatypeParent(uml::Class umlClass, uml::Classifier umlNewParent) {
 	match {
-		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlNewParent tagged with TagLiterals.
+		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlNewParent tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -43,9 +43,9 @@ reaction CompositeDataTypeGeneralizationRemoved {
 
 routine removeCompositeDatatypeParent(uml::Class umlClass, uml::Classifier umlOldParent) {
 	match {
-		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged with TagLiterals.
+		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlClass tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlOldParent tagged with TagLiterals.
+		val pcmParentCompositeDataType = retrieve pcm::CompositeDataType corresponding to umlOldParent tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -65,7 +65,7 @@ reaction CompositeDataTypeGeneralizationTypeChanged {
 routine replaceCollectionDatatypeParent(uml::Generalization gen, uml::Classifier umlNewParent, uml::Classifier umlOldParent) {
 	match {
 		val pcmCompositeDataType = retrieve pcm::CompositeDataType corresponding to gen.
-			specific tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
+			specific tagged TagLiterals.COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		removeCompositeDatatypeParent(gen.specific as Class, umlOldParent)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREClass.reactions
@@ -26,7 +26,7 @@ reaction IPREClassRemoved {
 
 routine warnUserAboutImplRemoveIfIPRECorrespondenceExists(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to umlClass tagged with TagLiterals.
+		val pcmRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to umlClass tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 	}
 	update {
@@ -42,7 +42,7 @@ reaction IPREClassNameChanged {
 
 routine changeNameOfCorrespondingIPRE_Implementation(uml::Class umlClass, String newName) {
 	match {
-		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlClass tagged with TagLiterals.
+		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlClass tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREClass.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREClass.reactions
@@ -1,9 +1,8 @@
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
-
 
 //	The following reactions and routines synchronize a pcm::InterfaceProvidingRequiringEntity (RepositoryComponent or System) 
 //	with its corresponding uml::Class (implementation).
@@ -15,7 +14,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		PcmRepositoryComponent.reactions, PcmSystem.reactions
 //		RepositoryComponentConceptTest, SystemConceptTest		
-
 reactions: umlIPREClassReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -28,7 +26,8 @@ reaction IPREClassRemoved {
 
 routine warnUserAboutImplRemoveIfIPRECorrespondenceExists(uml::Class umlClass, uml::Package umlPackage) {
 	match {
-		val pcmRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to umlClass tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val pcmRepositoryComponent = retrieve pcm::RepositoryComponent corresponding to umlClass tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 	}
 	update {
 		logger.warn(DefaultLiterals.WARNING_IPRE_IMPLEMENTATION_REMOVED + umlClass)
@@ -43,11 +42,13 @@ reaction IPREClassNameChanged {
 
 routine changeNameOfCorrespondingIPRE_Implementation(uml::Class umlClass, String newName) {
 	match {
-		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlClass tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlClass tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
 	}
 	update {
 		if (newName.endsWith(DefaultLiterals.IMPLEMENTATION_SUFFIX)) {
-			pcmIPRE.entityName = newName.substring(0, newName.length - DefaultLiterals.IMPLEMENTATION_SUFFIX.length).toFirstUpper
+			pcmIPRE.entityName = newName.substring(0, newName.length - DefaultLiterals.IMPLEMENTATION_SUFFIX.length).
+				toFirstUpper
 		} else {
 			pcmIPRE.entityName = newName
 		}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREConstructorOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREConstructorOperation.reactions
@@ -1,7 +1,7 @@
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::InterfaceProvidingRequiringEntity (RepositoryComponent or System) 
@@ -13,7 +13,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		PcmRepositoryComponent.reactions, PcmSystem.reactions
 //		RepositoryComponentConceptTest, SystemConceptTest
-
 reactions: umlIPREConstructorOperationReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -26,11 +25,13 @@ reaction IPREConstructorOperationNameChanged {
 
 routine changeNameOfCorrespondingIPRE_Constructor(uml::Operation umlOperation, String newName) {
 	match {
-		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlOperation tagged with TagLiterals.IPRE__CONSTRUCTOR
+		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlOperation tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
 	}
 	update {
 		if (newName.endsWith(DefaultLiterals.IMPLEMENTATION_SUFFIX)) {
-			pcmIPRE.entityName = newName.substring(0, newName.length - DefaultLiterals.IMPLEMENTATION_SUFFIX.length).toFirstUpper
+			pcmIPRE.entityName = newName.substring(0, newName.length - DefaultLiterals.IMPLEMENTATION_SUFFIX.length).
+				toFirstUpper
 		} else {
 			pcmIPRE.entityName = newName
 		}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREConstructorOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlIPREConstructorOperation.reactions
@@ -25,7 +25,7 @@ reaction IPREConstructorOperationNameChanged {
 
 routine changeNameOfCorrespondingIPRE_Constructor(uml::Operation umlOperation, String newName) {
 	match {
-		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlOperation tagged with TagLiterals.
+		val pcmIPRE = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlOperation tagged TagLiterals.
 			IPRE__CONSTRUCTOR
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
@@ -4,7 +4,7 @@ import org.palladiosimulator.pcm.repository.Repository
 import tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::InnerDeclaration with its corresponding uml::Property
@@ -13,7 +13,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		PcmInnerDeclaration.reactions, 
 //		AttributeConceptTest
-
 reactions: umlInnerDeclarationPropertyReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -26,7 +25,8 @@ reaction InnerDeclarationPropertyInserted {
 
 routine insertCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve optional pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS 
+		val pcmCompositeType = retrieve optional pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
 		if (pcmCompositeType.isPresent) {
@@ -41,13 +41,16 @@ routine insertCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Clas
 
 routine detectOrCreateCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS 
-		val pcmInnerDeclaration = retrieve optional pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val pcmInnerDeclaration = retrieve optional pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		if (!pcmInnerDeclaration.isPresent) {
-			val pcmInnerDeclarationCandidate = pcmCompositeType.innerDeclaration_CompositeDataType
-					.findFirst[it.entityName === umlProperty.name]
+			val pcmInnerDeclarationCandidate = pcmCompositeType.innerDeclaration_CompositeDataType.findFirst [
+				it.entityName === umlProperty.name
+			]
 			if (pcmInnerDeclarationCandidate !== null) {
 				addCorrespondenceForExistingInnerDeclaration(umlProperty, pcmInnerDeclarationCandidate)
 			} else {
@@ -59,8 +62,10 @@ routine detectOrCreateCorrespondingInnerDeclaration(uml::Property umlProperty, u
 
 routine addCorrespondenceForExistingInnerDeclaration(uml::Property umlProperty, pcm::InnerDeclaration pcmInnerDeclaration) {
 	match {
-		require absence of uml::Property corresponding to pcmInnerDeclaration tagged with TagLiterals.INNER_DECLARATION__PROPERTY
-		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		require absence of uml::Property corresponding to pcmInnerDeclaration tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
+		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		addCorrespondenceBetween(pcmInnerDeclaration, umlProperty, TagLiterals.INNER_DECLARATION__PROPERTY)
@@ -69,8 +74,10 @@ routine addCorrespondenceForExistingInnerDeclaration(uml::Property umlProperty, 
 
 routine createCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	create {
 		val pcmInnerDeclaration = new pcm::InnerDeclaration
@@ -85,8 +92,10 @@ routine createCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Clas
 
 routine moveCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		pcmCompositeType.innerDeclaration_CompositeDataType += pcmInnerDeclaration
@@ -95,14 +104,16 @@ routine moveCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class 
 
 reaction InnerDeclarationPropertyRemoved {
 	after element uml::Property removed from uml::Class[ownedAttribute]
-	with !affectedEObject.ownedAttributes.contains(oldValue) //validity check
+	with !affectedEObject.ownedAttributes.contains(oldValue) // validity check
 	call removeCorrespondingInnerDeclaration(oldValue, affectedEObject)
 }
 
 routine removeCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.COMPOSITE_DATATYPE__CLASS
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+			COMPOSITE_DATATYPE__CLASS
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		pcmCompositeType.innerDeclaration_CompositeDataType -= pcmInnerDeclaration
@@ -116,7 +127,8 @@ reaction InnerDeclarationPropertyDeleted {
 
 routine deleteCorrespondingInnerDeclaration(uml::Property umlProperty) {
 	match {
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		removeCorrespondenceBetween(pcmInnerDeclaration, umlProperty, TagLiterals.INNER_DECLARATION__PROPERTY)
@@ -132,7 +144,8 @@ reaction InnerDeclarationPropertyNameChanged {
 
 routine changeNameOfCorrespondingInnerDeclaration(uml::Property umlProperty, String newName) {
 	match {
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
 	}
 	update {
 		pcmInnerDeclaration.entityName = newName
@@ -141,8 +154,7 @@ routine changeNameOfCorrespondingInnerDeclaration(uml::Property umlProperty, Str
 
 reaction InnerDeclarationPropertyTypeChanged {
 	after element replaced at uml::Property[type]
-	with affectedEObject.type === newValue 
-		&& oldValue !== newValue
+	with affectedEObject.type === newValue && oldValue !== newValue
 	call propagateTypeChange(affectedEObject)
 }
 
@@ -153,8 +165,7 @@ reaction InnerDeclarationPropertyLowerChanged {
 
 reaction InnerDeclarationPropertyLowerChanged2 {
 	after attribute replaced at uml::LiteralInteger[value]
-	with affectedEObject.owner instanceof Property 
-		&& affectedEObject.value == newValue
+	with affectedEObject.owner instanceof Property && affectedEObject.value == newValue
 	call propagateTypeChange(affectedEObject.owner as Property)
 }
 
@@ -165,32 +176,35 @@ reaction InnerDeclarationPropertyUpperChanged {
 
 reaction InnerDeclarationPropertyUpperChanged2 {
 	after attribute replaced at uml::LiteralUnlimitedNatural[value]
-	with affectedEObject.owner instanceof Property 
-		&& affectedEObject.value == newValue
+	with affectedEObject.owner instanceof Property && affectedEObject.value == newValue
 	call propagateTypeChange(affectedEObject.owner as Property)
 }
 
 routine propagateTypeChange(uml::Property umlProperty) {
 	match {
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.INNER_DECLARATION__PROPERTY
-		
-		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+			INNER_DECLARATION__PROPERTY
+		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.
+			COLLECTION_DATATYPE__PROPERTY
 	}
 	update {
 		val pcmRepository = pcmInnerDeclaration.eResource.allContents.filter(Repository).head
-		val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(umlProperty.type, umlProperty.lower, umlProperty.upper, pcmRepository, userInteractor, [sourceElement, expectedType, tag |
-			getCorrespondingElement(sourceElement, expectedType, null, tag, false)
-		])
+		val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(umlProperty.type, umlProperty.lower,
+			umlProperty.upper, pcmRepository, userInteractor, [ sourceElement, expectedType, tag |
+				getCorrespondingElement(sourceElement, expectedType, null, tag, false)
+			])
 		pcmInnerDeclaration.datatype_InnerDeclaration = pcmDataType
-		
-		if(pcmOldCollectionType.isPresent && pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType(umlProperty)
+
+		if(pcmOldCollectionType.isPresent &&
+			pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType(umlProperty)
 		if(pcmDataType instanceof CollectionDataType) addCorrespondenceForCollectionType(umlProperty, pcmDataType)
 	}
 }
 
 routine removeCorrespondenceForOldCollectionType(uml::Property umlProperty) {
 	match {
-		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
+		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.
+			COLLECTION_DATATYPE__PROPERTY
 	}
 	update {
 		removeCorrespondenceBetween(pcmCollectionType, umlProperty, TagLiterals.COLLECTION_DATATYPE__PROPERTY)
@@ -200,7 +214,8 @@ routine removeCorrespondenceForOldCollectionType(uml::Property umlProperty) {
 routine addCorrespondenceForCollectionType(uml::Property umlProperty, pcm::CollectionDataType pcmCollectionType) {
 	match {
 		// one Parameter can only correspond to one CollectionDataType, but one CollectionDataType can correspond to many Parameters
-		require absence of pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
+		require absence of pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.
+			COLLECTION_DATATYPE__PROPERTY
 	}
 	update {
 		addCorrespondenceBetween(pcmCollectionType, umlProperty, TagLiterals.COLLECTION_DATATYPE__PROPERTY)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInnerDeclarationProperty.reactions
@@ -25,7 +25,7 @@ reaction InnerDeclarationPropertyInserted {
 
 routine insertCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve optional pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+		val pcmCompositeType = retrieve optional pcm::CompositeDataType corresponding to umlCompositeType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
 	}
 	update {
@@ -41,9 +41,9 @@ routine insertCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Clas
 
 routine detectOrCreateCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val pcmInnerDeclaration = retrieve optional pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+		val pcmInnerDeclaration = retrieve optional pcm::InnerDeclaration corresponding to umlProperty tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -62,9 +62,9 @@ routine detectOrCreateCorrespondingInnerDeclaration(uml::Property umlProperty, u
 
 routine addCorrespondenceForExistingInnerDeclaration(uml::Property umlProperty, pcm::InnerDeclaration pcmInnerDeclaration) {
 	match {
-		require absence of uml::Property corresponding to pcmInnerDeclaration tagged with TagLiterals.
+		require absence of uml::Property corresponding to pcmInnerDeclaration tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
-		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -74,9 +74,9 @@ routine addCorrespondenceForExistingInnerDeclaration(uml::Property umlProperty, 
 
 routine createCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+		require absence of pcm::InnerDeclaration corresponding to umlProperty tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	create {
@@ -92,9 +92,9 @@ routine createCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Clas
 
 routine moveCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -110,9 +110,9 @@ reaction InnerDeclarationPropertyRemoved {
 
 routine removeCorrespondingInnerDeclaration(uml::Property umlProperty, uml::Class umlCompositeType) {
 	match {
-		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged with TagLiterals.
+		val pcmCompositeType = retrieve pcm::CompositeDataType corresponding to umlCompositeType tagged TagLiterals.
 			COMPOSITE_DATATYPE__CLASS
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -127,7 +127,7 @@ reaction InnerDeclarationPropertyDeleted {
 
 routine deleteCorrespondingInnerDeclaration(uml::Property umlProperty) {
 	match {
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -144,7 +144,7 @@ reaction InnerDeclarationPropertyNameChanged {
 
 routine changeNameOfCorrespondingInnerDeclaration(uml::Property umlProperty, String newName) {
 	match {
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
 	}
 	update {
@@ -182,9 +182,9 @@ reaction InnerDeclarationPropertyUpperChanged2 {
 
 routine propagateTypeChange(uml::Property umlProperty) {
 	match {
-		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged with TagLiterals.
+		val pcmInnerDeclaration = retrieve pcm::InnerDeclaration corresponding to umlProperty tagged TagLiterals.
 			INNER_DECLARATION__PROPERTY
-		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.
+		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlProperty tagged TagLiterals.
 			COLLECTION_DATATYPE__PROPERTY
 	}
 	update {
@@ -203,7 +203,7 @@ routine propagateTypeChange(uml::Property umlProperty) {
 
 routine removeCorrespondenceForOldCollectionType(uml::Property umlProperty) {
 	match {
-		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.
+		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlProperty tagged TagLiterals.
 			COLLECTION_DATATYPE__PROPERTY
 	}
 	update {
@@ -214,7 +214,7 @@ routine removeCorrespondenceForOldCollectionType(uml::Property umlProperty) {
 routine addCorrespondenceForCollectionType(uml::Property umlProperty, pcm::CollectionDataType pcmCollectionType) {
 	match {
 		// one Parameter can only correspond to one CollectionDataType, but one CollectionDataType can correspond to many Parameters
-		require absence of pcm::CollectionDataType corresponding to umlProperty tagged with TagLiterals.
+		require absence of pcm::CollectionDataType corresponding to umlProperty tagged TagLiterals.
 			COLLECTION_DATATYPE__PROPERTY
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
@@ -1,7 +1,7 @@
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import org.palladiosimulator.pcm.repository.OperationInterface
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationInterface
@@ -13,7 +13,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmInterface.reactions
 //		UmlInterfaceGeneralization.reactions
 //		InterfaceConceptTest
-
 reactions: umlInterfaceReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -25,24 +24,30 @@ reaction InterfaceInserted {
 
 routine insertCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
 	}
 	update {
 		if (pcmRepository.isPresent) {
-			detectOrCreateCorrespondingInterface(umlInterface, umlPackage) 
-			moveCorrespondingInterface(umlInterface, umlPackage) 
+			detectOrCreateCorrespondingInterface(umlInterface, umlPackage)
+			moveCorrespondingInterface(umlInterface, umlPackage)
 		} else {
-			deleteCorrespondingInterface(umlInterface) 
+			deleteCorrespondingInterface(umlInterface)
 		}
 	}
 }
+
 routine detectOrCreateCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
-		val pcmInterfaceCandidate = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst[it.entityName == umlInterface.name]
+		val pcmInterfaceCandidate = pcmRepository.interfaces__Repository.filter(OperationInterface).findFirst [
+			it.entityName == umlInterface.name
+		]
 		if (pcmInterfaceCandidate !== null) {
 			addCorrespondenceForExistingInterface(umlInterface, pcmInterfaceCandidate)
 		} else {
@@ -53,7 +58,8 @@ routine detectOrCreateCorrespondingInterface(uml::Interface umlInterface, uml::P
 
 routine addCorrespondenceForExistingInterface(uml::Interface umlInterface, pcm::OperationInterface pcmInterface) {
 	match {
-		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 		require absence of uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -63,7 +69,8 @@ routine addCorrespondenceForExistingInterface(uml::Interface umlInterface, pcm::
 
 routine createCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	create {
 		val pcmInterface = new pcm::OperationInterface
@@ -76,8 +83,10 @@ routine createCorrespondingInterface(uml::Interface umlInterface, uml::Package u
 
 routine moveCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		pcmRepository.interfaces__Repository += pcmInterface
@@ -91,8 +100,10 @@ reaction InterfaceRemoved {
 
 routine removeCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		pcmRepository.interfaces__Repository -= pcmInterface
@@ -106,7 +117,8 @@ reaction InterfaceDeleted {
 
 routine deleteCorrespondingInterface(uml::Interface umlInterface) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		removeCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
@@ -116,13 +128,14 @@ routine deleteCorrespondingInterface(uml::Interface umlInterface) {
 
 reaction InterfaceRenamed {
 	after attribute replaced at uml::Interface[name]
-	with affectedEObject.name == newValue //validity check
+	with affectedEObject.name == newValue // validity check
 	call renameCorrespondingInterface(affectedEObject, newValue)
 }
 
 routine renameCorrespondingInterface(uml::Interface umlInterface, String newName) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		pcmInterface.entityName = umlInterface.name

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterface.reactions
@@ -24,7 +24,7 @@ reaction InterfaceInserted {
 
 routine insertCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
 	}
 	update {
@@ -39,9 +39,9 @@ routine insertCorrespondingInterface(uml::Interface umlInterface, uml::Package u
 
 routine detectOrCreateCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		require absence of pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -58,9 +58,9 @@ routine detectOrCreateCorrespondingInterface(uml::Interface umlInterface, uml::P
 
 routine addCorrespondenceForExistingInterface(uml::Interface umlInterface, pcm::OperationInterface pcmInterface) {
 	match {
-		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		require absence of pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		require absence of uml::Interface corresponding to pcmInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of uml::Interface corresponding to pcmInterface tagged TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	update {
 		addCorrespondenceBetween(pcmInterface, umlInterface, TagLiterals.INTERFACE_TO_INTERFACE)
@@ -69,7 +69,7 @@ routine addCorrespondenceForExistingInterface(uml::Interface umlInterface, pcm::
 
 routine createCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		require absence of pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		require absence of pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	create {
@@ -83,9 +83,9 @@ routine createCorrespondingInterface(uml::Interface umlInterface, uml::Package u
 
 routine moveCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve asserted pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -100,9 +100,9 @@ reaction InterfaceRemoved {
 
 routine removeCorrespondingInterface(uml::Interface umlInterface, uml::Package umlPackage) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -117,7 +117,7 @@ reaction InterfaceDeleted {
 
 routine deleteCorrespondingInterface(uml::Interface umlInterface) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -134,7 +134,7 @@ reaction InterfaceRenamed {
 
 routine renameCorrespondingInterface(uml::Interface umlInterface, String newName) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterfaceGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterfaceGeneralization.reactions
@@ -1,7 +1,7 @@
 import org.eclipse.uml2.uml.Interface
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize the parent interface reference of pcm::OperationInterface
@@ -11,25 +11,25 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmInterface.reactions
 //		UmlInterface.reactions
 //		InterfaceConceptTest
-
 reactions: umlInterfaceGeneralizationReactions
 in reaction to changes in uml
 execute actions in pcm
 
-
 reaction InterfaceGeneralizationAdded {
 	after element uml::Generalization inserted in uml::Interface[generalization]
-	with affectedEObject.generalizations.contains(newValue) //validity check
+	with affectedEObject.generalizations.contains(newValue) // validity check
 	call addParentInterface(affectedEObject, newValue.general)
 }
 
 routine addParentInterface(uml::Interface umlInterface, uml::Classifier umlNewParent) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val pcmNewParent = retrieve pcm::OperationInterface corresponding to umlNewParent tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val pcmNewParent = retrieve pcm::OperationInterface corresponding to umlNewParent tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
-		val isAlreadyParent = pcmInterface.parentInterfaces__Interface.contains(pcmNewParent) 
+		val isAlreadyParent = pcmInterface.parentInterfaces__Interface.contains(pcmNewParent)
 		if (!isAlreadyParent) {
 			pcmInterface.parentInterfaces__Interface += pcmNewParent
 		}
@@ -38,14 +38,16 @@ routine addParentInterface(uml::Interface umlInterface, uml::Classifier umlNewPa
 
 reaction InterfaceGeneralizationRemoved {
 	after element uml::Generalization removed from uml::Interface[generalization]
-	with !affectedEObject.generalizations.contains(oldValue) //validity check
+	with !affectedEObject.generalizations.contains(oldValue) // validity check
 	call removeParentInterface(affectedEObject, oldValue.general)
 }
 
 routine removeParentInterface(uml::Interface umlInterface, uml::Classifier umlOldParent) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val pcmOldParent = retrieve pcm::OperationInterface corresponding to umlOldParent tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val pcmOldParent = retrieve pcm::OperationInterface corresponding to umlOldParent tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		if (pcmInterface.parentInterfaces__Interface.contains(pcmOldParent))
@@ -62,10 +64,11 @@ reaction ParentInterfaceReplaced {
 
 routine replaceParentInterface(uml::Generalization gen, uml::Classifier newParent, uml::Classifier oldParent) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to gen.specific tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to gen.specific tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
-		if (oldParent === newParent) return; //nothing to do
+		if(oldParent === newParent) return; // nothing to do
 		removeParentInterface(gen.specific as Interface, oldParent)
 		if (gen.general === newParent) { // delayed validity check
 			addParentInterface(gen.specific as Interface, newParent)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterfaceGeneralization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlInterfaceGeneralization.reactions
@@ -23,9 +23,9 @@ reaction InterfaceGeneralizationAdded {
 
 routine addParentInterface(uml::Interface umlInterface, uml::Classifier umlNewParent) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val pcmNewParent = retrieve pcm::OperationInterface corresponding to umlNewParent tagged with TagLiterals.
+		val pcmNewParent = retrieve pcm::OperationInterface corresponding to umlNewParent tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -44,9 +44,9 @@ reaction InterfaceGeneralizationRemoved {
 
 routine removeParentInterface(uml::Interface umlInterface, uml::Classifier umlOldParent) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val pcmOldParent = retrieve pcm::OperationInterface corresponding to umlOldParent tagged with TagLiterals.
+		val pcmOldParent = retrieve pcm::OperationInterface corresponding to umlOldParent tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -64,7 +64,7 @@ reaction ParentInterfaceReplaced {
 
 routine replaceParentInterface(uml::Generalization gen, uml::Classifier newParent, uml::Classifier oldParent) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to gen.specific tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to gen.specific tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
@@ -27,10 +27,10 @@ reaction ProvidedRoleRealizationAdded {
 routine insertCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
 		// context check
-		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlRealization.
-			contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
+			contract tagged TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	update {
 		if (pcmComponent.isPresent && (pcmInterface.isPresent || umlRealization.contract === null) // allow 'null' for uninitialized InterfaceRealization
@@ -46,11 +46,11 @@ routine insertCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 
 routine detectOrCreateCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.
-			contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			contract tagged TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -66,9 +66,9 @@ routine detectOrCreateCorrespondingProvidedRole(uml::InterfaceRealization umlRea
 
 routine addCorrespondenceForExistingProvidedRole(uml::InterfaceRealization umlRealization, pcm::OperationProvidedRole pcmProvided) {
 	match {
-		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
-		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -78,11 +78,11 @@ routine addCorrespondenceForExistingProvidedRole(uml::InterfaceRealization umlRe
 
 routine createCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.
-			contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			contract tagged TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	create {
@@ -98,9 +98,9 @@ routine createCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 
 routine moveCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -116,9 +116,9 @@ reaction ProvidedRoleRealizationRemoved {
 
 routine removeCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -134,7 +134,7 @@ reaction ProvidedRoleRealizationDeleted {
 
 routine deleteCorrespondingProvidedRole(uml::InterfaceRealization umlRealization) {
 	match {
-		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -151,7 +151,7 @@ reaction ProvidedRoleRealizationNameChanged {
 
 routine changeNameOfCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, String newName) {
 	match {
-		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
@@ -168,10 +168,10 @@ reaction ProvidedRoleRealizationTypeChanged {
 routine changeTypeOfCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Interface umlNewInterface) {
 	match {
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlRealization.
-			implementingClassifier tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmProvided = retrieve optional pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			implementingClassifier tagged TagLiterals.IPRE__IMPLEMENTATION
+		val pcmProvided = retrieve optional pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
-		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.
+		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
@@ -48,8 +48,8 @@ routine detectOrCreateCorrespondingProvidedRole(uml::InterfaceRealization umlRea
 	match {
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.
-			contract tagged TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.contract tagged TagLiterals.
+			INTERFACE_TO_INTERFACE
 		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
@@ -80,8 +80,8 @@ routine createCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 	match {
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.
-			contract tagged TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.contract tagged TagLiterals.
+			INTERFACE_TO_INTERFACE
 		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged TagLiterals.
 			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlProvidedRoleRealization.reactions
@@ -1,7 +1,7 @@
 import org.palladiosimulator.pcm.repository.OperationProvidedRole
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationProvidedRole in an pcm::InterfaceProvidingRequiringEntity (IPRE)
@@ -14,26 +14,26 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files: 
 //		PcmProvidedRole.reactions,
 //		ProvidedRoleTest
-
 reactions: umlProvidedRoleRealizationReactions
 in reaction to changes in uml
 execute actions in pcm
 
 reaction ProvidedRoleRealizationAdded {
 	after element uml::InterfaceRealization inserted in uml::Class[interfaceRealization]
-	with affectedEObject.interfaceRealizations.contains(newValue) //validity check
+	with affectedEObject.interfaceRealizations.contains(newValue) // validity check
 	call insertCorrespondingProvidedRole(newValue, affectedEObject)
 }
 
 routine insertCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
-	match{
+	match {
 		// context check
-		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlRealization.contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlRealization.
+			contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	update {
-		if (pcmComponent.isPresent 
-			&& (pcmInterface.isPresent || umlRealization.contract === null) // allow 'null' for uninitialized InterfaceRealization
+		if (pcmComponent.isPresent && (pcmInterface.isPresent || umlRealization.contract === null) // allow 'null' for uninitialized InterfaceRealization
 		) {
 			detectOrCreateCorrespondingProvidedRole(umlRealization, umlComponent)
 			moveCorrespondingProvidedRole(umlRealization, umlComponent)
@@ -46,13 +46,16 @@ routine insertCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 
 routine detectOrCreateCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.
+			contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
-		val pcmProvidedCandidate = pcmComponent.providedRoles_InterfaceProvidingEntity
-			.filter(OperationProvidedRole).findFirst[it.providedInterface__OperationProvidedRole === pcmInterface]
+		val pcmProvidedCandidate = pcmComponent.providedRoles_InterfaceProvidingEntity.filter(OperationProvidedRole).
+			findFirst[it.providedInterface__OperationProvidedRole === pcmInterface]
 		if (pcmProvidedCandidate !== null) {
 			addCorrespondenceForExistingProvidedRole(umlRealization, pcmProvidedCandidate)
 		} else {
@@ -63,8 +66,10 @@ routine detectOrCreateCorrespondingProvidedRole(uml::InterfaceRealization umlRea
 
 routine addCorrespondenceForExistingProvidedRole(uml::InterfaceRealization umlRealization, pcm::OperationProvidedRole pcmProvided) {
 	match {
-		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
-		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		require absence of uml::InterfaceRealization corresponding to pcmProvided tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		addCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
@@ -73,9 +78,12 @@ routine addCorrespondenceForExistingProvidedRole(uml::InterfaceRealization umlRe
 
 routine createCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlRealization.
+			contract tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	create {
 		val pcmProvided = new pcm::OperationProvidedRole
@@ -90,8 +98,10 @@ routine createCorrespondingProvidedRole(uml::InterfaceRealization umlRealization
 
 routine moveCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		pcmComponent.providedRoles_InterfaceProvidingEntity += pcmProvided
@@ -100,14 +110,16 @@ routine moveCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, 
 
 reaction ProvidedRoleRealizationRemoved {
 	after element uml::InterfaceRealization removed from uml::Class[interfaceRealization]
-	with !affectedEObject.interfaceRealizations.contains(oldValue) //validity check
+	with !affectedEObject.interfaceRealizations.contains(oldValue) // validity check
 	call removeCorrespondingProvidedRole(oldValue, affectedEObject)
 }
 
 routine removeCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		umlRealization.clients -= umlComponent // isn't automatically done, when the InterfaceRealization is removed
@@ -122,7 +134,8 @@ reaction ProvidedRoleRealizationDeleted {
 
 routine deleteCorrespondingProvidedRole(uml::InterfaceRealization umlRealization) {
 	match {
-		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		removeCorrespondenceBetween(pcmProvided, umlRealization, TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION)
@@ -137,8 +150,9 @@ reaction ProvidedRoleRealizationNameChanged {
 }
 
 routine changeNameOfCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, String newName) {
-	match{
-		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
+	match {
+		val pcmProvided = retrieve pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
 	}
 	update {
 		pcmProvided.entityName = newName
@@ -152,22 +166,27 @@ reaction ProvidedRoleRealizationTypeChanged {
 }
 
 routine changeTypeOfCorrespondingProvidedRole(uml::InterfaceRealization umlRealization, uml::Interface umlNewInterface) {
-	match{
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlRealization.implementingClassifier tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmProvided = retrieve optional pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.PROVIDED_ROLE__INTERFACE_REALIZATION
-		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+	match {
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlRealization.
+			implementingClassifier tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val pcmProvided = retrieve optional pcm::OperationProvidedRole corresponding to umlRealization tagged with TagLiterals.
+			PROVIDED_ROLE__INTERFACE_REALIZATION
+		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		if (!pcmProvided.isPresent && pcmNewInterface.isPresent) {
-			createCorrespondingProvidedRole(umlRealization, umlRealization.implementingClassifier as org.eclipse.uml2.uml.Class)
+			createCorrespondingProvidedRole(umlRealization,
+				umlRealization.implementingClassifier as org.eclipse.uml2.uml.Class)
 		} else if (pcmProvided.isPresent && pcmNewInterface.isPresent) {
 			pcmProvided.get.providedInterface__OperationProvidedRole = pcmNewInterface.get
-		} else if(pcmProvided.isPresent && umlNewInterface === null) {
-			//might be a transitional state -> keep correspondence, but synchronize 'null'
+		} else if (pcmProvided.isPresent && umlNewInterface === null) {
+			// might be a transitional state -> keep correspondence, but synchronize 'null'
 			pcmProvided.get.providedInterface__OperationProvidedRole = null
 		} else {
-			logger.warn("The general-type of a uml::InterfaceRealization in a pcm::OperationProvidedRole ~ uml::InterfaceRealization correspondence"
-						+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationProvidedRole will be deleted.")
+			logger.warn(
+				"The general-type of a uml::InterfaceRealization in a pcm::OperationProvidedRole ~ uml::InterfaceRealization correspondence" +
+					"has been set to a non-OperationInterface type. This is against convention and the corresponding OperationProvidedRole will be deleted.")
 			deleteCorrespondingProvidedRole(umlRealization)
 		}
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
@@ -69,10 +69,8 @@ routine detectOrCreateCorrespondingRegularParameter(uml::Parameter umlParam, uml
 
 routine addCorrespondenceForExistingRegularParameter(uml::Parameter umlParameter, pcm::Parameter pcmParameter) {
 	match {
-		require absence of pcm::Parameter corresponding to umlParameter tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
-		require absence of uml::Parameter corresponding to pcmParameter tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		require absence of pcm::Parameter corresponding to umlParameter tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
+		require absence of uml::Parameter corresponding to pcmParameter tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		addCorrespondenceBetween(pcmParameter, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
@@ -85,8 +83,7 @@ routine createCorrespondingRegularParameter(uml::Parameter umlParameter, uml::Op
 			SIGNATURE__OPERATION
 		require absence of pcm::OperationSignature corresponding to umlParameter tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		require absence of pcm::Parameter corresponding to umlParameter tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		require absence of pcm::Parameter corresponding to umlParameter tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	create {
 		val pcmParameter = new pcm::Parameter
@@ -104,8 +101,7 @@ routine moveCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operatio
 			SIGNATURE__OPERATION
 		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		pcmSignature.parameters__OperationSignature += pcmParam
@@ -124,8 +120,7 @@ routine removeCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operat
 			SIGNATURE__OPERATION
 		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		pcmSignature.parameters__OperationSignature -= pcmParam
@@ -141,8 +136,7 @@ routine deleteCorrespondingRegularParameter(uml::Parameter umlParam) {
 	match {
 		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		removeCorrespondenceBetween(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER)
@@ -160,8 +154,7 @@ routine changeNameOfCorrespondingRegularParameter(uml::Parameter umlParam, Strin
 	match {
 		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.
-			PARAMETER__REGULAR_PARAMETER
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		pcmParam.parameterName = newName

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
@@ -2,7 +2,7 @@ import org.palladiosimulator.pcm.repository.ParameterModifier
 import tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize an uml::Parameter corresponding to 
@@ -14,7 +14,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmParameter.reactions
 //		UmlReturnAndRegularParameterType.reactions
 //		ParameterConceptTest
-
 reactions: umlRegularParameterReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -27,10 +26,12 @@ reaction RegularParameterInserted {
 
 routine insertCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
-		
-		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		if (pcmSignature.isPresent) {
@@ -38,20 +39,25 @@ routine insertCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operat
 			moveCorrespondingRegularParameter(umlParam, umlOperation)
 		} else {
 			// not a synchronized context -> delete corresponding parameter if necessary
-			deleteCorrespondingRegularParameter(umlParam)				
+			deleteCorrespondingRegularParameter(umlParam)
 		}
 	}
 }
 
 routine detectOrCreateCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION	
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
-		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		if (!pcmParam.isPresent) {
-			val pcmParamCandidate = pcmSignature.parameters__OperationSignature.findFirst[it.parameterName == umlParam.name]
+			val pcmParamCandidate = pcmSignature.parameters__OperationSignature.findFirst [
+				it.parameterName == umlParam.name
+			]
 			if (pcmParamCandidate !== null) {
 				addCorrespondenceForExistingRegularParameter(umlParam, pcmParamCandidate)
 			} else {
@@ -63,8 +69,10 @@ routine detectOrCreateCorrespondingRegularParameter(uml::Parameter umlParam, uml
 
 routine addCorrespondenceForExistingRegularParameter(uml::Parameter umlParameter, pcm::Parameter pcmParameter) {
 	match {
-		require absence of pcm::Parameter corresponding to umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
-		require absence of uml::Parameter corresponding to pcmParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		require absence of pcm::Parameter corresponding to umlParameter tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
+		require absence of uml::Parameter corresponding to pcmParameter tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		addCorrespondenceBetween(pcmParameter, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
@@ -73,9 +81,12 @@ routine addCorrespondenceForExistingRegularParameter(uml::Parameter umlParameter
 
 routine createCorrespondingRegularParameter(uml::Parameter umlParameter, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION	
-		require absence of pcm::OperationSignature corresponding to umlParameter tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
-		require absence of pcm::Parameter corresponding to umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlParameter tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		require absence of pcm::Parameter corresponding to umlParameter tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	create {
 		val pcmParameter = new pcm::Parameter
@@ -83,15 +94,18 @@ routine createCorrespondingRegularParameter(uml::Parameter umlParameter, uml::Op
 	update {
 		pcmParameter.parameterName = umlParameter.name
 		addCorrespondenceBetween(pcmParameter, umlParameter, TagLiterals.PARAMETER__REGULAR_PARAMETER)
-		// type propagation is done in UmlReturnAndRegularParameterType.reactions
+	// type propagation is done in UmlReturnAndRegularParameterType.reactions
 	}
 }
 
 routine moveCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION	
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		pcmSignature.parameters__OperationSignature += pcmParam
@@ -106,9 +120,12 @@ reaction RegularParameterRemoved {
 
 routine removeCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION	
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		pcmSignature.parameters__OperationSignature -= pcmParam
@@ -122,8 +139,10 @@ reaction RegularParameterDeleted {
 
 routine deleteCorrespondingRegularParameter(uml::Parameter umlParam) {
 	match {
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		removeCorrespondenceBetween(pcmParam, umlParam, TagLiterals.PARAMETER__REGULAR_PARAMETER)
@@ -132,22 +151,24 @@ routine deleteCorrespondingRegularParameter(uml::Parameter umlParam) {
 }
 
 reaction RegularParameterNameChanged {
-	after attribute replaced at uml::Parameter[name]	
+	after attribute replaced at uml::Parameter[name]
 	with affectedEObject.name == newValue // validity check
 	call changeNameOfCorrespondingRegularParameter(affectedEObject, newValue)
 }
 
 routine changeNameOfCorrespondingRegularParameter(uml::Parameter umlParam, String newName) {
 	match {
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER	
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		pcmParam.parameterName = newName
 	}
 }
 
-reaction RegularParameterDirectionChanged{
+reaction RegularParameterDirectionChanged {
 	after attribute replaced at uml::Parameter[direction]
 	with affectedEObject.direction === newValue
 	call changeModifierOfCorrespondingRegularParameter(affectedEObject)
@@ -156,7 +177,8 @@ reaction RegularParameterDirectionChanged{
 // pcm::ParameterDirectionKind import can't be resolved for some reason -> retrieve from element
 routine changeModifierOfCorrespondingRegularParameter(uml::Parameter umlParameter) {
 	match {
-		val pcmParameter = retrieve pcm::Parameter corresponding to umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
+		val pcmParameter = retrieve pcm::Parameter corresponding to umlParameter tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
 		var matchingModifier = ParameterModifier.NONE

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRegularParameter.reactions
@@ -26,11 +26,11 @@ reaction RegularParameterInserted {
 
 routine insertCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -46,11 +46,11 @@ routine insertCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operat
 
 routine detectOrCreateCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+		val pcmParam = retrieve optional pcm::Parameter corresponding to umlParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -69,9 +69,9 @@ routine detectOrCreateCorrespondingRegularParameter(uml::Parameter umlParam, uml
 
 routine addCorrespondenceForExistingRegularParameter(uml::Parameter umlParameter, pcm::Parameter pcmParameter) {
 	match {
-		require absence of pcm::Parameter corresponding to umlParameter tagged with TagLiterals.
+		require absence of pcm::Parameter corresponding to umlParameter tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
-		require absence of uml::Parameter corresponding to pcmParameter tagged with TagLiterals.
+		require absence of uml::Parameter corresponding to pcmParameter tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -81,11 +81,11 @@ routine addCorrespondenceForExistingRegularParameter(uml::Parameter umlParameter
 
 routine createCorrespondingRegularParameter(uml::Parameter umlParameter, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of pcm::OperationSignature corresponding to umlParameter tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlParameter tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		require absence of pcm::Parameter corresponding to umlParameter tagged with TagLiterals.
+		require absence of pcm::Parameter corresponding to umlParameter tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	create {
@@ -100,11 +100,11 @@ routine createCorrespondingRegularParameter(uml::Parameter umlParameter, uml::Op
 
 routine moveCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -120,11 +120,11 @@ reaction RegularParameterRemoved {
 
 routine removeCorrespondingRegularParameter(uml::Parameter umlParam, uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -139,9 +139,9 @@ reaction RegularParameterDeleted {
 
 routine deleteCorrespondingRegularParameter(uml::Parameter umlParam) {
 	match {
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -158,9 +158,9 @@ reaction RegularParameterNameChanged {
 
 routine changeNameOfCorrespondingRegularParameter(uml::Parameter umlParam, String newName) {
 	match {
-		require absence of pcm::OperationSignature corresponding to umlParam tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlParam tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged with TagLiterals.
+		val pcmParam = retrieve pcm::Parameter corresponding to umlParam tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {
@@ -177,7 +177,7 @@ reaction RegularParameterDirectionChanged {
 // pcm::ParameterDirectionKind import can't be resolved for some reason -> retrieve from element
 routine changeModifierOfCorrespondingRegularParameter(uml::Parameter umlParameter) {
 	match {
-		val pcmParameter = retrieve pcm::Parameter corresponding to umlParameter tagged with TagLiterals.
+		val pcmParameter = retrieve pcm::Parameter corresponding to umlParameter tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -59,9 +59,9 @@ reaction RepositoryOrSystemPackageInserted {
 
 routine insertCorrespondingRepositoryOrSystem(uml::Package umlPackage, uml::Package umlParentPackage) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmSystem = retrieve optional pcm::System corresponding to umlPackage tagged with TagLiterals.
+		val pcmSystem = retrieve optional pcm::System corresponding to umlPackage tagged TagLiterals.
 			SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
@@ -98,7 +98,7 @@ routine userDisambiguateRepositoryOrSystemCreation(uml::Package umlPkg, uml::Pac
 
 routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.
+		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
 		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.
 			REPOSITORY with umlPkg.isPackageFor(foundRepository)
@@ -164,7 +164,7 @@ routine createCorrespondingRepository(uml::Package umlPkg, uml::Package umlParen
 
 routine createOrFindCorrespondingSystem(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		require absence of pcm::System corresponding to umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		require absence of pcm::System corresponding to umlPkg tagged TagLiterals.SYSTEM__SYSTEM_PACKAGE
 		val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM with umlPkg.
 			isPackageFor(foundSystem)
 	}
@@ -238,7 +238,7 @@ routine deletePackage(uml::Package umlPackage) {
 
 routine deleteCorrespondingRepository(uml::Package umlRepositoryPkg) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlRepositoryPkg tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlRepositoryPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
@@ -249,7 +249,7 @@ routine deleteCorrespondingRepository(uml::Package umlRepositoryPkg) {
 
 routine deleteCorrespondingSystem(uml::Package umlSystemPkg) {
 	match {
-		val pcmSystem = retrieve pcm::System corresponding to umlSystemPkg tagged with TagLiterals.
+		val pcmSystem = retrieve pcm::System corresponding to umlSystemPkg tagged TagLiterals.
 			SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
@@ -266,9 +266,9 @@ reaction RepositoryOrSystemPackageRenamed {
 
 routine renameCorrespondingRepositoryOrSystem(uml::Package umlPkg, String newName) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPkg tagged with TagLiterals.
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmSystem = retrieve optional pcm::System corresponding to umlPkg tagged with TagLiterals.
+		val pcmSystem = retrieve optional pcm::System corresponding to umlPkg tagged TagLiterals.
 			SYSTEM__SYSTEM_PACKAGE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -98,8 +98,7 @@ routine userDisambiguateRepositoryOrSystemCreation(uml::Package umlPkg, uml::Pac
 
 routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.
-			REPOSITORY_TO_REPOSITORY_PACKAGE
+		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.
 			REPOSITORY with umlPkg.isPackageFor(foundRepository)
 	}
@@ -249,8 +248,7 @@ routine deleteCorrespondingRepository(uml::Package umlRepositoryPkg) {
 
 routine deleteCorrespondingSystem(uml::Package umlSystemPkg) {
 	match {
-		val pcmSystem = retrieve pcm::System corresponding to umlSystemPkg tagged TagLiterals.
-			SYSTEM__SYSTEM_PACKAGE
+		val pcmSystem = retrieve pcm::System corresponding to umlSystemPkg tagged TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
 		removeCorrespondenceBetween(pcmSystem, umlSystemPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
@@ -268,8 +266,7 @@ routine renameCorrespondingRepositoryOrSystem(uml::Package umlPkg, String newNam
 	match {
 		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmSystem = retrieve optional pcm::System corresponding to umlPkg tagged TagLiterals.
-			SYSTEM__SYSTEM_PACKAGE
+		val pcmSystem = retrieve optional pcm::System corresponding to umlPkg tagged TagLiterals.SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
 		if (pcmRepository.isPresent)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -25,24 +25,23 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //	Related files:
 //		PcmRepository.reactions, PcmSystem.reactions
 //		RepositoryConceptTest, SystemConceptTest
-
 reactions: umlRepositoryAndSystemPackageReactions
 in reaction to changes in uml
 execute actions in pcm
 
 reaction UmlModelCreated {
-    after element uml::Model inserted as root
-    call ensureModelCorrespondenceExists(newValue)
+	after element uml::Model inserted as root
+	call ensureModelCorrespondenceExists(newValue)
 }
 
 routine ensureModelCorrespondenceExists(uml::Model newModel) {
-    match {
-        val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
-        check !alreadyCorrespondingModels.contains(newModel)
-    }
-    update {
-        addCorrespondenceBetween(UMLPackage.Literals.MODEL, newModel)
-    }
+	match {
+		val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
+		check !alreadyCorrespondingModels.contains(newModel)
+	}
+	update {
+		addCorrespondenceBetween(UMLPackage.Literals.MODEL, newModel)
+	}
 }
 
 reaction RepositoryOrSystemPackageInserted {
@@ -60,16 +59,18 @@ reaction RepositoryOrSystemPackageInserted {
 
 routine insertCorrespondingRepositoryOrSystem(uml::Package umlPackage, uml::Package umlParentPackage) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmSystem = retrieve optional pcm::System corresponding to umlPackage tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPackage tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val pcmSystem = retrieve optional pcm::System corresponding to umlPackage tagged with TagLiterals.
+			SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
-		if(!PcmUmlClassHelper.isContainedInRepositoryHierarchy(umlPackage, [sourceElement, expectedType, tag |
+		if (!PcmUmlClassHelper.isContainedInRepositoryHierarchy(umlPackage, [ sourceElement, expectedType, tag |
 			getCorrespondingElement(sourceElement, expectedType, null, tag, false)
 		])) {
 			if (!pcmRepository.isPresent && !pcmSystem.isPresent)
 				userDisambiguateRepositoryOrSystemCreation(umlPackage, umlParentPackage)
-			//no move-operation necessary since both repository and system are root elements
+		// no move-operation necessary since both repository and system are root elements
 		} else {
 			// nested component repositories and component based systems are not allowed
 			deleteCorrespondingRepository(umlPackage)
@@ -80,50 +81,51 @@ routine insertCorrespondingRepositoryOrSystem(uml::Package umlPackage, uml::Pack
 
 routine userDisambiguateRepositoryOrSystemCreation(uml::Package umlPkg, uml::Package umlParentPkg) {
 	update {
-		val pcmElementType = userInteractor.singleSelectionDialogBuilder
-				.message(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REQUEST)
-				.choices(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__OPTIONS)
-				.windowModality(WindowModality.MODAL)
-				.startInteraction
+		val pcmElementType = userInteractor.singleSelectionDialogBuilder.message(
+			DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REQUEST).choices(
+			DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__OPTIONS).windowModality(WindowModality.MODAL).
+			startInteraction
 		switch (pcmElementType) {
 			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__REPOSITORY:
-					createOrFindCorrespondingRepository(umlPkg, umlParentPkg)
+				createOrFindCorrespondingRepository(umlPkg, umlParentPkg)
 			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORY_SYSTEM__SYSTEM:
-					createOrFindCorrespondingSystem(umlPkg, umlParentPkg)
-			default: return //do nothing
+				createOrFindCorrespondingSystem(umlPkg, umlParentPkg)
+			default:
+				return // do nothing
 		}
 	}
 }
 
 routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package umlParentPkg) {
-    match {
-        require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-        val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.REPOSITORY
-           with umlPkg.isPackageFor(foundRepository)
-    }
-    update {
-        if (foundRepository.isPresent) {
-            ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, umlPkg)
-            addRepositoryCorrespondence(foundRepository.get, umlPkg)
-        } else {
-            createCorrespondingRepository(umlPkg, umlParentPkg)
-        }
-    }
+	match {
+		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.
+			REPOSITORY with umlPkg.isPackageFor(foundRepository)
+	}
+	update {
+		if (foundRepository.isPresent) {
+			ensureFirstCaseUpperCaseRepositoryNaming(foundRepository.get, umlPkg)
+			addRepositoryCorrespondence(foundRepository.get, umlPkg)
+		} else {
+			createCorrespondingRepository(umlPkg, umlParentPkg)
+		}
+	}
 }
 
 routine ensureFirstCaseUpperCaseRepositoryNaming(pcm::Repository pcmRepository, uml::Package umlPackage) {
-    match {
-       check pcmRepository.entityName == umlPackage.name
-    }
-    update {
+	match {
+		check pcmRepository.entityName == umlPackage.name
+	}
+	update {
 		pcmRepository.entityName = umlPackage.name.toFirstUpper
-    }
+	}
 }
 
 routine addRepositoryCorrespondence(pcm::Repository pcmRepository, uml::Package umlPkg) {
-    update {
-        addCorrespondenceBetween(pcmRepository, umlPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
-    }
+	update {
+		addCorrespondenceBetween(pcmRepository, umlPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
+	}
 }
 
 routine createCorrespondingRepository(uml::Package umlPkg, uml::Package umlParentPkg) {
@@ -136,21 +138,22 @@ routine createCorrespondingRepository(uml::Package umlPkg, uml::Package umlParen
 		addCorrespondenceBetween(pcmRepository, RepositoryPackage.Literals.REPOSITORY)
 		val fileExtension = DefaultLiterals.PCM_REPOSITORY_EXTENSION
 
-		var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction
+		var relativeModelPath = userInteractor.textInputDialogBuilder.message(
+			DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction
 		if (relativeModelPath.nullOrEmpty) {
 			relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.PCM_REPOSITORY_FILE_NAME;
 		}
 
-		//check if a model at the specified path already exists; if so, append a number
-		//remove extension for now, so that it is easier to add a suffix if necessary
+		// check if a model at the specified path already exists; if so, append a number
+		// remove extension for now, so that it is easier to add a suffix if necessary
 		if (relativeModelPath.endsWith(fileExtension)) {
 			relativeModelPath.substring(0, relativeModelPath.length - fileExtension.length)
 		}
 		var uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + fileExtension)
-		while(URIUtil.existsResourceAtUri(uri)) {
+		while (URIUtil.existsResourceAtUri(uri)) {
 			uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + "-2" + fileExtension)
 		}
-		//append file extension now
+		// append file extension now
 		if (!relativeModelPath.endsWith(fileExtension)) {
 			relativeModelPath += fileExtension
 		}
@@ -160,24 +163,24 @@ routine createCorrespondingRepository(uml::Package umlPkg, uml::Package umlParen
 }
 
 routine createOrFindCorrespondingSystem(uml::Package umlPkg, uml::Package umlParentPkg) {
-    match {
-        require absence of pcm::System corresponding to umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
-        val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM
-            with umlPkg.isPackageFor(foundSystem)
-    }
-    update {
-        if (foundSystem.isPresent) {
-            addSystemCorrespondence(foundSystem.get, umlPkg)
-        } else {
-            createCorrespondingSystem(umlPkg, umlParentPkg)
-        }
-    }
+	match {
+		require absence of pcm::System corresponding to umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM with umlPkg.
+			isPackageFor(foundSystem)
+	}
+	update {
+		if (foundSystem.isPresent) {
+			addSystemCorrespondence(foundSystem.get, umlPkg)
+		} else {
+			createCorrespondingSystem(umlPkg, umlParentPkg)
+		}
+	}
 }
 
 routine addSystemCorrespondence(pcm::System pcmSystem, uml::Package umlPkg) {
-    update {
-        addCorrespondenceBetween(pcmSystem, umlPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
-    }
+	update {
+		addCorrespondenceBetween(pcmSystem, umlPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
+	}
 }
 
 routine createCorrespondingSystem(uml::Package umlPkg, uml::Package umlParentPkg) {
@@ -187,23 +190,24 @@ routine createCorrespondingSystem(uml::Package umlPkg, uml::Package umlParentPkg
 	update {
 		pcmSystem.entityName = umlPkg.name?.toFirstUpper
 		addCorrespondenceBetween(pcmSystem, umlPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
-		addCorrespondenceBetween(pcmSystem,  SystemPackage.Literals.SYSTEM)
+		addCorrespondenceBetween(pcmSystem, SystemPackage.Literals.SYSTEM)
 		val fileExtension = DefaultLiterals.PCM_SYSTEM_EXTENSION
-		var relativeModelPath = userInteractor.textInputDialogBuilder.message(DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction
+		var relativeModelPath = userInteractor.textInputDialogBuilder.message(
+			DefaultLiterals.INPUT_REQUEST_NEW_MODEL_PATH).startInteraction
 		if (relativeModelPath.nullOrEmpty) {
 			relativeModelPath = DefaultLiterals.MODEL_DIRECTORY + "/" + DefaultLiterals.PCM_SYSTEM_FILE_NAME;
 		}
 
-		//check if a model at the specified path already exists; if so, append a number
-		//remove extension for now, so that it is easier to add a suffix if necessary
+		// check if a model at the specified path already exists; if so, append a number
+		// remove extension for now, so that it is easier to add a suffix if necessary
 		if (relativeModelPath.endsWith(fileExtension)) {
 			relativeModelPath.substring(0, relativeModelPath.length - fileExtension.length)
 		}
 		var uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + fileExtension)
-		while(URIUtil.existsResourceAtUri(uri)) {
+		while (URIUtil.existsResourceAtUri(uri)) {
 			uri = PersistenceHelper.getURIFromSourceProjectFolder(umlPkg, relativeModelPath + "-2" + fileExtension)
 		}
-		//append file extension now
+		// append file extension now
 		if (!relativeModelPath.endsWith(fileExtension)) {
 			relativeModelPath += fileExtension
 		}
@@ -234,7 +238,8 @@ routine deletePackage(uml::Package umlPackage) {
 
 routine deleteCorrespondingRepository(uml::Package umlRepositoryPkg) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlRepositoryPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		val pcmRepository = retrieve pcm::Repository corresponding to umlRepositoryPkg tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
 		removeCorrespondenceBetween(pcmRepository, umlRepositoryPkg, TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE)
@@ -244,7 +249,8 @@ routine deleteCorrespondingRepository(uml::Package umlRepositoryPkg) {
 
 routine deleteCorrespondingSystem(uml::Package umlSystemPkg) {
 	match {
-		val pcmSystem = retrieve pcm::System corresponding to umlSystemPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		val pcmSystem = retrieve pcm::System corresponding to umlSystemPkg tagged with TagLiterals.
+			SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
 		removeCorrespondenceBetween(pcmSystem, umlSystemPkg, TagLiterals.SYSTEM__SYSTEM_PACKAGE)
@@ -260,8 +266,10 @@ reaction RepositoryOrSystemPackageRenamed {
 
 routine renameCorrespondingRepositoryOrSystem(uml::Package umlPkg, String newName) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmSystem = retrieve optional pcm::System corresponding to umlPkg tagged with TagLiterals.SYSTEM__SYSTEM_PACKAGE
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val pcmSystem = retrieve optional pcm::System corresponding to umlPkg tagged with TagLiterals.
+			SYSTEM__SYSTEM_PACKAGE
 	}
 	update {
 		if (pcmRepository.isPresent)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
@@ -55,10 +55,8 @@ routine insertCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package
 	match {
 		val pcmRepository = retrieve optional pcm::Repository corresponding to umlParentPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.
-			REPOSITORY_TO_CONTRACTS_PACKAGE
-		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.
-			REPOSITORY_TO_DATATYPES_PACKAGE
+		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
+		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
 		if (pcmRepository.isPresent) {
@@ -92,8 +90,7 @@ routine addCorrespondenceForExistingRepositoryComponent(uml::Package umlPkg, pcm
 	match {
 		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
-		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.
-			REPOSITORY_COMPONENT__PACKAGE
+		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		addCorrespondenceBetween(pcmComponent, umlPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
@@ -32,7 +32,7 @@ reaction RepositoryComponentPackageInserted {
 routine detectDatatypesSubpackage(uml::Package umlPackage, uml::Package umlParentPackage) {
 	match {
 		check umlPackage.name == DefaultLiterals.DATATYPES_PACKAGE_NAME
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
@@ -43,7 +43,7 @@ routine detectDatatypesSubpackage(uml::Package umlPackage, uml::Package umlParen
 routine detectContractsSubpackage(uml::Package umlPackage, uml::Package umlParentPackage) {
 	match {
 		check umlPackage.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
@@ -53,11 +53,11 @@ routine detectContractsSubpackage(uml::Package umlPackage, uml::Package umlParen
 
 routine insertCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlParentPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.
+		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_TO_CONTRACTS_PACKAGE
-		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.
+		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
@@ -73,9 +73,9 @@ routine insertCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package
 
 routine detectOrCreateCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -90,9 +90,9 @@ routine detectOrCreateCorrespondingRepositoryComponent(uml::Package umlPkg, uml:
 
 routine addCorrespondenceForExistingRepositoryComponent(uml::Package umlPkg, pcm::RepositoryComponent pcmComponent) {
 	match {
-		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
-		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.
+		require absence of uml::Package corresponding to pcmComponent tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -151,9 +151,9 @@ routine createCorrespondingSubSystem(uml::Package umlPkg, uml::Package umlParent
 
 routine moveCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -169,9 +169,9 @@ reaction RepositoryComponentPackageRemoved {
 
 routine removeCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged TagLiterals.
 			REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -186,7 +186,7 @@ reaction PackageDeleted {
 
 routine deleteCorrespondingRepositoryComponent(uml::Package umlComponentPkg) {
 	match {
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlComponentPkg tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlComponentPkg tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
@@ -203,7 +203,7 @@ reaction RepositoryComponentPackageRenamed {
 
 routine changeNameOfCorrespondingRepositoryComponent(uml::Package umlPkg, String newName) {
 	match {
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged TagLiterals.
 			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryComponentPackage.reactions
@@ -2,7 +2,7 @@ import tools.vitruv.applications.pcmumlclass.DefaultLiterals
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import static extension tools.vitruv.applications.pcmumlclass.PcmUmlClassHelper.isPackageFor
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::RepositoryComponent 
@@ -16,7 +16,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmRepositoryComponent.reactions
 //		UmlIPREClassReactions.reactions, UmlIPREConstructorOperation.reactions
 //		RepositoryComponentConceptTest
-
 reactions: umlRepositoryComponentPackageReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -33,7 +32,8 @@ reaction RepositoryComponentPackageInserted {
 routine detectDatatypesSubpackage(uml::Package umlPackage, uml::Package umlParentPackage) {
 	match {
 		check umlPackage.name == DefaultLiterals.DATATYPES_PACKAGE_NAME
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
 		addCorrespondenceBetween(umlPackage, pcmRepository, TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE)
@@ -43,7 +43,8 @@ routine detectDatatypesSubpackage(uml::Package umlPackage, uml::Package umlParen
 routine detectContractsSubpackage(uml::Package umlPackage, uml::Package umlParentPackage) {
 	match {
 		check umlPackage.name == DefaultLiterals.CONTRACTS_PACKAGE_NAME
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPackage tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
 	}
 	update {
 		addCorrespondenceBetween(umlPackage, pcmRepository, TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE)
@@ -52,9 +53,12 @@ routine detectContractsSubpackage(uml::Package umlPackage, uml::Package umlParen
 
 routine insertCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		val pcmRepository = retrieve optional pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_CONTRACTS_PACKAGE
-		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.REPOSITORY_TO_DATATYPES_PACKAGE
+		val pcmRepository = retrieve optional pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_TO_CONTRACTS_PACKAGE
+		require absence of pcm::Repository corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_TO_DATATYPES_PACKAGE
 	}
 	update {
 		if (pcmRepository.isPresent) {
@@ -69,8 +73,10 @@ routine insertCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package
 
 routine detectOrCreateCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		val pcmComponentCandidate = pcmRepository.components__Repository.findFirst[umlPkg.isPackageFor(it)]
@@ -83,9 +89,11 @@ routine detectOrCreateCorrespondingRepositoryComponent(uml::Package umlPkg, uml:
 }
 
 routine addCorrespondenceForExistingRepositoryComponent(uml::Package umlPkg, pcm::RepositoryComponent pcmComponent) {
-	match{
-		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
-		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+	match {
+		require absence of pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
+		require absence of uml::Package corresponding to pcmComponent tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		addCorrespondenceBetween(pcmComponent, umlPkg, TagLiterals.REPOSITORY_COMPONENT__PACKAGE)
@@ -94,19 +102,19 @@ routine addCorrespondenceForExistingRepositoryComponent(uml::Package umlPkg, pcm
 
 routine userDisambiguateCorrespondingRepositoryComponentType(uml::Package umlPkg, uml::Package umlParentPkg) {
 	update {
-		val componentType = userInteractor.singleSelectionDialogBuilder
-				.message(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__REQUEST)
-				.choices(DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__OPTIONS)
-				.startInteraction
-				
+		val componentType = userInteractor.singleSelectionDialogBuilder.message(
+			DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__REQUEST).choices(
+			DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__OPTIONS).startInteraction
+
 		switch (componentType) {
-			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__BASIC_COMPONENT: 
+			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__BASIC_COMPONENT:
 				createCorrespondingBasicComponent(umlPkg, umlParentPkg)
 			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__COMPOSITE_COMPONENT:
 				createCorrespondingCompositeComponent(umlPkg, umlParentPkg)
 			case DefaultLiterals.USER_DISAMBIGUATE_REPOSITORYCOMPONENT_TYPE__SUB_SYSTEM:
 				createCorrespondingSubSystem(umlPkg, umlParentPkg)
-			default: return //do nothing
+			default:
+				return // do nothing
 		}
 	}
 }
@@ -143,8 +151,10 @@ routine createCorrespondingSubSystem(uml::Package umlPkg, uml::Package umlParent
 
 routine moveCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		pcmRepository.components__Repository += pcmComponent
@@ -159,8 +169,10 @@ reaction RepositoryComponentPackageRemoved {
 
 routine removeCorrespondingRepositoryComponent(uml::Package umlPkg, uml::Package umlParentPkg) {
 	match {
-		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val pcmRepository = retrieve pcm::Repository corresponding to umlParentPkg tagged with TagLiterals.
+			REPOSITORY_TO_REPOSITORY_PACKAGE
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		pcmRepository.components__Repository -= pcmComponent
@@ -174,7 +186,8 @@ reaction PackageDeleted {
 
 routine deleteCorrespondingRepositoryComponent(uml::Package umlComponentPkg) {
 	match {
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlComponentPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlComponentPkg tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		removeCorrespondenceBetween(pcmComponent, umlComponentPkg)
@@ -190,7 +203,8 @@ reaction RepositoryComponentPackageRenamed {
 
 routine changeNameOfCorrespondingRepositoryComponent(uml::Package umlPkg, String newName) {
 	match {
-		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.REPOSITORY_COMPONENT__PACKAGE
+		val pcmComponent = retrieve pcm::RepositoryComponent corresponding to umlPkg tagged with TagLiterals.
+			REPOSITORY_COMPONENT__PACKAGE
 	}
 	update {
 		pcmComponent.entityName = newName?.toFirstUpper

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
@@ -3,7 +3,7 @@ import org.palladiosimulator.pcm.repository.OperationRequiredRole
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import org.eclipse.uml2.uml.Interface
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationRequiredRole of a pcm::InterfaceProvidingRequiringEntity (IPRE)
@@ -13,7 +13,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmRequiredRole.reactions, 
 //		UmlRequiredRoleProperty.reactions,
 //		RequiredRoleConceptTest
-
 reactions: umlRequiredRoleParameterReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -26,13 +25,15 @@ reaction RequiredRoleParameterInserted {
 
 routine parameter_insertCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
 	match {
-		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.INTERFACE_TO_INTERFACE 
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
+		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlParameter.
+			type tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
-		if (pcmComponent.isPresent 
-			&& (pcmInterface.isPresent || umlParameter.type === null) // allow 'null' for uninitialized Generalizations
+		if (pcmComponent.isPresent && (pcmInterface.isPresent || umlParameter.type === null) // allow 'null' for uninitialized Generalizations
 		) {
 			parameter_detectOrCreateCorrespondingRequiredRole(umlParameter, umlConstructor)
 			parameter_moveCorrespondingRequiredRole(umlParameter, umlConstructor)
@@ -45,15 +46,19 @@ routine parameter_insertCorrespondingRequiredRole(uml::Parameter umlParameter, u
 
 routine parameter_detectOrCreateCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
 		if (!pcmRequired.isPresent) {
-			val pcmRequiredCandidate = pcmComponent.requiredRoles_InterfaceRequiringEntity
-				.filter(OperationRequiredRole)
-				.findFirst[it.requiredInterface__OperationRequiredRole === pcmInterface && it.entityName == umlParameter.name]
+			val pcmRequiredCandidate = pcmComponent.requiredRoles_InterfaceRequiringEntity.filter(
+				OperationRequiredRole).findFirst [
+				it.requiredInterface__OperationRequiredRole === pcmInterface && it.entityName == umlParameter.name
+			]
 			if (pcmRequiredCandidate !== null) {
 				parameter_addCorrespondenceForExistingRequiredRole(umlParameter, pcmRequiredCandidate)
 			} else {
@@ -64,9 +69,10 @@ routine parameter_detectOrCreateCorrespondingRequiredRole(uml::Parameter umlPara
 }
 
 routine parameter_addCorrespondenceForExistingRequiredRole(uml::Parameter umlParameter, pcm::OperationRequiredRole pcmRequired) {
-	match{
+	match {
 		require absence of uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
 		addCorrespondenceBetween(pcmRequired, umlParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
@@ -74,10 +80,13 @@ routine parameter_addCorrespondenceForExistingRequiredRole(uml::Parameter umlPar
 }
 
 routine parameter_createCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
-	match{
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+	match {
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	create {
 		val pcmRequired = new pcm::OperationRequiredRole
@@ -91,9 +100,11 @@ routine parameter_createCorrespondingRequiredRole(uml::Parameter umlParameter, u
 }
 
 routine parameter_moveCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
-	match{
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+	match {
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
 		pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
@@ -102,14 +113,16 @@ routine parameter_moveCorrespondingRequiredRole(uml::Parameter umlParameter, uml
 
 reaction RequiredRolePropertyRemoved {
 	after element uml::Parameter removed from uml::Operation[ownedParameter]
-	with !affectedEObject.ownedParameters.contains(oldValue) //validity check
+	with !affectedEObject.ownedParameters.contains(oldValue) // validity check
 	call parameter_removeCorrespondingRequiredRole(oldValue, affectedEObject)
 }
 
 routine parameter_removeCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
-	match{
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+	match {
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+			IPRE__CONSTRUCTOR
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
 		pcmComponent.requiredRoles_InterfaceRequiringEntity -= pcmRequired
@@ -123,7 +136,8 @@ reaction RequiredRolePropertyDeleted {
 
 routine parameter_deleteCorrespondingRequiredRole(uml::Parameter umlParameter) {
 	match {
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
 		removeCorrespondenceBetween(pcmRequired, umlParameter, TagLiterals.REQUIRED_ROLE__PARAMETER)
@@ -139,13 +153,13 @@ reaction RequiredRoleParameterNameChanged {
 
 routine parameter_changeNameOfCorrespondingRequiredRole(uml::Parameter umlParameter, String newName) {
 	match {
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER 
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
 	}
 	update {
 		pcmRequired.entityName = newName
 	}
 }
-
 
 reaction RequiredRoleParameterTypeChanged {
 	after element uml::Interface replaced at uml::Parameter[type]
@@ -155,21 +169,24 @@ reaction RequiredRoleParameterTypeChanged {
 
 routine parameter_changeTypeOfCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Interface umlNewInterface) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlParameter.owner tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.REQUIRED_ROLE__PARAMETER 
-		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlParameter.
+			owner tagged with TagLiterals.IPRE__CONSTRUCTOR
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			REQUIRED_ROLE__PARAMETER
+		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		if (!pcmRequired.isPresent && pcmNewInterface.isPresent) {
 			parameter_createCorrespondingRequiredRole(umlParameter, umlParameter.owner as Operation)
 		} else if (pcmRequired.isPresent && pcmNewInterface.isPresent) {
 			pcmRequired.get.requiredInterface__OperationRequiredRole = pcmNewInterface.get
-		} else if(pcmRequired.isPresent && umlNewInterface === null) {
-			//might be a transitional state -> keep correspondence, but synchronize 'null'
+		} else if (pcmRequired.isPresent && umlNewInterface === null) {
+			// might be a transitional state -> keep correspondence, but synchronize 'null'
 			pcmRequired.get.requiredInterface__OperationRequiredRole = null
 		} else {
-			logger.warn("The type of a uml::Property in a pcm::OperationRequiredRole ~ uml::Property correspondence"
-						+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationRequiredRole will be deleted.")
+			logger.warn("The type of a uml::Property in a pcm::OperationRequiredRole ~ uml::Property correspondence" +
+				"has been set to a non-OperationInterface type. This is against convention and the corresponding OperationRequiredRole will be deleted.")
 			parameter_deleteCorrespondingRequiredRole(umlParameter)
 		}
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleParameter.reactions
@@ -25,11 +25,11 @@ reaction RequiredRoleParameterInserted {
 
 routine parameter_insertCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
 	match {
-		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged TagLiterals.
 			IPRE__CONSTRUCTOR
 		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlParameter.
-			type tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			type tagged TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -46,11 +46,11 @@ routine parameter_insertCorrespondingRequiredRole(uml::Parameter umlParameter, u
 
 routine parameter_detectOrCreateCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged TagLiterals.
 			IPRE__CONSTRUCTOR
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -70,8 +70,8 @@ routine parameter_detectOrCreateCorrespondingRequiredRole(uml::Parameter umlPara
 
 routine parameter_addCorrespondenceForExistingRequiredRole(uml::Parameter umlParameter, pcm::OperationRequiredRole pcmRequired) {
 	match {
-		require absence of uml::Parameter corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PARAMETER
-		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+		require absence of uml::Parameter corresponding to pcmRequired tagged TagLiterals.REQUIRED_ROLE__PARAMETER
+		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -81,11 +81,11 @@ routine parameter_addCorrespondenceForExistingRequiredRole(uml::Parameter umlPar
 
 routine parameter_createCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged TagLiterals.
 			IPRE__CONSTRUCTOR
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlParameter.type tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+		require absence of pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	create {
@@ -101,9 +101,9 @@ routine parameter_createCorrespondingRequiredRole(uml::Parameter umlParameter, u
 
 routine parameter_moveCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged TagLiterals.
 			IPRE__CONSTRUCTOR
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -119,9 +119,9 @@ reaction RequiredRolePropertyRemoved {
 
 routine parameter_removeCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Operation umlConstructor) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlConstructor tagged TagLiterals.
 			IPRE__CONSTRUCTOR
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -136,7 +136,7 @@ reaction RequiredRolePropertyDeleted {
 
 routine parameter_deleteCorrespondingRequiredRole(uml::Parameter umlParameter) {
 	match {
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -153,7 +153,7 @@ reaction RequiredRoleParameterNameChanged {
 
 routine parameter_changeNameOfCorrespondingRequiredRole(uml::Parameter umlParameter, String newName) {
 	match {
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
 	}
 	update {
@@ -170,10 +170,10 @@ reaction RequiredRoleParameterTypeChanged {
 routine parameter_changeTypeOfCorrespondingRequiredRole(uml::Parameter umlParameter, uml::Interface umlNewInterface) {
 	match {
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlParameter.
-			owner tagged with TagLiterals.IPRE__CONSTRUCTOR
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged with TagLiterals.
+			owner tagged TagLiterals.IPRE__CONSTRUCTOR
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlParameter tagged TagLiterals.
 			REQUIRED_ROLE__PARAMETER
-		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.
+		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
@@ -25,10 +25,10 @@ reaction RequiredRolePropertyInserted {
 
 routine insertCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
 		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlProperty.
-			type tagged with TagLiterals.INTERFACE_TO_INTERFACE
+			type tagged TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	update {
 		if (pcmComponent.isPresent && (pcmInterface.isPresent || umlProperty.type === null) // allow 'null' for uninitialized Generalizations
@@ -44,11 +44,11 @@ routine insertCorrespondingRequiredRole(uml::Property umlProperty, uml::Class um
 
 routine detectOrCreateCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -68,8 +68,8 @@ routine detectOrCreateCorrespondingRequiredRole(uml::Property umlProperty, uml::
 
 routine addCorrespondenceForExistingRequiredRole(uml::Property umlProperty, pcm::OperationRequiredRole pcmRequired) {
 	match {
-		require absence of uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
-		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+		require absence of uml::Property corresponding to pcmRequired tagged TagLiterals.REQUIRED_ROLE__PROPERTY
+		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -79,11 +79,11 @@ routine addCorrespondenceForExistingRequiredRole(uml::Property umlProperty, pcm:
 
 routine createCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	create {
@@ -99,9 +99,9 @@ routine createCorrespondingRequiredRole(uml::Property umlProperty, uml::Class um
 
 routine moveCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -117,9 +117,9 @@ reaction RequiredRolePropertyRemoved {
 
 routine removeCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged TagLiterals.
 			IPRE__IMPLEMENTATION
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -134,7 +134,7 @@ reaction RequiredRolePropertyDeleted {
 
 routine deleteCorrespondingRequiredRole(uml::Property umlProperty) {
 	match {
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -151,7 +151,7 @@ reaction RequiredRolePropertyNameChanged {
 
 routine changeNameOfCorrespondingRequiredRole(uml::Property umlProperty, String newName) {
 	match {
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
 	}
 	update {
@@ -168,10 +168,10 @@ reaction RequiredRolePropertyTypeChanged {
 routine changeTypeOfCorrespondingRequiredRole(uml::Property umlProperty, uml::Interface umlNewInterface) {
 	match {
 		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlProperty.
-			owner tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			owner tagged TagLiterals.IPRE__IMPLEMENTATION
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged TagLiterals.
 			REQUIRED_ROLE__PROPERTY
-		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.
+		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRequiredRoleProperty.reactions
@@ -3,7 +3,7 @@ import org.palladiosimulator.pcm.repository.OperationRequiredRole
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 import org.eclipse.uml2.uml.Interface
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationRequiredRole of a pcm::InterfaceProvidingRequiringEntity (IPRE)
@@ -13,7 +13,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmRequiredRole.reactions, 
 //		UmlRequiredRoleParameter.reactions,
 //		RequiredRoleConceptTest
-
 reactions: umlRequiredRolePropertyReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -26,12 +25,13 @@ reaction RequiredRolePropertyInserted {
 
 routine insertCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.INTERFACE_TO_INTERFACE 
+		val pcmComponent = retrieve optional pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlProperty.
+			type tagged with TagLiterals.INTERFACE_TO_INTERFACE
 	}
 	update {
-		if (pcmComponent.isPresent 
-			&& (pcmInterface.isPresent || umlProperty.type === null) // allow 'null' for uninitialized Generalizations
+		if (pcmComponent.isPresent && (pcmInterface.isPresent || umlProperty.type === null) // allow 'null' for uninitialized Generalizations
 		) {
 			detectOrCreateCorrespondingRequiredRole(umlProperty, umlComponent)
 			moveCorrespondingRequiredRole(umlProperty, umlComponent)
@@ -44,15 +44,19 @@ routine insertCorrespondingRequiredRole(uml::Property umlProperty, uml::Class um
 
 routine detectOrCreateCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.INTERFACE_TO_INTERFACE 
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		if (!pcmRequired.isPresent) {
-			val pcmRequiredCandidate = pcmComponent.requiredRoles_InterfaceRequiringEntity
-				.filter(OperationRequiredRole)
-				.findFirst[it.requiredInterface__OperationRequiredRole === pcmInterface && it.entityName == umlProperty.name]
+			val pcmRequiredCandidate = pcmComponent.requiredRoles_InterfaceRequiringEntity.filter(
+				OperationRequiredRole).findFirst [
+				it.requiredInterface__OperationRequiredRole === pcmInterface && it.entityName == umlProperty.name
+			]
 			if (pcmRequiredCandidate !== null) {
 				addCorrespondenceForExistingRequiredRole(umlProperty, pcmRequiredCandidate)
 			} else {
@@ -65,7 +69,8 @@ routine detectOrCreateCorrespondingRequiredRole(uml::Property umlProperty, uml::
 routine addCorrespondenceForExistingRequiredRole(uml::Property umlProperty, pcm::OperationRequiredRole pcmRequired) {
 	match {
 		require absence of uml::Property corresponding to pcmRequired tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
-		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		addCorrespondenceBetween(pcmRequired, umlProperty, TagLiterals.REQUIRED_ROLE__PROPERTY)
@@ -74,9 +79,12 @@ routine addCorrespondenceForExistingRequiredRole(uml::Property umlProperty, pcm:
 
 routine createCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.INTERFACE_TO_INTERFACE 
-		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlProperty.type tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	create {
 		val pcmRequired = new pcm::OperationRequiredRole
@@ -91,8 +99,10 @@ routine createCorrespondingRequiredRole(uml::Property umlProperty, uml::Class um
 
 routine moveCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		pcmComponent.requiredRoles_InterfaceRequiringEntity += pcmRequired
@@ -101,14 +111,16 @@ routine moveCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlC
 
 reaction RequiredRolePropertyRemoved {
 	after element uml::Property removed from uml::Class[ownedAttribute]
-	with !affectedEObject.ownedAttributes.contains(oldValue) //validity check
+	with !affectedEObject.ownedAttributes.contains(oldValue) // validity check
 	call removeCorrespondingRequiredRole(oldValue, affectedEObject)
 }
 
 routine removeCorrespondingRequiredRole(uml::Property umlProperty, uml::Class umlComponent) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlComponent tagged with TagLiterals.
+			IPRE__IMPLEMENTATION
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		pcmComponent.requiredRoles_InterfaceRequiringEntity -= pcmRequired
@@ -122,7 +134,8 @@ reaction RequiredRolePropertyDeleted {
 
 routine deleteCorrespondingRequiredRole(uml::Property umlProperty) {
 	match {
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		removeCorrespondenceBetween(pcmRequired, umlProperty, TagLiterals.REQUIRED_ROLE__PROPERTY)
@@ -138,7 +151,8 @@ reaction RequiredRolePropertyNameChanged {
 
 routine changeNameOfCorrespondingRequiredRole(uml::Property umlProperty, String newName) {
 	match {
-		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
+		val pcmRequired = retrieve pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
 	}
 	update {
 		pcmRequired.entityName = newName
@@ -153,21 +167,24 @@ reaction RequiredRolePropertyTypeChanged {
 
 routine changeTypeOfCorrespondingRequiredRole(uml::Property umlProperty, uml::Interface umlNewInterface) {
 	match {
-		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlProperty.owner tagged with TagLiterals.IPRE__IMPLEMENTATION
-		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.REQUIRED_ROLE__PROPERTY
-		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE 
+		val pcmComponent = retrieve pcm::InterfaceProvidingRequiringEntity corresponding to umlProperty.
+			owner tagged with TagLiterals.IPRE__IMPLEMENTATION
+		val pcmRequired = retrieve optional pcm::OperationRequiredRole corresponding to umlProperty tagged with TagLiterals.
+			REQUIRED_ROLE__PROPERTY
+		val pcmNewInterface = retrieve optional pcm::OperationInterface corresponding to umlNewInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		if (!pcmRequired.isPresent && pcmNewInterface.isPresent) {
 			createCorrespondingRequiredRole(umlProperty, umlProperty.owner as Class)
 		} else if (pcmRequired.isPresent && pcmNewInterface.isPresent) {
 			pcmRequired.get.requiredInterface__OperationRequiredRole = pcmNewInterface.get
-		} else if(pcmRequired.isPresent && umlNewInterface === null) {
-			//might be a transitional state -> keep correspondence, but synchronize 'null'
+		} else if (pcmRequired.isPresent && umlNewInterface === null) {
+			// might be a transitional state -> keep correspondence, but synchronize 'null'
 			pcmRequired.get.requiredInterface__OperationRequiredRole = null
 		} else {
-			logger.warn("The type of a uml::Property in a pcm::OperationRequiredRole ~ uml::Property correspondence"
-						+ "has been set to a non-OperationInterface type. This is against convention and the corresponding OperationRequiredRole will be deleted.")
+			logger.warn("The type of a uml::Property in a pcm::OperationRequiredRole ~ uml::Property correspondence" +
+				"has been set to a non-OperationInterface type. This is against convention and the corresponding OperationRequiredRole will be deleted.")
 			deleteCorrespondingRequiredRole(umlProperty)
 		}
 	}

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
@@ -74,11 +74,10 @@ routine propagateTypeChange(uml::Parameter umlParameter) {
 				pcmParameter.get.dataType__Parameter = pcmDataType
 			}
 
-			if(pcmOldCollectionType.isPresent &&
-				pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType_Parameter(
-				umlParameter)
-			if(pcmDataType instanceof CollectionDataType) addCorrespondenceForCollectionType_Parameter(umlParameter,
-				pcmDataType)
+			if (pcmOldCollectionType.isPresent && pcmOldCollectionType.get !== pcmDataType)
+				removeCorrespondenceForOldCollectionType_Parameter(umlParameter)
+			if (pcmDataType instanceof CollectionDataType)
+				addCorrespondenceForCollectionType_Parameter(umlParameter, pcmDataType)
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
@@ -52,11 +52,11 @@ reaction RegularOrReturnParameterUpperChanged2 {
 
 routine propagateTypeChange(uml::Parameter umlParameter) {
 	match {
-		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlParameter tagged with TagLiterals.
+		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlParameter tagged TagLiterals.
 			SIGNATURE__RETURN_PARAMETER
-		val pcmParameter = retrieve optional pcm::Parameter corresponding to umlParameter tagged with TagLiterals.
+		val pcmParameter = retrieve optional pcm::Parameter corresponding to umlParameter tagged TagLiterals.
 			PARAMETER__REGULAR_PARAMETER
-		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.
+		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlParameter tagged TagLiterals.
 			COLLECTION_DATATYPE__PROPERTY
 	}
 	update {
@@ -85,7 +85,7 @@ routine propagateTypeChange(uml::Parameter umlParameter) {
 
 routine removeCorrespondenceForOldCollectionType_Parameter(uml::Parameter umlParameter) {
 	match {
-		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.
+		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlParameter tagged TagLiterals.
 			COLLECTION_DATATYPE__PARAMETER
 	}
 	update {
@@ -96,7 +96,7 @@ routine removeCorrespondenceForOldCollectionType_Parameter(uml::Parameter umlPar
 routine addCorrespondenceForCollectionType_Parameter(uml::Parameter umlParameter, pcm::CollectionDataType pcmCollectionType) {
 	match {
 		// one Parameter can only correspond to one CollectionDataType, but one CollectionDataType can correspond to many Parameters
-		require absence of pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.
+		require absence of pcm::CollectionDataType corresponding to umlParameter tagged TagLiterals.
 			COLLECTION_DATATYPE__PARAMETER
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlReturnAndRegularParameterType.reactions
@@ -5,7 +5,7 @@ import org.eclipse.uml2.uml.Parameter
 import org.palladiosimulator.pcm.repository.Repository
 import org.eclipse.emf.ecore.EObject
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines handle type and multiplicity changes for an uml::Parameter corresponding to 
@@ -18,15 +18,13 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmSignature.reactions, PcmParameter.reactions
 //		UmlRegularParameter.reactions
 //		SignatureConceptTest, ParameterConceptTest
-
 reactions: umlReturnAndRegularParameterTypeReactions
 in reaction to changes in uml
 execute actions in pcm
 
 reaction RegularOrReturnParameterTypeChanged {
 	after element replaced at uml::Parameter[type]
-	with affectedEObject.type === newValue 
-		&& oldValue !== newValue
+	with affectedEObject.type === newValue && oldValue !== newValue
 	call propagateTypeChange(affectedEObject)
 }
 
@@ -34,10 +32,10 @@ reaction RegularOrReturnParameterLowerChanged {
 	after element replaced at uml::Parameter[lowerValue]
 	call propagateTypeChange(affectedEObject)
 }
+
 reaction RegularOrReturnParameterLowerChanged2 {
 	after attribute replaced at uml::LiteralInteger[value]
-	with affectedEObject.owner instanceof Parameter 
-		&& affectedEObject.value == newValue
+	with affectedEObject.owner instanceof Parameter && affectedEObject.value == newValue
 	call propagateTypeChange(affectedEObject.owner as Parameter)
 }
 
@@ -48,37 +46,47 @@ reaction RegularOrReturnParameterUpperChanged {
 
 reaction RegularOrReturnParameterUpperChanged2 {
 	after attribute replaced at uml::LiteralUnlimitedNatural[value]
-	with affectedEObject.owner instanceof Parameter 
-		&& affectedEObject.value == newValue
+	with affectedEObject.owner instanceof Parameter && affectedEObject.value == newValue
 	call propagateTypeChange(affectedEObject.owner as Parameter)
 }
 
 routine propagateTypeChange(uml::Parameter umlParameter) {
 	match {
-		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlParameter tagged with TagLiterals.SIGNATURE__RETURN_PARAMETER
-		val pcmParameter = retrieve optional pcm::Parameter corresponding to umlParameter tagged with TagLiterals.PARAMETER__REGULAR_PARAMETER
-		
-		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.COLLECTION_DATATYPE__PROPERTY
+		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlParameter tagged with TagLiterals.
+			SIGNATURE__RETURN_PARAMETER
+		val pcmParameter = retrieve optional pcm::Parameter corresponding to umlParameter tagged with TagLiterals.
+			PARAMETER__REGULAR_PARAMETER
+		val pcmOldCollectionType = retrieve optional pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.
+			COLLECTION_DATATYPE__PROPERTY
 	}
 	update {
 		if (pcmSignature.isPresent || pcmParameter.isPresent) { // limit context to synchronized uml::Parameters
-			val EObject pcmStoredElement = if (pcmSignature.isPresent) pcmSignature.get else pcmParameter.get
+			val EObject pcmStoredElement = if(pcmSignature.isPresent) pcmSignature.get else pcmParameter.get
 			val pcmRepository = pcmStoredElement.eResource.allContents.filter(Repository).head
-			val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(umlParameter.type, umlParameter.lower, umlParameter.upper, pcmRepository, userInteractor, [sourceElement, expectedType, tag |
-				getCorrespondingElement(sourceElement, expectedType, null, tag, false)
-			])
-			if (pcmSignature.isPresent) {pcmSignature.get.returnType__OperationSignature = pcmDataType}
-			if (pcmParameter.isPresent) {pcmParameter.get.dataType__Parameter = pcmDataType}
-			
-			if(pcmOldCollectionType.isPresent  && pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType_Parameter(umlParameter)
-			if(pcmDataType instanceof CollectionDataType) addCorrespondenceForCollectionType_Parameter(umlParameter, pcmDataType)
+			val pcmDataType = PcmUmlClassHelper.getCorrespondingPcmDataType(umlParameter.type, umlParameter.lower,
+				umlParameter.upper, pcmRepository, userInteractor, [ sourceElement, expectedType, tag |
+					getCorrespondingElement(sourceElement, expectedType, null, tag, false)
+				])
+			if (pcmSignature.isPresent) {
+				pcmSignature.get.returnType__OperationSignature = pcmDataType
+			}
+			if (pcmParameter.isPresent) {
+				pcmParameter.get.dataType__Parameter = pcmDataType
+			}
+
+			if(pcmOldCollectionType.isPresent &&
+				pcmOldCollectionType.get !== pcmDataType) removeCorrespondenceForOldCollectionType_Parameter(
+				umlParameter)
+			if(pcmDataType instanceof CollectionDataType) addCorrespondenceForCollectionType_Parameter(umlParameter,
+				pcmDataType)
 		}
 	}
 }
 
 routine removeCorrespondenceForOldCollectionType_Parameter(uml::Parameter umlParameter) {
 	match {
-		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.COLLECTION_DATATYPE__PARAMETER
+		val pcmCollectionType = retrieve pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.
+			COLLECTION_DATATYPE__PARAMETER
 	}
 	update {
 		removeCorrespondenceBetween(pcmCollectionType, umlParameter, TagLiterals.COLLECTION_DATATYPE__PARAMETER)
@@ -88,7 +96,8 @@ routine removeCorrespondenceForOldCollectionType_Parameter(uml::Parameter umlPar
 routine addCorrespondenceForCollectionType_Parameter(uml::Parameter umlParameter, pcm::CollectionDataType pcmCollectionType) {
 	match {
 		// one Parameter can only correspond to one CollectionDataType, but one CollectionDataType can correspond to many Parameters
-		require absence of pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.COLLECTION_DATATYPE__PARAMETER
+		require absence of pcm::CollectionDataType corresponding to umlParameter tagged with TagLiterals.
+			COLLECTION_DATATYPE__PARAMETER
 	}
 	update {
 		addCorrespondenceBetween(pcmCollectionType, umlParameter, TagLiterals.COLLECTION_DATATYPE__PARAMETER)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
@@ -24,7 +24,7 @@ reaction SignatureOperationInserted {
 
 routine insertCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -39,9 +39,9 @@ routine insertCorrespondingSignature(uml::Operation umlOperation, uml::Interface
 
 routine detectOrCreateCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
 	}
 	update {
@@ -60,9 +60,9 @@ routine detectOrCreateCorrespondingSignature(uml::Operation umlOperation, uml::I
 
 routine addCorrespondenceForExistingSignature(uml::Operation umlOperation, pcm::OperationSignature pcmSignature) {
 	match {
-		require absence of pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
-		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
+		require absence of uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 	}
 	update {
 		addCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
@@ -71,9 +71,9 @@ routine addCorrespondenceForExistingSignature(uml::Operation umlOperation, pcm::
 
 routine createCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		require absence of pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
 	}
 	create {
@@ -88,9 +88,9 @@ routine createCorrespondingSignature(uml::Operation umlOperation, uml::Interface
 
 routine moveCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmSignature = retrieve asserted pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve asserted pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
-		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -106,9 +106,9 @@ reaction SignatureOperationRemoved {
 
 routine removeCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
 	}
 	update {
@@ -123,7 +123,7 @@ reaction SignatureOperationDeleted {
 
 routine deleteCorrespondingSignature(uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
 	}
 	update {
@@ -140,7 +140,7 @@ reaction SignatureOperationRenamed {
 
 routine renameCorrespondingSignature(uml::Operation umlOperation, String newName) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
 			SIGNATURE__OPERATION
 	}
 	update {

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
@@ -60,8 +60,7 @@ routine detectOrCreateCorrespondingSignature(uml::Operation umlOperation, uml::I
 
 routine addCorrespondenceForExistingSignature(uml::Operation umlOperation, pcm::OperationSignature pcmSignature) {
 	match {
-		require absence of pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
-			SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.SIGNATURE__OPERATION
 		require absence of uml::Operation corresponding to pcmSignature tagged TagLiterals.SIGNATURE__OPERATION
 	}
 	update {
@@ -73,8 +72,7 @@ routine createCorrespondingSignature(uml::Operation umlOperation, uml::Interface
 	match {
 		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged TagLiterals.
 			INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.
-			SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlOperation tagged TagLiterals.SIGNATURE__OPERATION
 	}
 	create {
 		val pcmSignature = new pcm::OperationSignature

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlSignatureOperation.reactions
@@ -1,6 +1,6 @@
 import tools.vitruv.applications.pcmumlclass.TagLiterals
 
-import "http://www.eclipse.org/uml2/5.0.0/UML" as uml 
+import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
 import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 
 //	The following reactions and routines synchronize a pcm::OperationSignature with its corresponding uml::Operation.
@@ -12,7 +12,6 @@ import "http://palladiosimulator.org/PalladioComponentModel/5.2" as pcm
 //		PcmSignature.reactions,
 //		UmlReturnAndRegularParameterType.reactions,
 //		SignatureConceptTest
-
 reactions: umlSignatureOperationReactions
 in reaction to changes in uml
 execute actions in pcm
@@ -25,7 +24,8 @@ reaction SignatureOperationInserted {
 
 routine insertCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmInterface = retrieve optional pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		if (pcmInterface.isPresent) {
@@ -39,12 +39,16 @@ routine insertCorrespondingSignature(uml::Operation umlOperation, uml::Interface
 
 routine detectOrCreateCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		val pcmSignature = retrieve optional pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
 	}
 	update {
 		if (!pcmSignature.isPresent) {
-			val pcmSignatureCandidate = pcmInterface.signatures__OperationInterface.findFirst[it.entityName == umlOperation.name]
+			val pcmSignatureCandidate = pcmInterface.signatures__OperationInterface.findFirst [
+				it.entityName == umlOperation.name
+			]
 			if (pcmSignatureCandidate !== null) {
 				addCorrespondenceForExistingSignature(umlOperation, pcmSignatureCandidate)
 			} else {
@@ -56,7 +60,8 @@ routine detectOrCreateCorrespondingSignature(uml::Operation umlOperation, uml::I
 
 routine addCorrespondenceForExistingSignature(uml::Operation umlOperation, pcm::OperationSignature pcmSignature) {
 	match {
-		require absence of pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
+		require absence of pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
 		require absence of uml::Operation corresponding to pcmSignature tagged with TagLiterals.SIGNATURE__OPERATION
 	}
 	update {
@@ -66,8 +71,10 @@ routine addCorrespondenceForExistingSignature(uml::Operation umlOperation, pcm::
 
 routine createCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
-		require absence of pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
+		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
+		require absence of pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
 	}
 	create {
 		val pcmSignature = new pcm::OperationSignature
@@ -81,8 +88,10 @@ routine createCorrespondingSignature(uml::Operation umlOperation, uml::Interface
 
 routine moveCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmSignature = retrieve asserted pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
-		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmSignature = retrieve asserted pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		val pcmInterface = retrieve asserted pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		pcmInterface.signatures__OperationInterface += pcmSignature
@@ -97,8 +106,10 @@ reaction SignatureOperationRemoved {
 
 routine removeCorrespondingSignature(uml::Operation umlOperation, uml::Interface umlInterface) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
-		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.INTERFACE_TO_INTERFACE
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
+		val pcmInterface = retrieve pcm::OperationInterface corresponding to umlInterface tagged with TagLiterals.
+			INTERFACE_TO_INTERFACE
 	}
 	update {
 		pcmInterface.signatures__OperationInterface -= pcmSignature
@@ -112,7 +123,8 @@ reaction SignatureOperationDeleted {
 
 routine deleteCorrespondingSignature(uml::Operation umlOperation) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
 	}
 	update {
 		removeCorrespondenceBetween(pcmSignature, umlOperation, TagLiterals.SIGNATURE__OPERATION)
@@ -128,7 +140,8 @@ reaction SignatureOperationRenamed {
 
 routine renameCorrespondingSignature(uml::Operation umlOperation, String newName) {
 	match {
-		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.SIGNATURE__OPERATION
+		val pcmSignature = retrieve pcm::OperationSignature corresponding to umlOperation tagged with TagLiterals.
+			SIGNATURE__OPERATION
 	}
 	update {
 		pcmSignature.entityName = umlOperation.name

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUml.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUml.reactions
@@ -8,3 +8,4 @@ execute actions in uml
 import javaToUmlAttribute using qualified names
 import javaToUmlClassifier using qualified names
 import javaToUmlMethod using qualified names
+

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlAttribute.reactions
@@ -11,125 +11,125 @@ execute actions in uml
 import routines javaToUmlTypePropagation using qualified names
 
 reaction JavaAttributeCreatedInClass {
-    after element java::Field inserted in java::Class[members]
-    call createOrFindUmlAttributeInClass(affectedEObject, newValue)
+	after element java::Field inserted in java::Class[members]
+	call createOrFindUmlAttributeInClass(affectedEObject, newValue)
 }
 
 reaction JavaAttributeCreatedInEnum {
-    after element java::Field inserted in java::Enumeration[members]
-    call createOrFindUmlAttributeInEnum(affectedEObject, newValue)
+	after element java::Field inserted in java::Enumeration[members]
+	call createOrFindUmlAttributeInEnum(affectedEObject, newValue)
 }
 
 routine addAttributeCorrespondence(uml::Property umlAttribute, java::Field javaField) {
-     update {
-         addCorrespondenceBetween(umlAttribute, javaField)
-     }
+	update {
+		addCorrespondenceBetween(umlAttribute, javaField)
+	}
 }
 
 //UML-Enumeration, UML-Class don't have a common superclass for "having ownedAttributes".
 //Therefore we implemented two separate routines
 routine createOrFindUmlAttributeInEnum(java::Enumeration javaEnum, java::Field javaField) {
-    match {
-        val umlEnum = retrieve uml::Enumeration corresponding to javaEnum
-        require absence of uml::Property corresponding to javaField
-    }
-    update {
-        val foundAttribute = umlEnum.ownedAttributes.filter[name == javaField.name].claimNotMany
-        if (foundAttribute === null) {
-            createUmlAttributeInEnum(javaEnum, javaField)
-        } else {
-            addAttributeCorrespondence(foundAttribute, javaField)
-        }
-    }
+	match {
+		val umlEnum = retrieve uml::Enumeration corresponding to javaEnum
+		require absence of uml::Property corresponding to javaField
+	}
+	update {
+		val foundAttribute = umlEnum.ownedAttributes.filter[name == javaField.name].claimNotMany
+		if (foundAttribute === null) {
+			createUmlAttributeInEnum(javaEnum, javaField)
+		} else {
+			addAttributeCorrespondence(foundAttribute, javaField)
+		}
+	}
 }
 
 routine createOrFindUmlAttributeInClass(java::Class javaClass, java::Field javaField) {
-    match {
-        val umlClass = retrieve uml::Class corresponding to javaClass
-        require absence of uml::Property corresponding to javaField
-    }
-    update {
-        val foundAttribute = umlClass.ownedAttributes.filter[name == javaField.name].claimNotMany
-        if (foundAttribute === null) {
-            createUmlAttributeInClass(javaClass, javaField)
-        } else {
-            addAttributeCorrespondence(foundAttribute, javaField)
-        }
-    }
+	match {
+		val umlClass = retrieve uml::Class corresponding to javaClass
+		require absence of uml::Property corresponding to javaField
+	}
+	update {
+		val foundAttribute = umlClass.ownedAttributes.filter[name == javaField.name].claimNotMany
+		if (foundAttribute === null) {
+			createUmlAttributeInClass(javaClass, javaField)
+		} else {
+			addAttributeCorrespondence(foundAttribute, javaField)
+		}
+	}
 }
 
 //UML-Enumeration, UML-Class don't have a common superclass for "having ownedAttributes".
 //Therefore we implemented two separate routines
 routine createUmlAttributeInEnum(java::Enumeration jEnum, java::Field jAttr) {
-    match {
-        val uEnum = retrieve uml::Enumeration corresponding to jEnum
-        require absence of uml::Property corresponding to jAttr
-    }
-    create {
-    	val uAttr = new uml::Property
-    }
-    update {
+	match {
+		val uEnum = retrieve uml::Enumeration corresponding to jEnum
+		require absence of uml::Property corresponding to jAttr
+	}
+	create {
+		val uAttr = new uml::Property
+	}
+	update {
 		uAttr.name = jAttr.name
-        addCorrespondenceBetween(uAttr, jAttr)
-        uEnum.ownedAttributes += uAttr
-    }
+		addCorrespondenceBetween(uAttr, jAttr)
+		uEnum.ownedAttributes += uAttr
+	}
 }
 
 routine createUmlAttributeInClass(java::Class jClass, java::Field jAttr) {
-    match {
-        val uClass = retrieve uml::Class corresponding to jClass
-        require absence of uml::Property corresponding to jAttr
-    }
-    create {
-    	val uAttr = new uml::Property
-   	}
-    update {
+	match {
+		val uClass = retrieve uml::Class corresponding to jClass
+		require absence of uml::Property corresponding to jAttr
+	}
+	create {
+		val uAttr = new uml::Property
+	}
+	update {
 		uAttr.name = jAttr.name;
-        addCorrespondenceBetween(uAttr, jAttr)
+		addCorrespondenceBetween(uAttr, jAttr)
 		uClass.ownedAttributes += uAttr
-    }
+	}
 }
 
 reaction JavaAttributeTypeChanged {
-    after element java::TypeReference replaced at java::Field[typeReference]
-    call {
-        changeUmlAttributeType(affectedEObject, newValue)
-        }
+	after element java::TypeReference replaced at java::Field[typeReference]
+	call {
+		changeUmlAttributeType(affectedEObject, newValue)
+	}
 }
 
 routine changeUmlAttributeType(java::Field jAttr, java::TypeReference jType) {
-    match {
-        val uAttr = retrieve uml::Property corresponding to jAttr
-    }
-    update {
-        javaToUmlTypePropagation.propagateAttributeTypeChange(jAttr, uAttr)
-    }
+	match {
+		val uAttr = retrieve uml::Property corresponding to jAttr
+	}
+	update {
+		javaToUmlTypePropagation.propagateAttributeTypeChange(jAttr, uAttr)
+	}
 }
 
 reaction JavaAttributeMadeFinal {
-    after element java::Final inserted in java::Field[annotationsAndModifiers]
-    call setUmlAttributeFinal(affectedEObject, true)
+	after element java::Final inserted in java::Field[annotationsAndModifiers]
+	call setUmlAttributeFinal(affectedEObject, true)
 }
 
 reaction JavaAttributeMadeNonFinal {
-    after element java::Final removed from java::Field[annotationsAndModifiers]
-    call setUmlAttributeFinal(affectedEObject, false)
+	after element java::Final removed from java::Field[annotationsAndModifiers]
+	call setUmlAttributeFinal(affectedEObject, false)
 }
 
 routine setUmlAttributeFinal(java::Field jAttr, Boolean isFinal) {
-    match {
-        val uAttr = retrieve uml::Property corresponding to jAttr 
-    }
-    update {
+	match {
+		val uAttr = retrieve uml::Property corresponding to jAttr
+	}
+	update {
 		uAttr.isReadOnly = isFinal
-    }
+	}
 }
 
 //===========================================
 //=========================================== Unsupported
 //===========================================
-
 reaction JavaAttributeCreatedInInterface {
-    after element java::Field inserted in java::Interface[members]
-    call showMessage(userInteractor, "Adding fields to " + affectedEObject.class.simpleName +" is not supported. Please remove " + newValue)
+	after element java::Field inserted in java::Interface[members]
+	call showMessage(userInteractor,
+		"Adding fields to " + affectedEObject.class.simpleName + " is not supported. Please remove " + newValue)
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlClassifier.reactions
@@ -5,7 +5,6 @@ import org.eclipse.uml2.uml.UMLPackage
 import org.emftext.language.java.classifiers.Class
 import org.emftext.language.java.classifiers.Interface
 import tools.vitruv.dsls.reactions.runtime.helper.PersistenceHelper
-
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlPackage
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlClass
 import static tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.findUmlEnum
@@ -27,7 +26,6 @@ execute actions in uml
 //===========================================
 //=========================================== All Types
 //===========================================
-
 routine addTypeCorrespondence(java::ConcreteClassifier jClassifier, uml::Type umlType) {
 	update {
 		addCorrespondenceBetween(umlType, jClassifier)
@@ -52,7 +50,7 @@ routine detectOrCreateUmlModel(EObject alreadyPersistedEObject) { // TODO TS Thi
 		val rootModelFile = userModelPath + "/" + userModelName + ".uml"
 		// Check if a model at the specified path already exists; create one if necessary
 		var Model umlRootModel = null
-		if(alreadyPersistedEObject === null) {
+		if (alreadyPersistedEObject === null) {
 			// no objects persisted jet -> can't automatically retrieve projectPath
 			throw new UnsupportedOperationException(
 				"Cannot persist/load a uml::Model from JavaToUml-reactions without any previously persisted elements.")
@@ -61,7 +59,7 @@ routine detectOrCreateUmlModel(EObject alreadyPersistedEObject) { // TODO TS Thi
 		if (URIUtil.existsResourceAtUri(uri)) {
 			// The resource is only found if it was previously persisted, which only happens after the change propagation terminates.
 			// This should not be a problem, as long as any created model is registered on creation, to prevent creating a second one.
-			val resource = alreadyPersistedEObject.eResource.resourceSet.getResource(uri,true)
+			val resource = alreadyPersistedEObject.eResource.resourceSet.getResource(uri, true)
 			umlRootModel = resource.allContents.filter(Model).head
 		}
 		if (umlRootModel === null) {
@@ -70,7 +68,7 @@ routine detectOrCreateUmlModel(EObject alreadyPersistedEObject) { // TODO TS Thi
 			umlRootModel.name = userModelName
 			persistProjectRelative(alreadyPersistedEObject, umlRootModel, rootModelFile)
 		}
-		if (umlRootModel !== null ) {
+		if (umlRootModel !== null) {
 			registerUmlModelInCorrespondenceModel(umlRootModel)
 		}
 	}
@@ -86,19 +84,18 @@ routine registerUmlModelInCorrespondenceModel(uml::Model uModel) {
 }
 
 routine rootElementPreSetup(EObject alreadyPersistedEObject) {
-    update {
-        detectOrCreateUmlModel(alreadyPersistedEObject)
-        registerPredefinedUmlPrimitiveTypes(alreadyPersistedEObject)
-    }
+	update {
+		detectOrCreateUmlModel(alreadyPersistedEObject)
+		registerPredefinedUmlPrimitiveTypes(alreadyPersistedEObject)
+	}
 }
 
 routine registerPredefinedUmlPrimitiveTypes(EObject alreadyPersistedEObject) {
 	update {
-		getNotRegisteredPrimitiveTypesWithUnifiedNames([sourceElement, expectedType, tag |
+		getNotRegisteredPrimitiveTypesWithUnifiedNames([ sourceElement, expectedType, tag |
 			getCorrespondingElement(sourceElement, expectedType, null, tag, false)
-		], alreadyPersistedEObject.eResource.resourceSet).forEach[
-			addCorrespondenceBetween(UMLPackage.Literals.PRIMITIVE_TYPE,
-				it.key, it.value)
+		], alreadyPersistedEObject.eResource.resourceSet).forEach [
+			addCorrespondenceBetween(UMLPackage.Literals.PRIMITIVE_TYPE, it.key, it.value)
 		]
 	}
 }
@@ -106,60 +103,59 @@ routine registerPredefinedUmlPrimitiveTypes(EObject alreadyPersistedEObject) {
 //===========================================
 //=========================================== CompilationUnit
 //===========================================
-
 reaction JavaCompilationUnitInsertedAsRoot {
 	after element java::CompilationUnit inserted as root
 	call newValue.classifiers.forEach[insertUmlClassifier(it, newValue)]
 }
 
 reaction JavaCompilationUnitInsertedInPackage {
-    after element java::CompilationUnit inserted in java::Package[compilationUnits]
-    call {
-        rootElementPreSetup(newValue)
-        newValue.classifiers.forEach[insertUmlClassifierIntoPackage(it, affectedEObject)]
-    }
+	after element java::CompilationUnit inserted in java::Package[compilationUnits]
+	call {
+		rootElementPreSetup(newValue)
+		newValue.classifiers.forEach[insertUmlClassifierIntoPackage(it, affectedEObject)]
+	}
 }
 
 routine insertUmlClassifier(java::ConcreteClassifier jClassifier, java::CompilationUnit jCompUnit) {
-    match {
-        val umlClassifier = retrieve uml::Classifier corresponding to jClassifier
-    }
-    update {
-        addUmlElementToModelOrPackage(jCompUnit, umlClassifier)
-    }
+	match {
+		val umlClassifier = retrieve uml::Classifier corresponding to jClassifier
+	}
+	update {
+		addUmlElementToModelOrPackage(jCompUnit, umlClassifier)
+	}
 }
 
 routine insertUmlClassifierIntoPackage(java::ConcreteClassifier jClassifier, java::Package jPackage) {
-    match {
-        val uClassifier = retrieve uml::Classifier corresponding to jClassifier
-        val uPackage = retrieve uml::Package corresponding to jPackage
-    }
-    update {
-        uPackage.packagedElements += uClassifier
-    }
+	match {
+		val uClassifier = retrieve uml::Classifier corresponding to jClassifier
+		val uPackage = retrieve uml::Package corresponding to jPackage
+	}
+	update {
+		uPackage.packagedElements += uClassifier
+	}
 }
 
 routine addUmlElementToModelOrPackage(java::JavaRoot javaRoot, uml::PackageableElement umlPackageableElement) {
-    match {
-        val uModel = retrieve asserted uml::Model corresponding to UMLPackage.Literals.MODEL
-    }
-    update {
-        val uPackage = if (javaRoot.namespaces.nullOrEmpty) {
-            uModel
-        } else {
-            findUmlPackage(uModel, javaRoot.namespaces.last)
-        }
-        checkState(uPackage !== null, "Package %s does not exist in UML model", javaRoot.namespaces)
-        if (uPackage !== umlPackageableElement.eContainer) {
-            addUmlElementToPackage(umlPackageableElement, uPackage)
-        }
-    }
+	match {
+		val uModel = retrieve asserted uml::Model corresponding to UMLPackage.Literals.MODEL
+	}
+	update {
+		val uPackage = if (javaRoot.namespaces.nullOrEmpty) {
+				uModel
+			} else {
+				findUmlPackage(uModel, javaRoot.namespaces.last)
+			}
+		checkState(uPackage !== null, "Package %s does not exist in UML model", javaRoot.namespaces)
+		if (uPackage !== umlPackageableElement.eContainer) {
+			addUmlElementToPackage(umlPackageableElement, uPackage)
+		}
+	}
 }
 
 routine addUmlElementToPackage(uml::PackageableElement uPackageable, uml::Package uPackage) {
-    update {
-        uPackage.packagedElements += uPackageable
-    }
+	update {
+		uPackage.packagedElements += uPackageable
+	}
 }
 
 reaction JavaCompUnitDeleted {
@@ -183,54 +179,53 @@ routine deleteUmlClassifier(java::ConcreteClassifier javaClassifier) {
 }
 
 reaction JavaClassifierRemoved {
-    after element java::ConcreteClassifier removed from java::CompilationUnit[classifiers]
-    call cleanUpJavaCompilationUnit(affectedEObject)
+	after element java::ConcreteClassifier removed from java::CompilationUnit[classifiers]
+	call cleanUpJavaCompilationUnit(affectedEObject)
 }
 
 routine cleanUpJavaCompilationUnit(java::CompilationUnit jCompUnit) {
-    update {
-        removeObject(jCompUnit)
-    }
+	update {
+		removeObject(jCompUnit)
+	}
 }
 
 //===========================================
 //=========================================== Class
 //===========================================
-
 reaction JavaClassInserted {
-    after element java::Class inserted in java::CompilationUnit[classifiers]
-    call {
-        rootElementPreSetup(affectedEObject)
-        createOrFindUmlClass(newValue, affectedEObject)
-        insertUmlClassifier(newValue, affectedEObject)
-    }
+	after element java::Class inserted in java::CompilationUnit[classifiers]
+	call {
+		rootElementPreSetup(affectedEObject)
+		createOrFindUmlClass(newValue, affectedEObject)
+		insertUmlClassifier(newValue, affectedEObject)
+	}
 }
 
 routine createOrFindUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
-    match {
-        val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-        require absence of uml::Class corresponding to jClass
-        require absence of uml::DataType corresponding to jClass
-    }
-    update {
-        val uClass = findUmlClass(uModel, jClass.name, jCompUnit.namespaces.last)
-        if(uClass === null) {
-            createUmlClass(jClass, jCompUnit)
-        } else {
-            addTypeCorrespondence(jClass, uClass)
-        }
-    }
+	match {
+		val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
+		require absence of uml::Class corresponding to jClass
+		require absence of uml::DataType corresponding to jClass
+	}
+	update {
+		val uClass = findUmlClass(uModel, jClass.name, jCompUnit.namespaces.last)
+		if (uClass === null) {
+			createUmlClass(jClass, jCompUnit)
+		} else {
+			addTypeCorrespondence(jClass, uClass)
+		}
+	}
 }
 
 routine createUmlClass(java::Class jClass, java::CompilationUnit jCompUnit) {
 	create {
 		val uClass = new uml::Class
 	}
-    update {
+	update {
 		uClass.name = jClass.name
-        uClass.visibility = getUmlVisibilityKindFromJavaElement(jClass)
-        addTypeCorrespondence(jClass, uClass)
-    }
+		uClass.visibility = getUmlVisibilityKindFromJavaElement(jClass)
+		addTypeCorrespondence(jClass, uClass)
+	}
 }
 
 reaction JavaClassMadeAbstract {
@@ -283,7 +278,7 @@ reaction JavaSuperClassChanged {
 	}
 }
 
-routine addUmlSuperClassGeneralization(java::Class jClass, java::TypeReference jReference, java::Class jSuperClass){
+routine addUmlSuperClassGeneralization(java::Class jClass, java::TypeReference jReference, java::Class jSuperClass) {
 	match {
 		val uClass = retrieve uml::Class corresponding to jClass
 		val uSuperClass = retrieve uml::Class corresponding to jSuperClass
@@ -294,12 +289,13 @@ routine addUmlSuperClassGeneralization(java::Class jClass, java::TypeReference j
 			val uGeneralization = uClass.createGeneralization(uSuperClass)
 			addGeneralizationCorrespondence(uGeneralization, jReference)
 		} else {
-			logger.warn("Could not add " + jSuperClass.name + " as super class for " + uClass + " because the corresponding UML-SuperClass is null")
+			logger.warn("Could not add " + jSuperClass.name + " as super class for " + uClass +
+				" because the corresponding UML-SuperClass is null")
 		}
 	}
 }
 
-routine deleteUmlSuperClassGeneralization(java::TypeReference jReference){
+routine deleteUmlSuperClassGeneralization(java::TypeReference jReference) {
 	match {
 		val uGeneralization = retrieve uml::Generalization corresponding to jReference
 	}
@@ -325,20 +321,21 @@ routine addUmlClassImplement(java::Class jClass, java::TypeReference jReference,
 	}
 	update {
 		val matchingInterfaceRealization = uClass.interfaceRealizations.filter[contract == uInterface]
-		checkState(matchingInterfaceRealization.size <= 1, "There was more than one realization of interface %s in class %s", uInterface, uClass)
+		checkState(matchingInterfaceRealization.size <= 1,
+			"There was more than one realization of interface %s in class %s", uInterface, uClass)
 		if (matchingInterfaceRealization.size == 1) {
 			addImplementsCorrespondence(jReference, matchingInterfaceRealization.get(0))
 		} else if (uInterface !== null) {
 			val uRealization = uClass.createInterfaceRealization(uInterface.name, uInterface)
 			addImplementsCorrespondence(jReference, uRealization)
 		} else {
-			logger.warn("Could not add " + jInterface.name + " as implemented interface for " + uClass
-				+ " because the corresponding UML-Interface is null")
+			logger.warn("Could not add " + jInterface.name + " as implemented interface for " + uClass +
+				" because the corresponding UML-Interface is null")
 		}
 	}
 }
 
-routine addImplementsCorrespondence(java::TypeReference jReference, uml::InterfaceRealization uRealization){
+routine addImplementsCorrespondence(java::TypeReference jReference, uml::InterfaceRealization uRealization) {
 	match {
 		require absence of uml::InterfaceRealization corresponding to jReference
 	}
@@ -367,7 +364,6 @@ routine removeUmlClassImplement(java::Class jClass, java::TypeReference jReferen
 //===========================================
 //=========================================== Interface
 //===========================================
-
 reaction JavaInterfaceCreated {
 	after element java::Interface inserted in java::CompilationUnit[classifiers]
 	call {
@@ -384,7 +380,7 @@ routine createOrFindUmlInterface(java::Interface jInterface, java::CompilationUn
 	}
 	update {
 		val uInterface = findUmlInterface(uModel, jInterface.name, jCompUnit.namespaces.last)
-		if(uInterface === null) {
+		if (uInterface === null) {
 			createUmlInterface(jInterface, jCompUnit)
 		} else {
 			addTypeCorrespondence(jInterface, uInterface)
@@ -422,14 +418,15 @@ routine addUmlSuperinterfaces(java::Interface jInterface, java::TypeReference jR
 			val uGeneralization = uInterface.createGeneralization(uSuperInterface)
 			addGeneralizationCorrespondence(uGeneralization, jReference)
 		} else {
-			logger.warn("Could not add " + jSuperInterface.name + " as super interface for " + uInterface
-				+ " because the corresponding UML-Superinterface is null"
+			logger.warn(
+				"Could not add " + jSuperInterface.name + " as super interface for " + uInterface +
+					" because the corresponding UML-Superinterface is null"
 			)
 		}
 	}
 }
 
-routine addGeneralizationCorrespondence(uml::Generalization uGeneralization, java::TypeReference jReference){
+routine addGeneralizationCorrespondence(uml::Generalization uGeneralization, java::TypeReference jReference) {
 	match {
 		require absence of uml::Generalization corresponding to jReference
 		require absence of java::TypeReference corresponding to uGeneralization
@@ -458,102 +455,100 @@ routine removeUmlSuperInterface(java::Interface jInterface, java::TypeReference 
 //===========================================
 //=========================================== Enum
 //===========================================
-
 reaction JavaEnumCreated {
-    after element java::Enumeration inserted in java::CompilationUnit[classifiers]
-    call {
-        rootElementPreSetup(affectedEObject)
-        createOrFindUmlEnum(newValue, affectedEObject)
-        insertUmlClassifier(newValue, affectedEObject)
-    }
+	after element java::Enumeration inserted in java::CompilationUnit[classifiers]
+	call {
+		rootElementPreSetup(affectedEObject)
+		createOrFindUmlEnum(newValue, affectedEObject)
+		insertUmlClassifier(newValue, affectedEObject)
+	}
 }
 
 routine createOrFindUmlEnum(java::Enumeration jEnum, java::CompilationUnit jCompUnit) {
-    match {
-        val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
-        require absence of uml::Enumeration corresponding to jEnum
-    }
-    update {
-        val uEnum = findUmlEnum(uModel, jEnum.name, jCompUnit.namespaces.last)
-        if(uEnum === null) {
-            createUmlEnum(jEnum, jCompUnit)
-        } else {
-            addTypeCorrespondence(jEnum, uEnum)
-        }
-    }
+	match {
+		val uModel = retrieve uml::Model corresponding to UMLPackage.Literals.MODEL
+		require absence of uml::Enumeration corresponding to jEnum
+	}
+	update {
+		val uEnum = findUmlEnum(uModel, jEnum.name, jCompUnit.namespaces.last)
+		if (uEnum === null) {
+			createUmlEnum(jEnum, jCompUnit)
+		} else {
+			addTypeCorrespondence(jEnum, uEnum)
+		}
+	}
 }
 
 routine createUmlEnum(java::Enumeration jEnum, java::CompilationUnit jCompUnit) {
-    match {
-        require absence of uml::Enumeration corresponding to jEnum
-    }
-    create {
-    	val uEnum = new uml::Enumeration
-    }
-    update {
-        uEnum.name = jEnum.name
-        uEnum.visibility = getUmlVisibilityKindFromJavaElement(jEnum)
-        addTypeCorrespondence(jEnum, uEnum)
-    }
+	match {
+		require absence of uml::Enumeration corresponding to jEnum
+	}
+	create {
+		val uEnum = new uml::Enumeration
+	}
+	update {
+		uEnum.name = jEnum.name
+		uEnum.visibility = getUmlVisibilityKindFromJavaElement(jEnum)
+		addTypeCorrespondence(jEnum, uEnum)
+	}
 }
 
 reaction JavaEnumConstantCreated {
-    after element java::EnumConstant inserted in java::Enumeration[constants]
-    call createUmlEnumLiteral(affectedEObject, newValue)
+	after element java::EnumConstant inserted in java::Enumeration[constants]
+	call createUmlEnumLiteral(affectedEObject, newValue)
 }
 
 routine createUmlEnumLiteral(java::Enumeration jEnum, java::EnumConstant jConstant) {
-    match {
-        val uEnum = retrieve uml::Enumeration corresponding to jEnum
-        require absence of uml::EnumerationLiteral corresponding to jConstant
-    }
-    create {
-    	val uLiteral = new uml::EnumerationLiteral
-    }
-    update {
-        uLiteral.name = jConstant.name
-        addCorrespondenceBetween(uLiteral, jConstant)
-        uEnum.ownedLiterals += uLiteral
-    }
+	match {
+		val uEnum = retrieve uml::Enumeration corresponding to jEnum
+		require absence of uml::EnumerationLiteral corresponding to jConstant
+	}
+	create {
+		val uLiteral = new uml::EnumerationLiteral
+	}
+	update {
+		uLiteral.name = jConstant.name
+		addCorrespondenceBetween(uLiteral, jConstant)
+		uEnum.ownedLiterals += uLiteral
+	}
 }
 
 reaction JavaEnumConstantDeleted {
-    after element java::EnumConstant removed from java::Enumeration[constants]
-    call deleteUmlEnumLiteral(oldValue)
+	after element java::EnumConstant removed from java::Enumeration[constants]
+	call deleteUmlEnumLiteral(oldValue)
 }
 
 routine deleteUmlEnumLiteral(java::EnumConstant jConstant) {
-    match {
-        val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
-    }
-    update {
-        removeObject(uLiteral)
-        removeCorrespondenceBetween(uLiteral, jConstant)
-    }
+	match {
+		val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
+	}
+	update {
+		removeObject(uLiteral)
+		removeCorrespondenceBetween(uLiteral, jConstant)
+	}
 }
 
 reaction JavaEnumConstantRenamed {
-    after attribute replaced at java::EnumConstant[name]
-    call renameUmlEnumLiteral(affectedEObject)
+	after attribute replaced at java::EnumConstant[name]
+	call renameUmlEnumLiteral(affectedEObject)
 }
 
 routine renameUmlEnumLiteral(java::EnumConstant jConstant) {
-    match {
-        val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
-    }
-    update {
-        uLiteral.name = jConstant.name
-    }
+	match {
+		val uLiteral = retrieve uml::EnumerationLiteral corresponding to jConstant
+	}
+	update {
+		uLiteral.name = jConstant.name
+	}
 }
 
 //===========================================
 //=========================================== Package
 //===========================================
-
 reaction JavaPackageInserted {
 	after element java::Package inserted as root
 	call {
-	    rootElementPreSetup(newValue)
+		rootElementPreSetup(newValue)
 		createPackageEClassCorrespondence(newValue)
 		createOrFindUmlPackage(newValue)
 		potentiallyMoveUmlPackage(newValue)
@@ -589,7 +584,7 @@ routine createOrFindUmlPackage(java::Package jPackage) {
 	}
 	update {
 		val uPackage = findUmlPackage(uModel, jPackage.name)
-		if(uPackage === null) {
+		if (uPackage === null) {
 			createUmlPackage(jPackage, uModel)
 		} else {
 			// Existing package was created again, so delete the old one to ensure
@@ -612,7 +607,7 @@ routine deleteExistingJavaPackage(uml::Package umlPackage) {
 
 routine addPackageCorrespondence(java::Package jPackage, uml::Package uPackage) {
 	update {
-		 addCorrespondenceBetween(uPackage, jPackage)
+		addCorrespondenceBetween(uPackage, jPackage)
 	}
 }
 
@@ -659,13 +654,14 @@ routine deleteUmlPackage(uml::Package umlPackage) {
 //===========================================
 //=========================================== Unsupported
 //===========================================
-
 reaction JavaEnumerationImplementAdded {
 	after element java::TypeReference inserted in java::Enumeration[implements]
-	call showMessage(userInteractor, "Implement relations from enums are not supported. Please remove it from " + affectedEObject)
+	call showMessage(userInteractor,
+		"Implement relations from enums are not supported. Please remove it from " + affectedEObject)
 }
 
 reaction JavaClassifierMadeStatic {
 	after element java::Static inserted in java::ConcreteClassifier[annotationsAndModifiers]
-	call showMessage(userInteractor, "Static classifiers are not supported. Please undo the change at " + affectedEObject)
+	call showMessage(userInteractor,
+		"Static classifiers are not supported. Please undo the change at " + affectedEObject)
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -8,7 +8,6 @@ import org.emftext.language.java.modifiers.Private
 import org.emftext.language.java.modifiers.Protected
 import org.emftext.language.java.modifiers.Public
 import tools.vitruv.applications.umljava.util.UmlJavaCorrespondenceTag
-
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
 import static tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 
@@ -24,372 +23,371 @@ import routines javaToUmlTypePropagation using qualified names
 //===========================================
 //=========================================== Method
 //===========================================
-
 reaction JavaClassMethodCreated {
-    after element java::ClassMethod inserted in java::ConcreteClassifier[members]
-    with (affectedEObject instanceof Class)
-        || (affectedEObject instanceof Enumeration)
-    call {
-        createOrFindUmlClassMethod(newValue, affectedEObject)
-        insertUmlMethod(newValue, affectedEObject)
-    }
+	after element java::ClassMethod inserted in java::ConcreteClassifier[members]
+	with (affectedEObject instanceof Class) || (affectedEObject instanceof Enumeration)
+	call {
+		createOrFindUmlClassMethod(newValue, affectedEObject)
+		insertUmlMethod(newValue, affectedEObject)
+	}
 }
 
 routine createOrFindUmlClassMethod(java::ClassMethod jMethod, java::ConcreteClassifier jClassifier) {
-     match {
-        val uClassifier = retrieve uml::Classifier corresponding to jClassifier
-            with uClassifier instanceof OperationOwner
-        require absence of uml::Operation corresponding to jMethod
-        require absence of uml::Property corresponding to jMethod tagged with UmlJavaCorrespondenceTag.GETTER
-        require absence of uml::Property corresponding to jMethod tagged with UmlJavaCorrespondenceTag.SETTER
-    }
-    update {
-        val foundMethod = (uClassifier as OperationOwner).ownedOperations.findFirst[
-            name == jMethod.name && 
-            ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
-            jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
-        ]
-        if (foundMethod === null) {
-            createUmlClassMethod(jMethod, uClassifier)
-        } else {
-            addUmlMethodCorrespondence(foundMethod, jMethod)
-        }
-    }
+	match {
+		val uClassifier = retrieve uml::Classifier corresponding to jClassifier with uClassifier instanceof OperationOwner
+		require absence of uml::Operation corresponding to jMethod
+		require absence of uml::Property corresponding to jMethod tagged with UmlJavaCorrespondenceTag.GETTER
+		require absence of uml::Property corresponding to jMethod tagged with UmlJavaCorrespondenceTag.SETTER
+	}
+	update {
+		val foundMethod = (uClassifier as OperationOwner).ownedOperations.findFirst [
+			name == jMethod.name &&
+				ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size ==
+					jMethod.parameters.size && jMethod.parameters.forall [ jParameter |
+					ownedParameters.exists[name == jParameter.name]
+				]
+		]
+		if (foundMethod === null) {
+			createUmlClassMethod(jMethod, uClassifier)
+		} else {
+			addUmlMethodCorrespondence(foundMethod, jMethod)
+		}
+	}
 }
 
 routine createUmlClassMethod(java::ClassMethod jMethod, uml::Classifier uClassifier) {
 	create {
 		val uOperation = new uml::Operation
 	}
-    update {
-        uOperation.name = jMethod.name
-        uOperation.visibility = getUmlVisibilityKindFromJavaElement(jMethod)
-        addCorrespondenceBetween(uOperation, jMethod)
-    }
+	update {
+		uOperation.name = jMethod.name
+		uOperation.visibility = getUmlVisibilityKindFromJavaElement(jMethod)
+		addCorrespondenceBetween(uOperation, jMethod)
+	}
 }
 
 reaction JavaInterfaceMethodCreated {
-    after element java::InterfaceMethod inserted in java::Interface[members]
-    call {
-        createOrFindUmlInterfaceMethod(newValue, affectedEObject)
-        insertUmlMethod(newValue, affectedEObject)
-    }
+	after element java::InterfaceMethod inserted in java::Interface[members]
+	call {
+		createOrFindUmlInterfaceMethod(newValue, affectedEObject)
+		insertUmlMethod(newValue, affectedEObject)
+	}
 }
 
 routine createOrFindUmlInterfaceMethod(java::InterfaceMethod jMethod, java::Interface jInterface) {
-     match {
-        val uInterface = retrieve uml::Interface corresponding to jInterface
-        require absence of uml::Operation corresponding to jMethod
-    }
-    update {
-        val foundMethod = uInterface.ownedOperations.findFirst[
-            name == jMethod.name && 
-            ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size == jMethod.parameters.size &&
-            jMethod.parameters.forall[jParameter | ownedParameters.exists[name == jParameter.name]]
-        ]
-        if (foundMethod === null) {
-            createUmlInterfaceMethod(jMethod, uInterface)
-        } else {
-            addUmlMethodCorrespondence(foundMethod, jMethod)
-        }
-    }
+	match {
+		val uInterface = retrieve uml::Interface corresponding to jInterface
+		require absence of uml::Operation corresponding to jMethod
+	}
+	update {
+		val foundMethod = uInterface.ownedOperations.findFirst [
+			name == jMethod.name &&
+				ownedParameters.filter[direction != ParameterDirectionKind.RETURN_LITERAL].size ==
+					jMethod.parameters.size && jMethod.parameters.forall [ jParameter |
+					ownedParameters.exists[name == jParameter.name]
+				]
+		]
+		if (foundMethod === null) {
+			createUmlInterfaceMethod(jMethod, uInterface)
+		} else {
+			addUmlMethodCorrespondence(foundMethod, jMethod)
+		}
+	}
 }
 
 routine createUmlInterfaceMethod(java::InterfaceMethod jMeth, uml::Interface uInterface) {
 	create {
 		val uOperation = new uml::Operation
 	}
-    update {
-        uOperation.name = jMeth.name
-        uOperation.isAbstract = true
-        addCorrespondenceBetween(uOperation, jMeth)
-    }
+	update {
+		uOperation.name = jMeth.name
+		uOperation.isAbstract = true
+		addCorrespondenceBetween(uOperation, jMeth)
+	}
 }
 
 // Shared between interface methods, class methods, constructors:
 routine addUmlMethodCorrespondence(uml::Operation uOperation, java::Member jMethodOrConstructor) {
-    update {
-        addCorrespondenceBetween(uOperation, jMethodOrConstructor)
-    }
+	update {
+		addCorrespondenceBetween(uOperation, jMethodOrConstructor)
+	}
 }
 
 reaction JavaConstructorCreated {
-    after element java::Constructor inserted in java::ConcreteClassifier[members]
-    call {
-        createOrFindUmlConstructor(newValue, affectedEObject)
-        insertUmlMethod(newValue, affectedEObject)
-    }
+	after element java::Constructor inserted in java::ConcreteClassifier[members]
+	call {
+		createOrFindUmlConstructor(newValue, affectedEObject)
+		insertUmlMethod(newValue, affectedEObject)
+	}
 }
 
 routine createOrFindUmlConstructor(java::Constructor jConstructor, java::ConcreteClassifier jClassifier) {
-     match {
-        val uClassifier = retrieve uml::Class corresponding to jClassifier
-        require absence of uml::Operation corresponding to jConstructor
-    }
-    update {
-        val foundConstructor = uClassifier.ownedOperations.findFirst[name == jConstructor.name]
-        if (foundConstructor === null) {
-            createUmlConstructor(jConstructor, uClassifier)
-        } else {
-            addUmlMethodCorrespondence(foundConstructor, jConstructor)
-        }
-    }
+	match {
+		val uClassifier = retrieve uml::Class corresponding to jClassifier
+		require absence of uml::Operation corresponding to jConstructor
+	}
+	update {
+		val foundConstructor = uClassifier.ownedOperations.findFirst[name == jConstructor.name]
+		if (foundConstructor === null) {
+			createUmlConstructor(jConstructor, uClassifier)
+		} else {
+			addUmlMethodCorrespondence(foundConstructor, jConstructor)
+		}
+	}
 }
 
 routine createUmlConstructor(java::Constructor jConstructor, uml::Class uClassifier) {
 	create {
 		val uConstructor = new uml::Operation
 	}
-    update {
-        uConstructor.name = jConstructor.name
-        uConstructor.visibility = getUmlVisibilityKindFromJavaElement(jConstructor)
-        addCorrespondenceBetween(uConstructor, jConstructor)
-    }
+	update {
+		uConstructor.name = jConstructor.name
+		uConstructor.visibility = getUmlVisibilityKindFromJavaElement(jConstructor)
+		addCorrespondenceBetween(uConstructor, jConstructor)
+	}
 }
 
 routine insertUmlMethod(java::Member javaMethod, java::ConcreteClassifier javaClassifier) {
-    match {
-        val umlMethod = retrieve uml::Operation corresponding to javaMethod 
-        val umlClassifier = retrieve uml::Classifier corresponding to javaClassifier
-    }
-    update {
-        (umlClassifier as OperationOwner).ownedOperations += umlMethod
-    }
+	match {
+		val umlMethod = retrieve uml::Operation corresponding to javaMethod
+		val umlClassifier = retrieve uml::Classifier corresponding to javaClassifier
+	}
+	update {
+		(umlClassifier as OperationOwner).ownedOperations += umlMethod
+	}
 }
 
 reaction JavaMemberDeleted {
-    after element java::Member deleted
-    call {
-        deleteUmlMethod(affectedEObject)
-        deleteAccessorCorrespondence(affectedEObject, UmlJavaCorrespondenceTag.GETTER)
-        deleteAccessorCorrespondence(affectedEObject, UmlJavaCorrespondenceTag.SETTER)
-    }
+	after element java::Member deleted
+	call {
+		deleteUmlMethod(affectedEObject)
+		deleteAccessorCorrespondence(affectedEObject, UmlJavaCorrespondenceTag.GETTER)
+		deleteAccessorCorrespondence(affectedEObject, UmlJavaCorrespondenceTag.SETTER)
+	}
 }
 
 routine deleteUmlMethod(java::Member jMem) {
-    match {
-        val uMem = retrieve uml::NamedElement corresponding to jMem tagged with ""
-    }
-    update {
-        removeObject(uMem)
-        removeCorrespondenceBetween(uMem, jMem)
-    }
+	match {
+		val uMem = retrieve uml::NamedElement corresponding to jMem tagged with ""
+	}
+	update {
+		removeObject(uMem)
+		removeCorrespondenceBetween(uMem, jMem)
+	}
 }
 
 routine deleteAccessorCorrespondence(java::Member jMember, String tag) {
-    match {
-        val uProperty = retrieve uml::Property corresponding to jMember tagged with tag
-    }
-    update {
-        removeCorrespondenceBetween(uProperty, jMember, tag)
-    }
+	match {
+		val uProperty = retrieve uml::Property corresponding to jMember tagged with tag
+	}
+	update {
+		removeCorrespondenceBetween(uProperty, jMember, tag)
+	}
 }
 
 reaction JavaMethodMadeAbstract {
-    after element java::Abstract inserted in java::ClassMethod[annotationsAndModifiers]
-    call  {
-        setUmlMethodAbstract(affectedEObject, true)
-    }
+	after element java::Abstract inserted in java::ClassMethod[annotationsAndModifiers]
+	call {
+		setUmlMethodAbstract(affectedEObject, true)
+	}
 }
 
 reaction JavaMethodMadeNonAbstract {
-    after element java::Abstract removed from java::ClassMethod[annotationsAndModifiers]
-    call setUmlMethodAbstract(affectedEObject, false)
+	after element java::Abstract removed from java::ClassMethod[annotationsAndModifiers]
+	call setUmlMethodAbstract(affectedEObject, false)
 }
 
 routine setUmlMethodAbstract(java::ClassMethod jMeth, Boolean isAbstract) {
-    match {
-        val uOperation = retrieve uml::Operation corresponding to jMeth
-    }
-    update {
+	match {
+		val uOperation = retrieve uml::Operation corresponding to jMeth
+	}
+	update {
 		uOperation.isAbstract = isAbstract
-    }
+	}
 }
 
 reaction JavaMethodMadeFinal {
-    after element java::Final inserted in java::ClassMethod[annotationsAndModifiers]
-    call setUmlMethodFinal(affectedEObject, true)
+	after element java::Final inserted in java::ClassMethod[annotationsAndModifiers]
+	call setUmlMethodFinal(affectedEObject, true)
 }
 
 reaction JavaMethodMadeNonFinal {
-    after element java::Final removed from java::ClassMethod[annotationsAndModifiers]
-    call setUmlMethodFinal(affectedEObject, false)
+	after element java::Final removed from java::ClassMethod[annotationsAndModifiers]
+	call setUmlMethodFinal(affectedEObject, false)
 }
 
 routine setUmlMethodFinal(java::Method jMethod, Boolean isFinal) {
-    match {
-        val uOperation = retrieve uml::Operation corresponding to jMethod
-    }
-    update {
-        uOperation.isLeaf = isFinal
-    }
+	match {
+		val uOperation = retrieve uml::Operation corresponding to jMethod
+	}
+	update {
+		uOperation.isLeaf = isFinal
+	}
 }
 
 reaction JavaElementMadeStatic {
-    after element java::Static inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
-    call setUmlFeatureStatic(affectedEObject, true)
+	after element java::Static inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
+	call setUmlFeatureStatic(affectedEObject, true)
 }
 
 reaction JavaMethodMadeNonStatic {
-    after element java::Static removed from java::AnnotableAndModifiable[annotationsAndModifiers]
-    call setUmlFeatureStatic(affectedEObject, false)
+	after element java::Static removed from java::AnnotableAndModifiable[annotationsAndModifiers]
+	call setUmlFeatureStatic(affectedEObject, false)
 }
+
 //UML-Feature =  {Property, Operation}
 routine setUmlFeatureStatic(java::AnnotableAndModifiable jElem, Boolean isStatic) {
-    match {
-        val uFeature = retrieve uml::Feature corresponding to jElem
-    }
-    update {
-        uFeature.isStatic = isStatic
-    }
+	match {
+		val uFeature = retrieve uml::Feature corresponding to jElem
+	}
+	update {
+		uFeature.isStatic = isStatic
+	}
 }
 
 //===========================================
 //=========================================== Parameter
 //===========================================
-
 reaction JavaVariableLengthParameterCreated {
-    after element java::VariableLengthParameter inserted in java::Parametrizable[parameters]
-    call {
-        createUmlParameter(affectedEObject, newValue)
-        setMultiplicityOfCorrespondingParameterToUnlimited(newValue)
-    }
+	after element java::VariableLengthParameter inserted in java::Parametrizable[parameters]
+	call {
+		createUmlParameter(affectedEObject, newValue)
+		setMultiplicityOfCorrespondingParameterToUnlimited(newValue)
+	}
 }
 
 reaction JavaOrdinaryParameterCreated {
-    after element java::OrdinaryParameter inserted in java::Parametrizable[parameters]
-    call createUmlParameter(affectedEObject, newValue)
+	after element java::OrdinaryParameter inserted in java::Parametrizable[parameters]
+	call createUmlParameter(affectedEObject, newValue)
 }
 
 routine createUmlParameter(java::Parametrizable jMeth, java::Parameter jParam) {
-    match {
-        val uOperation = retrieve uml::Operation corresponding to jMeth
-        require absence of uml::Parameter corresponding to jParam
-    }
-    create {
-    	val uParam = new uml::Parameter
-    }
-    update {
-        uParam.name = jParam.name
-        addCorrespondenceBetween(uParam, jParam)
-        uOperation.ownedParameters += uParam
-    }
+	match {
+		val uOperation = retrieve uml::Operation corresponding to jMeth
+		require absence of uml::Parameter corresponding to jParam
+	}
+	create {
+		val uParam = new uml::Parameter
+	}
+	update {
+		uParam.name = jParam.name
+		addCorrespondenceBetween(uParam, jParam)
+		uOperation.ownedParameters += uParam
+	}
 }
 
 routine setMultiplicityOfCorrespondingParameterToUnlimited(java::Parameter parameter) {
-    match {
-        val umlParameter = retrieve uml::Parameter corresponding to parameter
-    }
-    update {
-        umlParameter => [
-            lower = 0
-            upper = LiteralUnlimitedNatural.UNLIMITED
-        ]
-    }
+	match {
+		val umlParameter = retrieve uml::Parameter corresponding to parameter
+	}
+	update {
+		umlParameter => [
+			lower = 0
+			upper = LiteralUnlimitedNatural.UNLIMITED
+		]
+	}
 }
 
 reaction JavaParameterDeleted {
-    after element java::Parameter removed from java::Parametrizable[parameters]
-    call deleteJavaParameter(oldValue)
+	after element java::Parameter removed from java::Parametrizable[parameters]
+	call deleteJavaParameter(oldValue)
 }
 
 routine deleteJavaParameter(java::Parameter jParam) {
-    match {
-        val uParam = retrieve uml::Parameter corresponding to jParam
-    }
-    update {
-        removeObject(uParam)
-        removeCorrespondenceBetween(uParam, jParam)
-    }
+	match {
+		val uParam = retrieve uml::Parameter corresponding to jParam
+	}
+	update {
+		removeObject(uParam)
+		removeCorrespondenceBetween(uParam, jParam)
+	}
 }
 
 reaction JavaParameterTypeChanged {
-    after element java::TypeReference replaced at java::Parameter[typeReference]
-    call changeUmlParameterType(affectedEObject, newValue)
+	after element java::TypeReference replaced at java::Parameter[typeReference]
+	call changeUmlParameterType(affectedEObject, newValue)
 }
 
 routine changeUmlParameterType(java::Parameter jParam, java::TypeReference jType) {
-    match {
-        val uParam = retrieve uml::Parameter corresponding to jParam
-    }
-    update {
-        javaToUmlTypePropagation.propagateParameterTypeChange(jParam, uParam)
-    }
+	match {
+		val uParam = retrieve uml::Parameter corresponding to jParam
+	}
+	update {
+		javaToUmlTypePropagation.propagateParameterTypeChange(jParam, uParam)
+	}
 }
 
 reaction JavaReturnTypeChanged {
-    after element java::TypeReference replaced at java::Method[typeReference]
-    call changeUmlReturnType(affectedEObject, newValue)
+	after element java::TypeReference replaced at java::Method[typeReference]
+	call changeUmlReturnType(affectedEObject, newValue)
 }
 
 routine changeUmlReturnType(java::Method jMeth, java::TypeReference jType) {
-    match {
-        val uOperation = retrieve uml::Operation corresponding to jMeth
-    }
-    update {
-        var uParam = uOperation.getReturnResult
-        if (uParam === null){
-            // create a new return parameter
-            uParam = uOperation.createOwnedParameter("returnParameter", null)
-            uParam.direction = ParameterDirectionKind.RETURN_LITERAL
-        }
-        javaToUmlTypePropagation.propagateMethodReturnTypeChange(jMeth, uParam)
-    }
+	match {
+		val uOperation = retrieve uml::Operation corresponding to jMeth
+	}
+	update {
+		var uParam = uOperation.getReturnResult
+		if (uParam === null) {
+			// create a new return parameter
+			uParam = uOperation.createOwnedParameter("returnParameter", null)
+			uParam.direction = ParameterDirectionKind.RETURN_LITERAL
+		}
+		javaToUmlTypePropagation.propagateMethodReturnTypeChange(jMeth, uParam)
+	}
 }
 
 //===========================================
 //=========================================== General
 //=========================================== 
-
 reaction JavaVisibilityModifierInserted {
-    after element java::Modifier inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
-    with newValue instanceof Public || newValue instanceof Private || newValue instanceof Protected
-    call changeUmlNamedElementVisibility(affectedEObject)
+	after element java::Modifier inserted in java::AnnotableAndModifiable[annotationsAndModifiers]
+	with newValue instanceof Public || newValue instanceof Private || newValue instanceof Protected
+	call changeUmlNamedElementVisibility(affectedEObject)
 }
 
 reaction JavaVisibilityModifierRemoved {
-    after element java::Modifier removed from java::AnnotableAndModifiable[annotationsAndModifiers]
-    with oldValue instanceof Private
-    || oldValue instanceof Public
-    || oldValue instanceof Protected
-    call changeUmlNamedElementVisibility(affectedEObject)
+	after element java::Modifier removed from java::AnnotableAndModifiable[annotationsAndModifiers]
+	with oldValue instanceof Private || oldValue instanceof Public || oldValue instanceof Protected
+	call changeUmlNamedElementVisibility(affectedEObject)
 }
 
 routine changeUmlNamedElementVisibility(java::AnnotableAndModifiable jElem) {
-    match {
-        val uElem = retrieve uml::NamedElement corresponding to jElem tagged with ""
-    }
-    update {
-        uElem.visibility = getUmlVisibilityKindFromJavaElement(jElem)
-    }
+	match {
+		val uElem = retrieve uml::NamedElement corresponding to jElem tagged with ""
+	}
+	update {
+		uElem.visibility = getUmlVisibilityKindFromJavaElement(jElem)
+	}
 }
 
 reaction JavaNamedElementRenamed {
-    after attribute replaced at java::NamedElement[name]
-    with !(affectedEObject instanceof CompilationUnit)
-    call renameUmlNamedElement(affectedEObject)
+	after attribute replaced at java::NamedElement[name]
+	with !(affectedEObject instanceof CompilationUnit)
+	call renameUmlNamedElement(affectedEObject)
 }
 
 routine renameUmlNamedElement(java::NamedElement jElement) {
-    match {
-        val uElement = retrieve uml::NamedElement corresponding to jElement tagged with ""
-    }
-    update {
-        uElement.name = jElement.name
-    }
+	match {
+		val uElement = retrieve uml::NamedElement corresponding to jElement tagged with ""
+	}
+	update {
+		uElement.name = jElement.name
+	}
 }
 
 //===========================================
 //=========================================== Unsupported
 //===========================================
-
 //An interface can theoretically have static, non-abstract methods
 reaction JavaClassMethodCreatedInInterface {
-    after element java::ClassMethod inserted in java::Interface[members]
-    call showMessage(userInteractor, "ClassMethods are currently not supported in Interfaces. Please delete " + newValue)
+	after element java::ClassMethod inserted in java::Interface[members]
+	call showMessage(userInteractor,
+		"ClassMethods are currently not supported in Interfaces. Please delete " + newValue)
 }
 
 reaction JavaParameterMadeFinal {
-    after element java::Final inserted in java::Parameter[annotationsAndModifiers]
-    call showMessage(userInteractor, "Final parameters are not supported. Please remove the modifier from " + affectedEObject)
+	after element java::Final inserted in java::Parameter[annotationsAndModifiers]
+	call showMessage(userInteractor,
+		"Final parameters are not supported. Please remove the modifier from " + affectedEObject)
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -36,8 +36,8 @@ routine createOrFindUmlClassMethod(java::ClassMethod jMethod, java::ConcreteClas
 	match {
 		val uClassifier = retrieve uml::Classifier corresponding to jClassifier with uClassifier instanceof OperationOwner
 		require absence of uml::Operation corresponding to jMethod
-		require absence of uml::Property corresponding to jMethod tagged with UmlJavaCorrespondenceTag.GETTER
-		require absence of uml::Property corresponding to jMethod tagged with UmlJavaCorrespondenceTag.SETTER
+		require absence of uml::Property corresponding to jMethod tagged UmlJavaCorrespondenceTag.GETTER
+		require absence of uml::Property corresponding to jMethod tagged UmlJavaCorrespondenceTag.SETTER
 	}
 	update {
 		val foundMethod = (uClassifier as OperationOwner).ownedOperations.findFirst [
@@ -168,7 +168,7 @@ reaction JavaMemberDeleted {
 
 routine deleteUmlMethod(java::Member jMem) {
 	match {
-		val uMem = retrieve uml::NamedElement corresponding to jMem tagged with ""
+		val uMem = retrieve uml::NamedElement corresponding to jMem tagged ""
 	}
 	update {
 		removeObject(uMem)
@@ -178,7 +178,7 @@ routine deleteUmlMethod(java::Member jMem) {
 
 routine deleteAccessorCorrespondence(java::Member jMember, String tag) {
 	match {
-		val uProperty = retrieve uml::Property corresponding to jMember tagged with tag
+		val uProperty = retrieve uml::Property corresponding to jMember tagged tag
 	}
 	update {
 		removeCorrespondenceBetween(uProperty, jMember, tag)
@@ -354,7 +354,7 @@ reaction JavaVisibilityModifierRemoved {
 
 routine changeUmlNamedElementVisibility(java::AnnotableAndModifiable jElem) {
 	match {
-		val uElem = retrieve uml::NamedElement corresponding to jElem tagged with ""
+		val uElem = retrieve uml::NamedElement corresponding to jElem tagged ""
 	}
 	update {
 		uElem.visibility = getUmlVisibilityKindFromJavaElement(jElem)
@@ -369,7 +369,7 @@ reaction JavaNamedElementRenamed {
 
 routine renameUmlNamedElement(java::NamedElement jElement) {
 	match {
-		val uElement = retrieve uml::NamedElement corresponding to jElement tagged with ""
+		val uElement = retrieve uml::NamedElement corresponding to jElement tagged ""
 	}
 	update {
 		uElement.name = jElement.name

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlTypePropagation.reactions
@@ -34,13 +34,14 @@ routine propagateParameterTypeChange(java::Parameter jParam, uml::Parameter uPar
 
 // ******** general variants to reduce code duplication. If possible please use the facade routines above
 routine propagateTypeChangeToTypedMultiplicityElement(uml::TypedElement uTyped, uml::MultiplicityElement uMultiplicity, // same element -- uml::Property or uml::Parameter
-		java::TypedElement jElement // java::Field, java::Parameter, or java::Method
+java::TypedElement jElement // java::Field, java::Parameter, or java::Method
 ) {
 	match {
 		check {
-			if(uTyped !== uMultiplicity) {
-				throw new IllegalStateException("uml::TypedElement uTyped, uml::MultiplicityElement uMultiplicity"
-					+ "have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
+			if (uTyped !== uMultiplicity) {
+				throw new IllegalStateException(
+					"uml::TypedElement uTyped, uml::MultiplicityElement uMultiplicity" +
+						"have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
 				)
 			}
 			true
@@ -51,16 +52,17 @@ routine propagateTypeChangeToTypedMultiplicityElement(uml::TypedElement uTyped, 
 		val jType = jElement.typeReference
 		val isCollectionReference = isCollectionTypeReference(jType)
 		val newJavaType = if (isCollectionReference) {
-			uMultiplicity.lower = 0
-			uMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
-			getInnerTypeRefOfCollectionReference(jType)
-		} else {
-			jType
-		}
-		if (newJavaType !== null && newJavaType.target instanceof ConcreteClassifier && newJavaType.target.containingCompilationUnit.namespaces.head == "java") {
+				uMultiplicity.lower = 0
+				uMultiplicity.upper = LiteralUnlimitedNatural.UNLIMITED
+				getInnerTypeRefOfCollectionReference(jType)
+			} else {
+				jType
+			}
+		if (newJavaType !== null && newJavaType.target instanceof ConcreteClassifier &&
+			newJavaType.target.containingCompilationUnit.namespaces.head == "java") {
 			createExistingUmlClassifier(newJavaType.target as ConcreteClassifier)
 		}
-		val newUmlType = getUmlTypeFromReference(newJavaType, [sourceElement, expectedType, tag |
+		val newUmlType = getUmlTypeFromReference(newJavaType, [ sourceElement, expectedType, tag |
 			getCorrespondingElement(sourceElement, expectedType, null, tag, false)
 		])
 		if (!EcoreUtil.equals(existingUmlType, newUmlType)) {
@@ -120,7 +122,9 @@ routine createExistingUmlPackage(String namespaces) {
 	update {
 		var org.eclipse.uml2.uml.Package currentPackage = umlModel
 		for (namespace : namespaces.split("\\.")) {
-			val existingUmlPackage = currentPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).findFirst[name == namespace]
+			val existingUmlPackage = currentPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).findFirst [
+				name == namespace
+			]
 			currentPackage = if (existingUmlPackage !== null) {
 				existingUmlPackage
 			} else {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJava.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJava.reactions
@@ -8,3 +8,4 @@ execute actions in java
 import umlToJavaAttribute using qualified names
 import umlToJavaClassifier using qualified names
 import umlToJavaMethod using qualified names
+

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
@@ -2,10 +2,8 @@ import org.eclipse.uml2.uml.Property
 import org.emftext.language.java.members.ClassMethod
 import org.emftext.language.java.members.Field
 import tools.vitruv.applications.umljava.util.UmlJavaCorrespondenceTag
-
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
 import static tools.vitruv.applications.util.temporary.java.JavaMemberAndParameterUtil.*
-
 import static extension edu.kit.ipd.sdq.commons.util.java.lang.IterableUtil.claimNotMany
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 
@@ -21,99 +19,104 @@ import routines umlToJavaTypePropagation using qualified names
 //We can not define one single reaction for attribute creation in enums and classes because
 //they don't share a common superclass for "having ownedAttributes"
 reaction UmlPropertyInsertedInClass {
-    after element uml::Property inserted in uml::Class[ownedAttribute]
-    call {
-        createOrFindJavaField(newValue, affectedEObject)
-        insertJavaField(newValue, affectedEObject)
-    }
+	after element uml::Property inserted in uml::Class[ownedAttribute]
+	call {
+		createOrFindJavaField(newValue, affectedEObject)
+		insertJavaField(newValue, affectedEObject)
+	}
 }
 
 reaction UmlPropertyInsertedInDataType {
-    after element uml::Property inserted in uml::DataType[ownedAttribute]
-    call {
-        createOrFindJavaField(newValue, affectedEObject)
-        insertJavaField(newValue, affectedEObject)
-    }
+	after element uml::Property inserted in uml::DataType[ownedAttribute]
+	call {
+		createOrFindJavaField(newValue, affectedEObject)
+		insertJavaField(newValue, affectedEObject)
+	}
 }
 
 routine createOrFindJavaField(uml::Property umlProperty, uml::Classifier umlClassifier) {
-    match {
-        val jClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-        require absence of java::Field corresponding to umlProperty
-    }
-    update {
-        val foundField = jClassifier.members.filter(Field).filter[name == umlProperty.name].claimNotMany
-        if (foundField === null) {
-            createJavaField(umlProperty) 
-        } else {
-            addAttributeCorrespondence(umlProperty, foundField)
-            val getter = jClassifier.methods.filter(ClassMethod).filter [ name == buildGetterName(umlProperty.name) ].claimNotMany
-            val setter = jClassifier.methods.filter(ClassMethod).filter [ name == buildSetterName(umlProperty.name) ].claimNotMany
-            if (getter !== null) {
-            	createAccessorCorrespondence(umlProperty, getter, UmlJavaCorrespondenceTag.GETTER)
-            }
-            if (setter !== null) {
-            	createAccessorCorrespondence(umlProperty, setter, UmlJavaCorrespondenceTag.SETTER)
-            }
-        }
-        changeJavaAttributeType(umlProperty)
-    }    
+	match {
+		val jClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
+		require absence of java::Field corresponding to umlProperty
+	}
+	update {
+		val foundField = jClassifier.members.filter(Field).filter[name == umlProperty.name].claimNotMany
+		if (foundField === null) {
+			createJavaField(umlProperty)
+		} else {
+			addAttributeCorrespondence(umlProperty, foundField)
+			val getter = jClassifier.methods.filter(ClassMethod).filter[name == buildGetterName(umlProperty.name)].
+				claimNotMany
+			val setter = jClassifier.methods.filter(ClassMethod).filter[name == buildSetterName(umlProperty.name)].
+				claimNotMany
+			if (getter !== null) {
+				createAccessorCorrespondence(umlProperty, getter, UmlJavaCorrespondenceTag.GETTER)
+			}
+			if (setter !== null) {
+				createAccessorCorrespondence(umlProperty, setter, UmlJavaCorrespondenceTag.SETTER)
+			}
+		}
+		changeJavaAttributeType(umlProperty)
+	}
 }
 
 routine createJavaField(uml::Property umlProperty) {
-    match {
-        require absence of java::Field corresponding to umlProperty
-    }
-    create {
-    	val javaField = new java::Field
-    }
-    update {
-        javaField.name = umlProperty.name
-        javaField.makePublic
-        addCorrespondenceBetween(umlProperty, javaField)
-        createOrFindJavaGetter(umlProperty, javaField)
-        createOrFindJavaSetter(umlProperty, javaField)
-    }
+	match {
+		require absence of java::Field corresponding to umlProperty
+	}
+	create {
+		val javaField = new java::Field
+	}
+	update {
+		javaField.name = umlProperty.name
+		javaField.makePublic
+		addCorrespondenceBetween(umlProperty, javaField)
+		createOrFindJavaGetter(umlProperty, javaField)
+		createOrFindJavaSetter(umlProperty, javaField)
+	}
 }
 
 routine addAttributeCorrespondence(uml::Property umlAttribute, java::Field javaField) {
-     update {
-         addCorrespondenceBetween(umlAttribute, javaField)
-     }
+	update {
+		addCorrespondenceBetween(umlAttribute, javaField)
+	}
 }
 
 routine insertJavaField(uml::Property umlProperty, uml::Classifier umlClassifier) {
-    match {
-        val javaField = retrieve java::Field corresponding to umlProperty
-        val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-        val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.GETTER
-        val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.SETTER
-    }
-    update {
-        javaClassifier.members += javaField
-        javaGetter.ifPresent [ javaClassifier.members += it ]
-        javaSetter.ifPresent [ javaClassifier.members += it ]
-    }
+	match {
+		val javaField = retrieve java::Field corresponding to umlProperty
+		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
+		val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.
+			GETTER
+		val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.
+			SETTER
+	}
+	update {
+		javaClassifier.members += javaField
+		javaGetter.ifPresent[javaClassifier.members += it]
+		javaSetter.ifPresent[javaClassifier.members += it]
+	}
 }
 
 reaction UmlAttributeDeleted {
-    after element uml::Property deleted
-    call deleteJavaField(affectedEObject)
+	after element uml::Property deleted
+	call deleteJavaField(affectedEObject)
 }
 
 routine deleteJavaField(uml::Property umlProperty) {
-    match {
-        val javaField = retrieve java::Field corresponding to umlProperty
-        val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.GETTER
-        val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.SETTER
-
-    }
-    update {
-        removeObject(javaField)
-        removeCorrespondenceBetween(javaField, umlProperty)
-    	deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.GETTER)
-    	deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.SETTER)
-    }
+	match {
+		val javaField = retrieve java::Field corresponding to umlProperty
+		val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.
+			GETTER
+		val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.
+			SETTER
+	}
+	update {
+		removeObject(javaField)
+		removeCorrespondenceBetween(javaField, umlProperty)
+		deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.GETTER)
+		deleteJavaAccessor(umlProperty, UmlJavaCorrespondenceTag.SETTER)
+	}
 }
 
 routine deleteJavaAccessor(uml::Property umlProperty, String tag) {
@@ -127,118 +130,123 @@ routine deleteJavaAccessor(uml::Property umlProperty, String tag) {
 }
 
 reaction UmlAttributeMadeFinal {
-    after attribute replaced at uml::Property[isReadOnly]
-    call setJavaAttributeFinal(affectedEObject)
+	after attribute replaced at uml::Property[isReadOnly]
+	call setJavaAttributeFinal(affectedEObject)
 }
 
 routine setJavaAttributeFinal(uml::Property umlAttr) {
-    match {
-        val jAttr = retrieve java::Field corresponding to umlAttr
-    }
-    update {
-        jAttr.final = umlAttr.readOnly
-    }
+	match {
+		val jAttr = retrieve java::Field corresponding to umlAttr
+	}
+	update {
+		jAttr.final = umlAttr.readOnly
+	}
 }
 
 reaction UmlAttributeMadeStatic {
-    after attribute replaced at uml::Property[isStatic]
-    call setStatic(affectedEObject)
+	after attribute replaced at uml::Property[isStatic]
+	call setStatic(affectedEObject)
 }
 
 routine setStatic(uml::Property umlAttr) {
-    match {
-        val jAttr = retrieve java::Field corresponding to umlAttr tagged with ""
-    }
-    update {
-        jAttr.static = umlAttr.isStatic
-        //TODO: updating the static property of a java field requires an update of its corresponding accessors
-    }
+	match {
+		val jAttr = retrieve java::Field corresponding to umlAttr tagged with ""
+	}
+	update {
+		jAttr.static = umlAttr.isStatic
+	// TODO: updating the static property of a java field requires an update of its corresponding accessors
+	}
 }
 
 reaction UmlAttributeTypeChanged {
-    after element uml::Type replaced at uml::Property[type]
-    call changeJavaAttributeType(affectedEObject)
+	after element uml::Type replaced at uml::Property[type]
+	call changeJavaAttributeType(affectedEObject)
 }
 
 reaction UmlLowerMultiplicityChanged {
-    after attribute replaced at uml::LiteralInteger[value]
-    with affectedEObject.owner instanceof Property
-    call changeJavaAttributeType(affectedEObject.owner as Property)
+	after attribute replaced at uml::LiteralInteger[value]
+	with affectedEObject.owner instanceof Property
+	call changeJavaAttributeType(affectedEObject.owner as Property)
 }
 
 reaction UmlUpperMultiplicityChanged {
-    after attribute replaced at uml::LiteralUnlimitedNatural[value]
-    with affectedEObject.owner instanceof Property
-    call changeJavaAttributeType(affectedEObject.owner as Property)
+	after attribute replaced at uml::LiteralUnlimitedNatural[value]
+	with affectedEObject.owner instanceof Property
+	call changeJavaAttributeType(affectedEObject.owner as Property)
 }
 
 routine changeJavaAttributeType(uml::Property uAttribute) {
-    match {
-        val jAttribute = retrieve java::Field corresponding to uAttribute
-        val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uAttribute.type
-        val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.GETTER
-        val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.SETTER
-    }
-    update {
-        umlToJavaTypePropagation.propagatePropertyTypeChanged(uAttribute, jAttribute, jCustomType.orElse(null))
-        jGetter.ifPresent [ updateAttributeTypeInGetter(it, jAttribute) ]
-        jSetter.ifPresent [ updateAttributeTypeInSetter(it, jAttribute) ]
-    }
+	match {
+		val jAttribute = retrieve java::Field corresponding to uAttribute
+		val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uAttribute.type
+		val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.
+			GETTER
+		val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.
+			SETTER
+	}
+	update {
+		umlToJavaTypePropagation.propagatePropertyTypeChanged(uAttribute, jAttribute, jCustomType.orElse(null))
+		jGetter.ifPresent[updateAttributeTypeInGetter(it, jAttribute)]
+		jSetter.ifPresent[updateAttributeTypeInSetter(it, jAttribute)]
+	}
 }
 
-
 routine createOrFindJavaGetter(uml::Property uAttribute, java::Field jAttribute) {
-    update {
-        var javaGetter = getJavaGettersOfAttribute(jAttribute).head
-        if (javaGetter === null) {
-            javaGetter = createGetterForAttribute(jAttribute)
-        }
-        createAccessorCorrespondence(uAttribute, javaGetter, UmlJavaCorrespondenceTag.GETTER)
-    }
+	update {
+		var javaGetter = getJavaGettersOfAttribute(jAttribute).head
+		if (javaGetter === null) {
+			javaGetter = createGetterForAttribute(jAttribute)
+		}
+		createAccessorCorrespondence(uAttribute, javaGetter, UmlJavaCorrespondenceTag.GETTER)
+	}
 }
 
 routine createOrFindJavaSetter(uml::Property uAttribute, java::Field jAttribute) {
-    update {
-        var javaSetter = getJavaSettersOfAttribute(jAttribute).head
-        if (javaSetter === null) {
-            javaSetter = createSetterForAttribute(jAttribute)
-        }
-        createAccessorCorrespondence(uAttribute, javaSetter, UmlJavaCorrespondenceTag.SETTER)
-    }
+	update {
+		var javaSetter = getJavaSettersOfAttribute(jAttribute).head
+		if (javaSetter === null) {
+			javaSetter = createSetterForAttribute(jAttribute)
+		}
+		createAccessorCorrespondence(uAttribute, javaSetter, UmlJavaCorrespondenceTag.SETTER)
+	}
 }
 
 routine createAccessorCorrespondence(uml::Property uAttribute, java::ClassMethod jMethod, String tag) {
-    update {
-        addCorrespondenceBetween(uAttribute, jMethod, tag)
-    }
+	update {
+		addCorrespondenceBetween(uAttribute, jMethod, tag)
+	}
 }
 
 reaction UmlAttributeRenamed {
-    after attribute replaced at uml::Property[name]
-    call renameJavaAttribute(newValue, oldValue, affectedEObject)
+	after attribute replaced at uml::Property[name]
+	call renameJavaAttribute(newValue, oldValue, affectedEObject)
 }
 
 routine renameJavaAttribute(String newName, String oldName, uml::Property uAttribute) {
-    match {
-        val jAttribute = retrieve java::Field corresponding to uAttribute
-        val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.GETTER
-        val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.SETTER
-    }
-    update {
-        jAttribute.name = uAttribute.name
-        jGetter.ifPresent [ renameGetterOfAttribute(it, jAttribute) ]
-        jSetter.ifPresent [ renameSetter(it, jAttribute, oldName) ]
-    }
+	match {
+		val jAttribute = retrieve java::Field corresponding to uAttribute
+		val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.
+			GETTER
+		val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.
+			SETTER
+	}
+	update {
+		jAttribute.name = uAttribute.name
+		jGetter.ifPresent[renameGetterOfAttribute(it, jAttribute)]
+		jSetter.ifPresent[renameSetter(it, jAttribute, oldName)]
+	}
 }
 
 reaction UmlAttributeCreatedInInterface {
-    after element uml::Property inserted in uml::Interface[ownedAttribute]
-    call showMessage(userInteractor, "We do not support adding attributes to interfaces. Please delete " + newValue + " from " + affectedEObject)
+	after element uml::Property inserted in uml::Interface[ownedAttribute]
+	call showMessage(userInteractor,
+		"We do not support adding attributes to interfaces. Please delete " + newValue + " from " + affectedEObject)
 }
 
 reaction UmlInterfaceMadeFinal {
-    after attribute replaced at uml::Interface[isFinalSpecialization]
-    with newValue == true
-    call showMessage(userInteractor, "We do not support making final interfaces. Please change " + affectedEObject + " to non-final. ")
+	after attribute replaced at uml::Interface[isFinalSpecialization]
+	with newValue == true
+	call showMessage(userInteractor,
+		"We do not support making final interfaces. Please change " + affectedEObject + " to non-final. ")
 }
 

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaAttribute.reactions
@@ -86,9 +86,9 @@ routine insertJavaField(uml::Property umlProperty, uml::Classifier umlClassifier
 	match {
 		val javaField = retrieve java::Field corresponding to umlProperty
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-		val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.
+		val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged UmlJavaCorrespondenceTag.
 			GETTER
-		val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.
+		val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged UmlJavaCorrespondenceTag.
 			SETTER
 	}
 	update {
@@ -106,9 +106,9 @@ reaction UmlAttributeDeleted {
 routine deleteJavaField(uml::Property umlProperty) {
 	match {
 		val javaField = retrieve java::Field corresponding to umlProperty
-		val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.
+		val javaGetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged UmlJavaCorrespondenceTag.
 			GETTER
-		val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged with UmlJavaCorrespondenceTag.
+		val javaSetter = retrieve optional java::ClassMethod corresponding to umlProperty tagged UmlJavaCorrespondenceTag.
 			SETTER
 	}
 	update {
@@ -121,7 +121,7 @@ routine deleteJavaField(uml::Property umlProperty) {
 
 routine deleteJavaAccessor(uml::Property umlProperty, String tag) {
 	match {
-		val javaAccessor = retrieve java::ClassMethod corresponding to umlProperty tagged with tag
+		val javaAccessor = retrieve java::ClassMethod corresponding to umlProperty tagged tag
 	}
 	update {
 		removeObject(javaAccessor)
@@ -150,7 +150,7 @@ reaction UmlAttributeMadeStatic {
 
 routine setStatic(uml::Property umlAttr) {
 	match {
-		val jAttr = retrieve java::Field corresponding to umlAttr tagged with ""
+		val jAttr = retrieve java::Field corresponding to umlAttr tagged ""
 	}
 	update {
 		jAttr.static = umlAttr.isStatic
@@ -179,9 +179,9 @@ routine changeJavaAttributeType(uml::Property uAttribute) {
 	match {
 		val jAttribute = retrieve java::Field corresponding to uAttribute
 		val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uAttribute.type
-		val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.
+		val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged UmlJavaCorrespondenceTag.
 			GETTER
-		val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.
+		val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged UmlJavaCorrespondenceTag.
 			SETTER
 	}
 	update {
@@ -225,9 +225,9 @@ reaction UmlAttributeRenamed {
 routine renameJavaAttribute(String newName, String oldName, uml::Property uAttribute) {
 	match {
 		val jAttribute = retrieve java::Field corresponding to uAttribute
-		val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.
+		val jGetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged UmlJavaCorrespondenceTag.
 			GETTER
-		val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged with UmlJavaCorrespondenceTag.
+		val jSetter = retrieve optional java::ClassMethod corresponding to uAttribute tagged UmlJavaCorrespondenceTag.
 			SETTER
 	}
 	update {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -8,12 +8,10 @@ import org.eclipse.uml2.uml.UMLPackage
 import org.emftext.language.java.containers.ContainersPackage
 import tools.vitruv.change.interaction.UserInteractionOptions.NotificationType
 import tools.vitruv.change.interaction.UserInteractionOptions.WindowModality
-
 import static extension tools.vitruv.applications.umljava.util.UmlJavaTypePropagationHelper.*
 import static tools.vitruv.applications.util.temporary.java.JavaTypeUtil.*
 import static tools.vitruv.applications.util.temporary.java.JavaPersistenceHelper.*
 import static com.google.common.base.Preconditions.checkState
-
 import static extension tools.vitruv.applications.util.temporary.uml.UmlClassifierAndPackageUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaContainerAndClassifierUtil.*
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
@@ -30,8 +28,6 @@ execute actions in java
 //===========================================
 //=========================================== Class
 //===========================================
-
-
 reaction UmlClassInserted {
 	after element uml::Class inserted in uml::Package[packagedElement]
 	call {
@@ -39,9 +35,9 @@ reaction UmlClassInserted {
 		insertJavaClassifier(newValue, affectedEObject)
 	}
 }
-	
+
 routine createOrFindJavaClass(uml::Classifier umlClassifier) {
-	match{
+	match {
 		require absence of java::Class corresponding to umlClassifier
 		val javaPackage = retrieve optional java::Package corresponding to umlClassifier.eContainer
 	}
@@ -57,7 +53,7 @@ routine createOrFindJavaClass(uml::Classifier umlClassifier) {
 routine createOrFindJavaClassInPackage(uml::Classifier umlClassifier, java::Package javaPackage) {
 	update {
 		val foundClass = findClassifier(umlClassifier.name, javaPackage, org.emftext.language.java.classifiers.Class)
-		if(foundClass === null) {
+		if (foundClass === null) {
 			createJavaClass(umlClassifier)
 		} else {
 			addMissingClassifierCorrespondence(umlClassifier, foundClass)
@@ -72,7 +68,7 @@ routine createJavaClass(uml::Classifier umlClassifier) {
 	update {
 		javaClassifier.name = umlClassifier.name
 		javaClassifier.makePublic
-		createJavaCompilationUnit (umlClassifier, javaClassifier)
+		createJavaCompilationUnit(umlClassifier, javaClassifier)
 		addCorrespondenceBetween(umlClassifier, javaClassifier)
 	}
 }
@@ -98,7 +94,7 @@ routine insertJavaClassifier(uml::Classifier umlClassifier, uml::Package umlPack
 		val javaPackage = retrieve optional java::Package corresponding to umlPackage
 	}
 	update {
-	    val javaCompilationUnit = javaClassifier.containingCompilationUnit
+		val javaCompilationUnit = javaClassifier.containingCompilationUnit
 		var modified = javaCompilationUnit.updateNamespaces(javaPackage)
 		val newName = getCompilationUnitName(javaPackage, javaClassifier.name)
 		modified = javaCompilationUnit.updateName(newName) || modified
@@ -140,8 +136,8 @@ routine deleteJavaClass(uml::Classifier umlClassifier) {
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
 	}
 	update {
-	    removeObject(javaClassifier.containingCompilationUnit)
-	    removeCorrespondenceBetween(javaClassifier.containingCompilationUnit, umlClassifier)
+		removeObject(javaClassifier.containingCompilationUnit)
+		removeCorrespondenceBetween(javaClassifier.containingCompilationUnit, umlClassifier)
 	}
 }
 
@@ -186,14 +182,15 @@ routine addJavaSuperClass(uml::Class uClass, uml::Generalization uGeneralization
 	}
 	update {
 		if (uClass.generals.size == 1) {
-			var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null, userInteractor)
+			var typeReference = createTypeReference(uGeneralization.general as Class, Optional.^of(jSuperClass), null,
+				userInteractor)
 			addJavaImport(jClass.containingCompilationUnit, typeReference)
 			jClass.extends = typeReference
 			addGeneralizationCorrespondence(uGeneralization, typeReference)
 		} else {
-			userInteractor.notificationDialogBuilder.message("Can not synchronize multiple inheritance for " + uClass)
-				.title("Warning").notificationType(NotificationType.WARNING).windowModality(WindowModality.MODAL)
-				.startInteraction
+			userInteractor.notificationDialogBuilder.message("Can not synchronize multiple inheritance for " + uClass).
+				title("Warning").notificationType(NotificationType.WARNING).windowModality(WindowModality.MODAL).
+				startInteraction
 			logger.warn("Routine not executed: Tried to set multiple inheritance for " + uClass)
 		}
 	}
@@ -216,7 +213,9 @@ routine deleteJavaSuperClass(uml::Generalization uGeneralization) {
 
 reaction UmlSuperClassReplaced {
 	after element uml::Class replaced at uml::Generalization[general]
-	with {affectedEObject.specific !== null && affectedEObject.specific instanceof Class}
+	with {
+		affectedEObject.specific !== null && affectedEObject.specific instanceof Class
+	}
 	call {
 		val uGeneralization = affectedEObject
 		val uClass = affectedEObject.specific as Class
@@ -232,7 +231,7 @@ reaction UmlInterfaceRealizationCreated {
 	call createJavaClassImplementsReference(newValue, affectedEObject)
 }
 
-routine createJavaClassImplementsReference(uml::InterfaceRealization uRealization, uml::Class uClass){
+routine createJavaClassImplementsReference(uml::InterfaceRealization uRealization, uml::Class uClass) {
 	match {
 		val jClass = retrieve java::Class corresponding to uClass
 		val jInterface = retrieve java::Interface corresponding to uRealization.contract
@@ -240,11 +239,13 @@ routine createJavaClassImplementsReference(uml::InterfaceRealization uRealizatio
 	}
 	update {
 		val matchingReference = jClass.implements.filter[target == jInterface]
-		checkState(matchingReference.size <= 1, "There is more than one implementation of Java interface %s in class %s", jInterface, jClass)
+		checkState(matchingReference.size <= 1,
+			"There is more than one implementation of Java interface %s in class %s", jInterface, jClass)
 		if (matchingReference.size == 1) {
 			addImplementsCorrespondence(uRealization, matchingReference.get(0))
 		} else {
-			var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null, userInteractor)
+			var typeReference = createTypeReference(uRealization.contract, Optional.^of(jInterface), null,
+				userInteractor)
 			addJavaImport(jClass.containingCompilationUnit, typeReference)
 			jClass.implements += typeReference
 			addImplementsCorrespondence(uRealization, typeReference)
@@ -280,8 +281,7 @@ routine deleteJavaClassImplementsReference(uml::InterfaceRealization uRealizatio
 
 reaction UmlInterfaceRealizationReplaced {
 	after element replaced at uml::InterfaceRealization[contract]
-	with affectedEObject.implementingClassifier !== null
-		&& affectedEObject.implementingClassifier instanceof Class
+	with affectedEObject.implementingClassifier !== null && affectedEObject.implementingClassifier instanceof Class
 	call {
 		val uRealization = affectedEObject
 		val uClass = affectedEObject.implementingClassifier as Class
@@ -292,12 +292,9 @@ reaction UmlInterfaceRealizationReplaced {
 	}
 }
 
-
-
 reaction UmlDataTypeInserted {
 	after element uml::DataType inserted in uml::Package[packagedElement]
-	with !(newValue instanceof PrimitiveType)
-		&& !(newValue instanceof Enumeration)
+	with !(newValue instanceof PrimitiveType) && !(newValue instanceof Enumeration)
 	call {
 		createOrFindJavaClass(newValue)
 		insertJavaClassifier(newValue, affectedEObject)
@@ -307,8 +304,6 @@ reaction UmlDataTypeInserted {
 //===========================================
 //=========================================== Interface
 //===========================================
-
-
 reaction UmlInterfaceInserted {
 	after element uml::Interface inserted in uml::Package[packagedElement]
 	call {
@@ -333,8 +328,9 @@ routine createOrFindJavaInterface(uml::Interface umlInterface) {
 
 routine createOrFindJavaInterfaceInPackage(uml::Interface umlInterface, java::Package javaPackage) {
 	update {
-		val foundInterface = findClassifier(umlInterface.name, javaPackage, org.emftext.language.java.classifiers.Interface)
-		if(foundInterface === null) {
+		val foundInterface = findClassifier(umlInterface.name, javaPackage,
+			org.emftext.language.java.classifiers.Interface)
+		if (foundInterface === null) {
 			createJavaInterface(umlInterface)
 		} else {
 			addMissingClassifierCorrespondence(umlInterface, foundInterface)
@@ -369,7 +365,8 @@ routine addJavaSuperInterface(uml::Interface uInterface, uml::Generalization uGe
 		require absence of java::TypeReference corresponding to uGeneralization
 	}
 	update {
-		var typeReference = createTypeReference(uGeneralization.general as Interface, Optional.^of(jSuperInterface), null, userInteractor)
+		var typeReference = createTypeReference(uGeneralization.general as Interface, Optional.^of(jSuperInterface),
+			null, userInteractor)
 		addJavaImport(jInterface.containingCompilationUnit, typeReference)
 		jInterface.extends += typeReference
 		addGeneralizationCorrespondence(uGeneralization, typeReference)
@@ -404,9 +401,9 @@ routine deleteJavaSuperInterface(uml::Generalization uGeneralization) {
 reaction UmlSuperInterfaceReplaced {
 	after element uml::Interface replaced at uml::Generalization[general]
 	call {
-		if(oldValue !== null)
+		if (oldValue !== null)
 			deleteJavaSuperInterface(affectedEObject)
-		if(affectedEObject.specific !== null && affectedEObject.specific instanceof Interface)
+		if (affectedEObject.specific !== null && affectedEObject.specific instanceof Interface)
 			addJavaSuperInterface(affectedEObject.specific as Interface, affectedEObject)
 	}
 }
@@ -414,8 +411,6 @@ reaction UmlSuperInterfaceReplaced {
 //===========================================
 //=========================================== Enum
 //===========================================
-
-
 reaction UmlEnumInserted {
 	after element uml::Enumeration inserted in uml::Package[packagedElement]
 	call {
@@ -477,11 +472,11 @@ routine deleteJavaEnumConstant(uml::EnumerationLiteral uLiteral) {
 //===========================================
 //=========================================== Package
 //===========================================
-
 reaction UmlModelCreated {
 	after element uml::Model inserted as root
 	call checkIfUmlModelCorrespondenceExists(newValue)
 }
+
 routine checkIfUmlModelCorrespondenceExists(uml::Model newModel) {
 	match {
 		val alreadyCorrespondingModels = retrieve many uml::Model corresponding to UMLPackage.Literals.MODEL
@@ -505,7 +500,6 @@ routine removeUmlModel(uml::Model removedModel) {
 	}
 }
 
-
 reaction UmlPackageInserted {
 	after element uml::Package inserted in uml::Package[packagedElement]
 	call {
@@ -517,11 +511,12 @@ reaction UmlPackageInserted {
 routine createOrFindJavaPackage(uml::Package uPackage) {
 	match {
 		require absence of java::Package corresponding to uPackage
-		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.PACKAGE
-		with matchingPackages.namespacesAsString + matchingPackages.name == getUmlNamespaceAsString(uPackage)
+		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.
+			PACKAGE with matchingPackages.namespacesAsString + matchingPackages.name ==
+			getUmlNamespaceAsString(uPackage)
 	}
 	update {
-		if(matchingPackages.empty) {
+		if (matchingPackages.empty) {
 			createJavaPackage(uPackage)
 		} else {
 			addPackageCorrespondence(uPackage, matchingPackages.head)
@@ -579,7 +574,7 @@ routine renameJavaPackage(uml::Package uPackage, uml::Namespace uNamespace) {
 routine changePackageOfJavaCompilationUnit(java::Package jPackage, java::CompilationUnit jCompUnit, uml::Namespace uNamespace) {
 	update {
 		if (jCompUnit.updateNamespaces(jPackage)) {
-			persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))	
+			persistProjectRelative(uNamespace, jCompUnit, buildJavaFilePath(jCompUnit))
 		}
 	}
 }
@@ -596,7 +591,7 @@ routine deleteJavaPackage(uml::Package uPackage) {
 	update {
 		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Package).forEach[deleteJavaPackage()]
 		uPackage.packagedElements.filter(org.eclipse.uml2.uml.Class).forEach[deleteJavaClass()]
-		jPackage.ifPresent[
+		jPackage.ifPresent [
 			removeObject(it)
 			removeCorrespondenceBetween(uPackage, it)
 		]
@@ -611,14 +606,11 @@ reaction UmlPrimitiveTypeInserted {
 routine validateSupportedPrimitiveType(uml::PrimitiveType type) {
 	update {
 		if (!type.isSupportedUmlPrimitiveType()) {
-			userInteractor.notificationDialogBuilder
-				.message("Only predefined uml::PrimitiveTypes will be mapped properly. "
-					+ "Please use the types defined in \"pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml\" "
-					+ "or \"pathmap://UML_LIBRARIES/JavaPrimitiveTypes.library.uml\" instead.")
-				.title("Warning")
-				.notificationType(NotificationType.WARNING)
-				.windowModality(WindowModality.MODAL)
-				.startInteraction
+			userInteractor.notificationDialogBuilder.message(
+				"Only predefined uml::PrimitiveTypes will be mapped properly. " +
+					"Please use the types defined in \"pathmap://UML_LIBRARIES/UMLPrimitiveTypes.library.uml\" " +
+					"or \"pathmap://UML_LIBRARIES/JavaPrimitiveTypes.library.uml\" instead.").title("Warning").
+				notificationType(NotificationType.WARNING).windowModality(WindowModality.MODAL).startInteraction
 		}
 	}
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -10,9 +10,7 @@ import org.emftext.language.java.members.Constructor
 import org.emftext.language.java.members.InterfaceMethod
 import org.emftext.language.java.members.Method
 import org.emftext.language.java.types.TypesFactory
-
 import static tools.vitruv.applications.umljava.util.CommonUtil.showMessage
-
 import static extension tools.vitruv.applications.util.temporary.java.JavaModifierUtil.*
 
 import "http://www.eclipse.org/uml2/5.0.0/UML" as uml
@@ -27,441 +25,427 @@ import routines umlToJavaTypePropagation using qualified names
 //===========================================
 //=========================================== Method
 //===========================================
-
-
 //We can not define one single reaction for attribute creation in enums and classes because
 //they don't share a common superclass for "having ownedOperations"
 reaction UmlOperationInsertedInClass {
-    after element uml::Operation inserted in uml::Class[ownedOperation]
-    call {
-        createOrFindJavaConstructor(newValue, affectedEObject)
-        createOrFindJavaClassMethod(newValue, affectedEObject)
-        insertJavaMethod(newValue, affectedEObject)       
-    }
+	after element uml::Operation inserted in uml::Class[ownedOperation]
+	call {
+		createOrFindJavaConstructor(newValue, affectedEObject)
+		createOrFindJavaClassMethod(newValue, affectedEObject)
+		insertJavaMethod(newValue, affectedEObject)
+	}
 }
 
 reaction UmlOperationInsertedInDataType {
-    after element uml::Operation inserted in uml::DataType[ownedOperation]
-    call {
-        createOrFindJavaConstructor(newValue, affectedEObject)
-        createOrFindJavaClassMethod(newValue, affectedEObject)
-        insertJavaMethod(newValue, affectedEObject)       
-    }
+	after element uml::Operation inserted in uml::DataType[ownedOperation]
+	call {
+		createOrFindJavaConstructor(newValue, affectedEObject)
+		createOrFindJavaClassMethod(newValue, affectedEObject)
+		insertJavaMethod(newValue, affectedEObject)
+	}
 }
 
 reaction UmlMethodInsertedInInterface {
-    after element uml::Operation inserted in uml::Interface[ownedOperation]
-    call {
-        createOrFindJavaInterfaceMethod(newValue, affectedEObject)
-        insertJavaMethod(newValue, affectedEObject)
-    }
+	after element uml::Operation inserted in uml::Interface[ownedOperation]
+	call {
+		createOrFindJavaInterfaceMethod(newValue, affectedEObject)
+		insertJavaMethod(newValue, affectedEObject)
+	}
 }
 
 routine createOrFindJavaConstructor(uml::Operation umlOperation, uml::Classifier umlClassifier) {
-    match {
-        check umlOperation.name.toFirstUpper == umlClassifier.name.toFirstUpper
-        val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-        require absence of java::Constructor corresponding to umlOperation
-        require absence of java::Method corresponding to umlOperation
-    }
-    update {
-        val foundConstructor = javaClassifier.members.filter(Constructor).findFirst[name == umlOperation.name]
-        if (foundConstructor === null) {
-            createJavaConstructor(umlOperation)
-        } else {
-            addMethodCorrespondence(foundConstructor, umlOperation)
-        }
-    }
+	match {
+		check umlOperation.name.toFirstUpper == umlClassifier.name.toFirstUpper
+		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
+		require absence of java::Constructor corresponding to umlOperation
+		require absence of java::Method corresponding to umlOperation
+	}
+	update {
+		val foundConstructor = javaClassifier.members.filter(Constructor).findFirst[name == umlOperation.name]
+		if (foundConstructor === null) {
+			createJavaConstructor(umlOperation)
+		} else {
+			addMethodCorrespondence(foundConstructor, umlOperation)
+		}
+	}
 }
 
 routine createJavaConstructor(uml::Operation umlOperation) {
 	create {
 		val javaConstructor = new java::Constructor
 	}
-    update {
-    	javaConstructor.name = umlOperation.name
+	update {
+		javaConstructor.name = umlOperation.name
 		setJavaVisibility(javaConstructor, umlOperation.visibility)
 		addCorrespondenceBetween(umlOperation, javaConstructor)
-    }
+	}
 }
 
 routine createOrFindJavaClassMethod(uml::Operation umlOperation, uml::Classifier umlClassifier) {
-    match {
-        check umlOperation.name.toFirstUpper != umlClassifier.name.toFirstUpper // -> constructor
-        val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-        require absence of java::ClassMethod corresponding to umlOperation
-        require absence of java::Constructor corresponding to umlOperation
-    }
-    update {
-        val foundMethod = javaClassifier.members.filter(ClassMethod).findFirst[name == umlOperation.name]
-        if (foundMethod === null) {
-            createJavaClassMethod(umlOperation)
-        } else {
-            addMethodCorrespondence(foundMethod, umlOperation)
-        }
-    }
+	match {
+		check umlOperation.name.toFirstUpper != umlClassifier.name.toFirstUpper // -> constructor
+		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
+		require absence of java::ClassMethod corresponding to umlOperation
+		require absence of java::Constructor corresponding to umlOperation
+	}
+	update {
+		val foundMethod = javaClassifier.members.filter(ClassMethod).findFirst[name == umlOperation.name]
+		if (foundMethod === null) {
+			createJavaClassMethod(umlOperation)
+		} else {
+			addMethodCorrespondence(foundMethod, umlOperation)
+		}
+	}
 }
 
 routine createJavaClassMethod(uml::Operation umlOperation) {
 	create {
 		val javaMethod = new java::ClassMethod
 	}
-    update {
+	update {
 		javaMethod.name = umlOperation.name
-        setJavaVisibility(javaMethod, umlOperation.visibility)
-        addCorrespondenceBetween(umlOperation, javaMethod)
-        setJavaMethodReturnType(umlOperation, umlOperation.getReturnResult)
-    }
+		setJavaVisibility(javaMethod, umlOperation.visibility)
+		addCorrespondenceBetween(umlOperation, javaMethod)
+		setJavaMethodReturnType(umlOperation, umlOperation.getReturnResult)
+	}
 }
 
 routine createOrFindJavaInterfaceMethod(uml::Operation umlOperation, uml::Classifier umlClassifier) {
-    match {
-        val javaClassifier = retrieve java::Interface corresponding to umlClassifier
-        require absence of java::InterfaceMethod corresponding to umlOperation
-    }
-    update {
-        val foundMethod = javaClassifier.members.filter(InterfaceMethod).findFirst[name == umlOperation.name]
-        if (foundMethod === null) {
-            createJavaInterfaceMethod(umlOperation)
-        } else {
-            addMethodCorrespondence(foundMethod, umlOperation)
-        }
-    }
+	match {
+		val javaClassifier = retrieve java::Interface corresponding to umlClassifier
+		require absence of java::InterfaceMethod corresponding to umlOperation
+	}
+	update {
+		val foundMethod = javaClassifier.members.filter(InterfaceMethod).findFirst[name == umlOperation.name]
+		if (foundMethod === null) {
+			createJavaInterfaceMethod(umlOperation)
+		} else {
+			addMethodCorrespondence(foundMethod, umlOperation)
+		}
+	}
 }
 
 routine createJavaInterfaceMethod(uml::Operation umlOperation) {
 	create {
 		val javaMethod = new java::InterfaceMethod
 	}
-    update {
+	update {
 		javaMethod.name = umlOperation.name
 		javaMethod.makePublic
-        addCorrespondenceBetween(umlOperation, javaMethod)
-        setJavaMethodReturnType(umlOperation, umlOperation.getReturnResult)
-    }
+		addCorrespondenceBetween(umlOperation, javaMethod)
+		setJavaMethodReturnType(umlOperation, umlOperation.getReturnResult)
+	}
 }
 
 routine addMethodCorrespondence(java::Member javaMethodOrConstructor, uml::Operation umlOperation) {
-     update {
-         addCorrespondenceBetween(umlOperation, javaMethodOrConstructor)
-     }
+	update {
+		addCorrespondenceBetween(umlOperation, javaMethodOrConstructor)
+	}
 }
 
 routine insertJavaMethod(uml::Operation umlOperation, uml::Classifier umlClassifier) {
-    match {
-        val javaMethod = retrieve java::Member corresponding to umlOperation 
-            with javaMethod instanceof Constructor || javaMethod instanceof Method
-        val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
-    }
-    update {
+	match {
+		val javaMethod = retrieve java::Member corresponding to umlOperation with javaMethod instanceof Constructor ||
+			javaMethod instanceof Method
+		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
+	}
+	update {
 		javaClassifier.members += javaMethod
-    }
+	}
 }
 
 reaction UmlMethodDeleted {
-    after element uml::Operation deleted
-    call deleteJavaMethod(affectedEObject)
+	after element uml::Operation deleted
+	call deleteJavaMethod(affectedEObject)
 }
 
 routine deleteJavaMethod(uml::Operation umlOperation) {
-    match {
-        val javaMethod = retrieve java::Member corresponding to umlOperation 
-            with javaMethod instanceof Constructor || javaMethod instanceof Method
-    }
-    update {
-        removeObject(javaMethod)
-        removeCorrespondenceBetween(javaMethod, umlOperation)
-    }
+	match {
+		val javaMethod = retrieve java::Member corresponding to umlOperation with javaMethod instanceof Constructor ||
+			javaMethod instanceof Method
+	}
+	update {
+		removeObject(javaMethod)
+		removeCorrespondenceBetween(javaMethod, umlOperation)
+	}
 }
 
 reaction UmlMethodReturnTypeChanged {
-    after element uml::Type replaced at uml::Parameter[type]
-    with affectedEObject.direction == ParameterDirectionKind.RETURN_LITERAL
-    call setJavaMethodReturnType(affectedEObject.operation, affectedEObject)
+	after element uml::Type replaced at uml::Parameter[type]
+	with affectedEObject.direction == ParameterDirectionKind.RETURN_LITERAL
+	call setJavaMethodReturnType(affectedEObject.operation, affectedEObject)
 }
 
 // if uParam is null, then the return type will be set to 'void'
 routine setJavaMethodReturnType(uml::Operation uOperation, uml::Parameter uParam) {
-    match {
-        val jMethod = retrieve java::Method corresponding to uOperation
-        val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uParam?.type
-    }
-    update {
-        if (uParam !== null){
-            umlToJavaTypePropagation.propagateReturnParameterTypeChanged(uParam, jMethod, jCustomType.orElse(null))
-        }
-        else {
-            jMethod.typeReference = TypesFactory.eINSTANCE.createVoid
-        }
-    }
+	match {
+		val jMethod = retrieve java::Method corresponding to uOperation
+		val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uParam?.type
+	}
+	update {
+		if (uParam !== null) {
+			umlToJavaTypePropagation.propagateReturnParameterTypeChanged(uParam, jMethod, jCustomType.orElse(null))
+		} else {
+			jMethod.typeReference = TypesFactory.eINSTANCE.createVoid
+		}
+	}
 }
 
 reaction UmlOperationMadeStatic {
-    after attribute replaced at uml::Operation[isStatic]
-    call setStatic(affectedEObject)
+	after attribute replaced at uml::Operation[isStatic]
+	call setStatic(affectedEObject)
 }
 
 routine setStatic(uml::Operation uFeat) {
-    match {
-        val jMethod = retrieve java::Method corresponding to uFeat tagged with ""
-    }
-    update {
+	match {
+		val jMethod = retrieve java::Method corresponding to uFeat tagged with ""
+	}
+	update {
 		jMethod.static = uFeat.isStatic
-    }
+	}
 }
 
 reaction UmlMethodMadeAbstract {
-    after attribute replaced at uml::Operation[isAbstract] 
-    call setJavaMethodAbstract(affectedEObject)
+	after attribute replaced at uml::Operation[isAbstract]
+	call setJavaMethodAbstract(affectedEObject)
 }
 
 routine setJavaMethodAbstract(uml::Operation uOperation) {
-    match {
-        val javaClass = retrieve java::Class corresponding to uOperation.class_
-        val javaMethod = retrieve java::ClassMethod corresponding to uOperation
-    }
-    update {
-        javaMethod.abstract = uOperation.abstract
-    }    
+	match {
+		val javaClass = retrieve java::Class corresponding to uOperation.class_
+		val javaMethod = retrieve java::ClassMethod corresponding to uOperation
+	}
+	update {
+		javaMethod.abstract = uOperation.abstract
+	}
 }
 
 reaction UmlMethodMadeFinal {
-    after attribute replaced at uml::Operation[isLeaf]
-    with !(affectedEObject.class_ instanceof Interface)
-    call setJavaMethodFinal(affectedEObject, newValue)
+	after attribute replaced at uml::Operation[isLeaf]
+	with !(affectedEObject.class_ instanceof Interface)
+	call setJavaMethodFinal(affectedEObject, newValue)
 }
 
 routine setJavaMethodFinal(uml::Operation uOperation, Boolean isFinal) {
-    match {
-        val jMethod = retrieve java::ClassMethod corresponding to uOperation
-    }
-    update {
-        jMethod.final = isFinal
-    }
+	match {
+		val jMethod = retrieve java::ClassMethod corresponding to uOperation
+	}
+	update {
+		jMethod.final = isFinal
+	}
 }
-
 
 //===========================================
 //=========================================== NamedElement
 //===========================================
-
-
 reaction UmlElementVisibilityChanged {
-    after attribute replaced at uml::NamedElement[visibility]
-    with !(affectedEObject.eContainer instanceof Interface)
-    call changeJavaElementVisibility(affectedEObject)
+	after attribute replaced at uml::NamedElement[visibility]
+	with !(affectedEObject.eContainer instanceof Interface)
+	call changeJavaElementVisibility(affectedEObject)
 }
 
 routine changeJavaElementVisibility(uml::NamedElement uElem) {
-    match {
-        val jElem = retrieve java::AnnotableAndModifiable corresponding to uElem tagged with ""
-    }
-    update {
-        setJavaVisibility(jElem, uElem.visibility);
-    }
+	match {
+		val jElem = retrieve java::AnnotableAndModifiable corresponding to uElem tagged with ""
+	}
+	update {
+		setJavaVisibility(jElem, uElem.visibility);
+	}
 }
 
-reaction UmlNamedElementRenamed{
-    after attribute replaced at uml::NamedElement[name] 
-    with !(affectedEObject instanceof Classifier)
-        && !(affectedEObject instanceof Property)
-        && !(affectedEObject instanceof Package)
-    call renameJavaNamedElement(affectedEObject, newValue)
+reaction UmlNamedElementRenamed {
+	after attribute replaced at uml::NamedElement[name]
+	with !(affectedEObject instanceof Classifier) && !(affectedEObject instanceof Property) &&
+		!(affectedEObject instanceof Package)
+	call renameJavaNamedElement(affectedEObject, newValue)
 }
 
 routine renameJavaNamedElement(uml::NamedElement uElem, String name) {
-    match {
-        val jElem = retrieve java::NamedElement corresponding to uElem
-    }
-    update {
-        jElem.name = name
-    }
+	match {
+		val jElem = retrieve java::NamedElement corresponding to uElem
+	}
+	update {
+		jElem.name = name
+	}
 }
-
 
 //===========================================
 //=========================================== Parameter
 //===========================================
-
-
-reaction UmlParameterRenamed{
-    after attribute replaced at uml::Parameter[name]
-    with affectedEObject.direction == ParameterDirectionKind.IN_LITERAL
-    call createMissingJavaParameter(affectedEObject)
+reaction UmlParameterRenamed {
+	after attribute replaced at uml::Parameter[name]
+	with affectedEObject.direction == ParameterDirectionKind.IN_LITERAL
+	call createMissingJavaParameter(affectedEObject)
 }
 
 routine createMissingJavaParameter(uml::Parameter uParameter) {
-    match {
-        require absence of java::OrdinaryParameter corresponding to uParameter
-    }
-    update {
-        createJavaParameter(uParameter.operation, uParameter)
-    }
+	match {
+		require absence of java::OrdinaryParameter corresponding to uParameter
+	}
+	update {
+		createJavaParameter(uParameter.operation, uParameter)
+	}
 }
 
 reaction UmlParameterCreated {
-    after element uml::Parameter inserted in uml::Operation[ownedParameter]
-    with newValue.direction == ParameterDirectionKind.IN_LITERAL && newValue.name !== null
-    call createJavaParameter(affectedEObject, newValue)
-
+	after element uml::Parameter inserted in uml::Operation[ownedParameter]
+	with newValue.direction == ParameterDirectionKind.IN_LITERAL && newValue.name !== null
+	call createJavaParameter(affectedEObject, newValue)
 }
 
 routine createJavaParameter(uml::Operation uMeth, uml::Parameter umlParam) {
-    match {
-        val javaMethod = retrieve java::Parametrizable corresponding to uMeth
-        val customType = retrieve optional java::ConcreteClassifier corresponding to umlParam.type
-        require absence of java::Parameter corresponding to umlParam
-    }
-    create {
-    	val javaParam = new java::OrdinaryParameter
-    }
-    update {
+	match {
+		val javaMethod = retrieve java::Parametrizable corresponding to uMeth
+		val customType = retrieve optional java::ConcreteClassifier corresponding to umlParam.type
+		require absence of java::Parameter corresponding to umlParam
+	}
+	create {
+		val javaParam = new java::OrdinaryParameter
+	}
+	update {
 		javaParam.name = umlParam.name
 		javaMethod.parameters += javaParam
-        addCorrespondenceBetween(javaParam, umlParam)
-        changeJavaParameterType(umlParam, umlParam.type)
-        // TODO On initialization the Interfaces or DataTypes may not yet be synchronized, 
-        // because UML changes may have already been applied and Components are synchronized before Interfaces.
-        // But the typeChanged-Change will still occur after the containment hierarchy is established and correctly propagate the type information.
-    }
+		addCorrespondenceBetween(javaParam, umlParam)
+		changeJavaParameterType(umlParam, umlParam.type)
+	// TODO On initialization the Interfaces or DataTypes may not yet be synchronized, 
+	// because UML changes may have already been applied and Components are synchronized before Interfaces.
+	// But the typeChanged-Change will still occur after the containment hierarchy is established and correctly propagate the type information.
+	}
 }
 
 reaction UmlReturnParameterDeleted {
-    after element uml::Parameter removed from uml::Operation[ownedParameter]
-    with oldValue.direction == ParameterDirectionKind.RETURN_LITERAL
-    call setJavaMethodReturnType(affectedEObject, affectedEObject.getReturnResult)
+	after element uml::Parameter removed from uml::Operation[ownedParameter]
+	with oldValue.direction == ParameterDirectionKind.RETURN_LITERAL
+	call setJavaMethodReturnType(affectedEObject, affectedEObject.getReturnResult)
 }
 
 reaction UmlParameterDeleted {
-    after element uml::Parameter removed from uml::Operation[ownedParameter]
-    with oldValue.direction == ParameterDirectionKind.IN_LITERAL
-    call deleteJavaParameter(oldValue)
+	after element uml::Parameter removed from uml::Operation[ownedParameter]
+	with oldValue.direction == ParameterDirectionKind.IN_LITERAL
+	call deleteJavaParameter(oldValue)
 }
 
 routine deleteJavaParameter(uml::Parameter uParam) {
-    match {
-        val jParam = retrieve java::OrdinaryParameter corresponding to uParam
-    }
-    update {
-        removeObject(jParam)
-        removeCorrespondenceBetween(jParam, uParam)
-    }
+	match {
+		val jParam = retrieve java::OrdinaryParameter corresponding to uParam
+	}
+	update {
+		removeObject(jParam)
+		removeCorrespondenceBetween(jParam, uParam)
+	}
 }
 
 reaction UmlParameterTypeChanged {
-    after element uml::Type replaced at uml::Parameter[type]
-    with affectedEObject.direction == ParameterDirectionKind.IN_LITERAL
-    call  changeJavaParameterType(affectedEObject, newValue)
+	after element uml::Type replaced at uml::Parameter[type]
+	with affectedEObject.direction == ParameterDirectionKind.IN_LITERAL
+	call changeJavaParameterType(affectedEObject, newValue)
 }
 
 routine changeJavaParameterType(uml::Parameter uParam, uml::Type uType) {
-    match {
-        val jParam = retrieve java::OrdinaryParameter corresponding to uParam
-        val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uType
-    }
-    update {
+	match {
+		val jParam = retrieve java::OrdinaryParameter corresponding to uParam
+		val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uType
+	}
+	update {
 		umlToJavaTypePropagation.propagateOrdinaryParameterTypeChanged(uParam, jParam, jCustomType.orElse(null))
-    }
+	}
 }
 
 reaction RegularOrReturnParameterLowerChanged {
-    after element replaced at uml::Parameter[lowerValue]
-    call adaptParameterBoundChanged(affectedEObject.operation, affectedEObject)
+	after element replaced at uml::Parameter[lowerValue]
+	call adaptParameterBoundChanged(affectedEObject.operation, affectedEObject)
 }
 
 reaction RegularOrReturnParameterUpperChanged {
-    after element replaced at uml::Parameter[upperValue]
-    call adaptParameterBoundChanged(affectedEObject.operation, affectedEObject)
+	after element replaced at uml::Parameter[upperValue]
+	call adaptParameterBoundChanged(affectedEObject.operation, affectedEObject)
 }
 
 reaction RegularOrReturnParameterIntegerBoundChanged {
-    after attribute replaced at uml::LiteralInteger[value]
-    with affectedEObject.owner instanceof Parameter 
-        && affectedEObject.value == newValue
-    call adaptParameterBoundChanged((affectedEObject.owner as Parameter).operation, affectedEObject.owner as Parameter)
+	after attribute replaced at uml::LiteralInteger[value]
+	with affectedEObject.owner instanceof Parameter && affectedEObject.value == newValue
+	call adaptParameterBoundChanged((affectedEObject.owner as Parameter).operation, affectedEObject.owner as Parameter)
 }
 
 reaction RegularOrReturnParameterUnlimitedBoundChanged {
-    after attribute replaced at uml::LiteralUnlimitedNatural[value]
-    with affectedEObject.owner instanceof Parameter 
-        && affectedEObject.value == newValue
-    call adaptParameterBoundChanged((affectedEObject.owner as Parameter).operation, affectedEObject.owner as Parameter)
+	after attribute replaced at uml::LiteralUnlimitedNatural[value]
+	with affectedEObject.owner instanceof Parameter && affectedEObject.value == newValue
+	call adaptParameterBoundChanged((affectedEObject.owner as Parameter).operation, affectedEObject.owner as Parameter)
 }
 
 routine adaptParameterBoundChanged(uml::Operation uOperation, uml::Parameter uParam) {
-    update {
-        if(uParam.direction == ParameterDirectionKind.RETURN_LITERAL) {
-            setJavaMethodReturnType(uOperation, uParam)
-        } else if (uParam.direction == ParameterDirectionKind.IN_LITERAL) {
-            changeJavaParameterType(uParam, uParam.type)
-        }
-    }
+	update {
+		if (uParam.direction == ParameterDirectionKind.RETURN_LITERAL) {
+			setJavaMethodReturnType(uOperation, uParam)
+		} else if (uParam.direction == ParameterDirectionKind.IN_LITERAL) {
+			changeJavaParameterType(uParam, uParam.type)
+		}
+	}
 }
 
 reaction UmlParameterDirectionChangedFromIn {
-    after attribute replaced at uml::Parameter[direction]
-    with oldValue == ParameterDirectionKind.IN_LITERAL
-    call deleteJavaParameter(affectedEObject)
+	after attribute replaced at uml::Parameter[direction]
+	with oldValue == ParameterDirectionKind.IN_LITERAL
+	call deleteJavaParameter(affectedEObject)
 }
 
 reaction UmlParameterDirectionChangedFromReturn {
-    after attribute replaced at uml::Parameter[direction]
-    with oldValue == ParameterDirectionKind.RETURN_LITERAL
-    call adaptParameterDirectionChangedFromReturn(affectedEObject.operation)
+	after attribute replaced at uml::Parameter[direction]
+	with oldValue == ParameterDirectionKind.RETURN_LITERAL
+	call adaptParameterDirectionChangedFromReturn(affectedEObject.operation)
 }
 
 routine adaptParameterDirectionChangedFromReturn(uml::Operation uOperation) {
-    match {
-        val jMethod = retrieve java::Method corresponding to uOperation
-    }
-    update {
-        jMethod.typeReference = TypesFactory.eINSTANCE.createVoid
-    }
+	match {
+		val jMethod = retrieve java::Method corresponding to uOperation
+	}
+	update {
+		jMethod.typeReference = TypesFactory.eINSTANCE.createVoid
+	}
 }
 
 reaction UmlParameterDirectionChangedToIn {
-    after attribute replaced at uml::Parameter[direction]
-    with newValue == ParameterDirectionKind.IN_LITERAL
-    call createJavaParameter(affectedEObject.operation, affectedEObject)
+	after attribute replaced at uml::Parameter[direction]
+	with newValue == ParameterDirectionKind.IN_LITERAL
+	call createJavaParameter(affectedEObject.operation, affectedEObject)
 }
 
 reaction UmlParameterDirectionChangedToReturn {
-    after attribute replaced at uml::Parameter[direction]
-    with newValue == ParameterDirectionKind.RETURN_LITERAL
-    call adaptParameterDirectionChangedToReturn(affectedEObject.operation, affectedEObject)
+	after attribute replaced at uml::Parameter[direction]
+	with newValue == ParameterDirectionKind.RETURN_LITERAL
+	call adaptParameterDirectionChangedToReturn(affectedEObject.operation, affectedEObject)
 }
 
 routine adaptParameterDirectionChangedToReturn(uml::Operation uOperation, uml::Parameter uParam) {
-    match {
-        val jMethod = retrieve java::Method corresponding to uOperation
-        val jParam = retrieve optional java::OrdinaryParameter corresponding to uParam
-        val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uParam.type
-    }
-    update {
-        umlToJavaTypePropagation.propagateReturnParameterTypeChanged(uParam, jMethod, jCustomType.orElse(null))
-    }
+	match {
+		val jMethod = retrieve java::Method corresponding to uOperation
+		val jParam = retrieve optional java::OrdinaryParameter corresponding to uParam
+		val jCustomType = retrieve optional java::ConcreteClassifier corresponding to uParam.type
+	}
+	update {
+		umlToJavaTypePropagation.propagateReturnParameterTypeChanged(uParam, jMethod, jCustomType.orElse(null))
+	}
 }
 
 //===========================================
 //=========================================== Unsupported
 //===========================================
-
 reaction UmlParameterDirectionKindChangedInvalid {
-    after attribute replaced at uml::Parameter[direction]
-    with (newValue !== ParameterDirectionKind.RETURN_LITERAL)
-        && (newValue !== ParameterDirectionKind.IN_LITERAL)
-    call showMessage(userInteractor, "The ParameterDirectionKind " + newValue + " is not supported")
+	after attribute replaced at uml::Parameter[direction]
+	with (newValue !== ParameterDirectionKind.RETURN_LITERAL) && (newValue !== ParameterDirectionKind.IN_LITERAL)
+	call showMessage(userInteractor, "The ParameterDirectionKind " + newValue + " is not supported")
 }
 
 reaction UmlInterfaceMethodVisibilityChanged {
-    after attribute replaced at uml::Operation[visibility]
-    with (affectedEObject.eContainer instanceof Interface)
-        && newValue != VisibilityKind.PUBLIC_LITERAL
-    call showMessage(userInteractor, "Non-public operations in interface are not valid. Please set " + affectedEObject + " to public")
+	after attribute replaced at uml::Operation[visibility]
+	with (affectedEObject.eContainer instanceof Interface) && newValue != VisibilityKind.PUBLIC_LITERAL
+	call showMessage(userInteractor,
+		"Non-public operations in interface are not valid. Please set " + affectedEObject + " to public")
 }
 
 reaction UmlInterfaceMethodMadeFinal {
-    after attribute replaced at uml::Operation[isLeaf]
-    with affectedEObject.class_ instanceof Interface
-    call showMessage(userInteractor, "Final Operations in Interfaces are not supported. Please undo it: " + affectedEObject)
+	after attribute replaced at uml::Operation[isLeaf]
+	with affectedEObject.class_ instanceof Interface
+	call showMessage(userInteractor,
+		"Final Operations in Interfaces are not supported. Please undo it: " + affectedEObject)
 }

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -198,7 +198,7 @@ reaction UmlOperationMadeStatic {
 
 routine setStatic(uml::Operation uFeat) {
 	match {
-		val jMethod = retrieve java::Method corresponding to uFeat tagged with ""
+		val jMethod = retrieve java::Method corresponding to uFeat tagged ""
 	}
 	update {
 		jMethod.static = uFeat.isStatic
@@ -246,7 +246,7 @@ reaction UmlElementVisibilityChanged {
 
 routine changeJavaElementVisibility(uml::NamedElement uElem) {
 	match {
-		val jElem = retrieve java::AnnotableAndModifiable corresponding to uElem tagged with ""
+		val jElem = retrieve java::AnnotableAndModifiable corresponding to uElem tagged ""
 	}
 	update {
 		setJavaVisibility(jElem, uElem.visibility);

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaTypePropagation.reactions
@@ -14,31 +14,27 @@ reactions: umlToJavaTypePropagation
 in reaction to changes in uml
 execute actions in java
 
-routine propagatePropertyTypeChanged(uml::Property uProperty, java::Field jElement,
-		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-) {
+routine propagatePropertyTypeChanged(uml::Property uProperty, java::Field jElement, java::ConcreteClassifier jType) { // new type retrieved from correspondences or null
 	update {
 		propagateTypedMultiplicityElementTypeChanged_defaultObject(uProperty, uProperty, jElement, jType)
 	}
 }
 
-routine propagateReturnParameterTypeChanged(uml::Parameter uReturnParameter, java::Method jMethod,
-		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-) {
+routine propagateReturnParameterTypeChanged(uml::Parameter uReturnParameter, java::Method jMethod, java::ConcreteClassifier jType) { // new type retrieved from correspondences or null
 	update {
 		if (uReturnParameter.direction !== ParameterDirectionKind.RETURN_LITERAL) {
-			throw new IllegalStateException("An uml::Parameter with direction!=RETURN_LITERAL cannot be synchronized with a java::Method.")
+			throw new IllegalStateException(
+				"An uml::Parameter with direction!=RETURN_LITERAL cannot be synchronized with a java::Method.")
 		}
 		propagateTypedMultiplicityElementTypeChanged_defaultVoid(uReturnParameter, uReturnParameter, jMethod, jType)
 	}
 }
 
-routine propagateOrdinaryParameterTypeChanged(uml::Parameter uParameter, java::OrdinaryParameter jParameter,
-		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-) {
+routine propagateOrdinaryParameterTypeChanged(uml::Parameter uParameter, java::OrdinaryParameter jParameter, java::ConcreteClassifier jType) { // new type retrieved from correspondences or null
 	update {
 		if (uParameter.direction === ParameterDirectionKind.RETURN_LITERAL) {
-			throw new IllegalStateException("An uml::Parameter with direction==RETURN_LITERAL cannot be synchronized with a java::Parameter.")
+			throw new IllegalStateException(
+				"An uml::Parameter with direction==RETURN_LITERAL cannot be synchronized with a java::Parameter.")
 		} else {
 			propagateTypedMultiplicityElementTypeChanged_defaultObject(uParameter, uParameter, jParameter, jType)
 		}
@@ -46,15 +42,16 @@ routine propagateOrdinaryParameterTypeChanged(uml::Parameter uParameter, java::O
 }
 
 // ******** general variants to reduce code duplication. If possible please use the facade routines above
-routine propagateTypedMultiplicityElementTypeChanged(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
-		java::TypedElement jElement, // java::Field, java::Parameter, or java::Method
-		java::ConcreteClassifier jType, // new type retrieved from correspondences or null
-		java::TypeReference defaultReference) {
+// uElement is uml::Property or uml::Parameter
+// jElement is java::Field, java::Parameter, or java::Method
+// jType is new type retrieved from correspondences or null
+routine propagateTypedMultiplicityElementTypeChanged(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, java::TypedElement jElement, java::ConcreteClassifier jType, java::TypeReference defaultReference) {
 	match {
 		check {
-			if(uElement !== uMultiplicity) {
-				throw new IllegalStateException("uml::TypedElement uElement and uml::MultiplicityElement uMultiplicity"
-					+ " have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
+			if (uElement !== uMultiplicity) {
+				throw new IllegalStateException(
+					"uml::TypedElement uElement and uml::MultiplicityElement uMultiplicity" +
+						" have to be the same element (uml::Parameter or uml::Property) for this routine to work, but they were not."
 				)
 			}
 			true
@@ -63,15 +60,16 @@ routine propagateTypedMultiplicityElementTypeChanged(uml::TypedElement uElement,
 	update {
 		val existingJavaTypeReference = jElement.typeReference
 		var typeReference = createTypeReference(uElement.type, jType, defaultReference, userInteractor)
-		if(uMultiplicity.upper == LiteralUnlimitedNatural.UNLIMITED || uMultiplicity.upper > 1) {
-			if (typeReference === defaultReference){
+		if (uMultiplicity.upper == LiteralUnlimitedNatural.UNLIMITED || uMultiplicity.upper > 1) {
+			if (typeReference === defaultReference) {
 				// could not create a specific typeReference for the uElement.type
 				// default to java.lang.Object as an inner type
 				typeReference = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass)
 			}
 			if (isCollectionTypeReference(jElement.typeReference)) {
 				// reuse previously selected CollectionType
-				val collectionClassifier = getNormalizedClassifierFromTypeReference(jElement.typeReference) as ConcreteClassifier
+				val collectionClassifier = getNormalizedClassifierFromTypeReference(
+					jElement.typeReference) as ConcreteClassifier
 				typeReference = createCollectionTypeReference(collectionClassifier, typeReference)
 			} else {
 				// no previously selected CollectionType
@@ -81,25 +79,25 @@ routine propagateTypedMultiplicityElementTypeChanged(uml::TypedElement uElement,
 		}
 		if (!EcoreUtil.equals(existingJavaTypeReference, typeReference)) {
 			jElement.typeReference = typeReference
-			addJavaImport(jElement.containingCompilationUnit, typeReference)				
+			addJavaImport(jElement.containingCompilationUnit, typeReference)
 		}
 	}
 }
 
-routine propagateTypedMultiplicityElementTypeChanged_defaultObject(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
-		java::TypedElement jElement, // java::Field, java::Parameter, or java::Method
-		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-) {
+// uElement is uml::Property or uml::Parameter
+// jElement is java::Field, java::Parameter, or java::Method
+// jType is new type retrieved from correspondences or null
+routine propagateTypedMultiplicityElementTypeChanged_defaultObject(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, java::TypedElement jElement, java::ConcreteClassifier jType) {
 	update {
 		val objectNsRef = JavaModificationUtil.createNamespaceClassifierReference(jElement.objectClass) // default to java.lang.Object
 		propagateTypedMultiplicityElementTypeChanged(uElement, uMultiplicity, jElement, jType, objectNsRef)
 	}
 }
 
-routine propagateTypedMultiplicityElementTypeChanged_defaultVoid(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, // uml::Property or uml::Parameter
-		java::TypedElement jElement, // java::Field, java::Parameter, or java::Method
-		java::ConcreteClassifier jType // new type retrieved from correspondences or null
-) {
+// uElement is uml::Property or uml::Parameter
+// jElement is java::Field, java::Parameter, or java::Method
+// jType is new type retrieved from correspondences or null
+routine propagateTypedMultiplicityElementTypeChanged_defaultVoid(uml::TypedElement uElement, uml::MultiplicityElement uMultiplicity, java::TypedElement jElement, java::ConcreteClassifier jType) {
 	update {
 		val voidRef = TypesFactory.eINSTANCE.createVoid
 		propagateTypedMultiplicityElementTypeChanged(uElement, uMultiplicity, jElement, jType, voidRef)


### PR DESCRIPTION
This PR adapts to the correction of the Reactions formatter in vitruv-tools/Vitruv-DSLs#43.
It consists of replacing the `tagged with` keyword with the `tagged` keyword and of reformatting all Reactions files using the formatter.