### PR TITLE
Adapt to changes parameter name in retrieval precondition methods

### DIFF
--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/java2pcm/Java2PcmClassifier.reactions
@@ -53,7 +53,7 @@ routine createPackageEClassCorrespondence(java::Package jPackage) {
 routine createOrFindArchitecturalElement(java::Package javaPackage, String containerName) {
 	match {
 		val containerPackage = retrieve optional java::Package corresponding to ContainersPackage.Literals.
-			PACKAGE with containerPackage.name == containerName
+			PACKAGE with name == containerName
 		require absence of pcm::RepositoryComponent corresponding to javaPackage
 		// ensure that we are not the root package (happens when the root package is being moved)
 		require absence of pcm::Repository corresponding to javaPackage tagged "package_root"
@@ -118,7 +118,7 @@ routine createOrFindRepository(java::Package javaPackage, String packageName, St
 		require absence of pcm::Repository corresponding to javaPackage tagged newTag
 		require absence of pcm::Repository corresponding to ContainersPackage.Literals.PACKAGE
 		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.
-			REPOSITORY with javaPackage.isPackageFor(foundRepository)
+			REPOSITORY with javaPackage.isPackageFor(it)
 	}
 	update {
 		if (foundRepository.isPresent) {
@@ -171,7 +171,7 @@ routine createOrFindSystem(java::Package javaPackage, String name) {
 	match {
 		require absence of pcm::System corresponding to javaPackage
 		val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM with javaPackage.
-			isPackageFor(foundSystem)
+			isPackageFor(it)
 	}
 	update {
 		if (foundSystem.isPresent) {
@@ -318,9 +318,8 @@ reaction InterfaceCreated {
 
 routine createOrFindPCMInterface(java::Interface javaInterface, java::CompilationUnit compilationUnit) {
 	match {
-		val containingPackage = retrieve java::Package corresponding to ContainersPackage.Literals.
-			PACKAGE with containingPackage.namespacesAsString + containingPackage.name + "." ==
-			compilationUnit.namespacesAsString
+		val containingPackage = retrieve java::Package corresponding to ContainersPackage.Literals.PACKAGE with 
+			namespacesAsString + name + "." == compilationUnit.namespacesAsString
 		val pcmRepository = retrieve optional pcm::Repository corresponding to containingPackage tagged "contracts"
 		require absence of pcm::OperationInterface corresponding to javaInterface
 	}

--- a/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
+++ b/bundles/tools.vitruv.applications.pcmjava/src/tools/vitruv/applications/pcmjava/pcm2java/Pcm2Java.reactions
@@ -358,8 +358,7 @@ reaction RenameComponent {
 routine renameComponentPackageAndClass(pcm::RepositoryComponent component) {
 	match {
 		val repositoryPackage = retrieve java::Package corresponding to component.
-			repository__RepositoryComponent with repositoryPackage.name ==
-			component.repository__RepositoryComponent.entityName
+			repository__RepositoryComponent with name == component.repository__RepositoryComponent.entityName
 	}
 	update {
 		renameJavaPackage(component, repositoryPackage, component.entityName, null);
@@ -398,8 +397,8 @@ reaction RenamedInterface {
 
 routine renameInterface(pcm::OperationInterface interf) {
 	match {
-		val contractsPackage = retrieve java::Package corresponding to interf.
-			repository__Interface with contractsPackage.name == "contracts"
+		val contractsPackage = retrieve java::Package corresponding to interf.repository__Interface with name ==
+			"contracts"
 	}
 	update {
 		renameJavaClassifier(interf, contractsPackage, interf.entityName)
@@ -416,7 +415,7 @@ reaction CreatedCompositeDataType {
 routine createCompositeDataTypeImplementation(pcm::CompositeDataType compositeDataType) {
 	match {
 		val datatypesPackage = retrieve java::Package corresponding to compositeDataType.
-			repository__DataType with datatypesPackage.name == "datatypes"
+			repository__DataType with name == "datatypes"
 	}
 	update {
 		createOrFindDataTypeClass(compositeDataType, datatypesPackage)
@@ -441,7 +440,7 @@ reaction RenamedCompositeDataType {
 routine renameCompositeDataType(pcm::CompositeDataType compositeDataType) {
 	match {
 		val datatypesPackage = retrieve java::Package corresponding to compositeDataType.
-			repository__DataType with datatypesPackage.name == "datatypes"
+			repository__DataType with name == "datatypes"
 	}
 	update {
 		renameJavaClassifier(compositeDataType, datatypesPackage, compositeDataType.entityName)
@@ -461,8 +460,8 @@ reaction CreatedCollectionDataType {
 routine createCollectionDataTypeImplementation(pcm::CollectionDataType dataType) {
 	match {
 		val innerTypeClass = retrieve optional java::Class corresponding to dataType.innerType_CollectionDataType
-		val datatypesPackage = retrieve java::Package corresponding to dataType.
-			repository__DataType with datatypesPackage.name == "datatypes"
+		val datatypesPackage = retrieve java::Package corresponding to dataType.repository__DataType with name ==
+			"datatypes"
 	}
 	update {
 		// create correct (and in case of primitive types wrapped) type reference for the inner type
@@ -517,7 +516,7 @@ reaction RenamedCollectionDataType {
 routine renameCollectionDataType(pcm::CollectionDataType collectionDataType) {
 	match {
 		val datatypesPackage = retrieve java::Package corresponding to collectionDataType.
-			repository__DataType with datatypesPackage.name == "datatypes"
+			repository__DataType with name == "datatypes"
 	}
 	update {
 		renameJavaClassifier(collectionDataType, datatypesPackage, collectionDataType.entityName)
@@ -629,8 +628,8 @@ routine createOrFindJavaPackage(EObject sourceElementMappedToPackage, java::Pack
 	match {
 		require absence of java::Package corresponding to sourceElementMappedToPackage tagged newTag
 		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.
-			PACKAGE with matchingPackages.name.toLowerCase == packageName.toLowerCase && (parentPackage === null ||
-			matchingPackages.namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + ".")
+			PACKAGE with name.toLowerCase == packageName.toLowerCase && (parentPackage === null ||
+			namespacesAsString == parentPackage.namespacesAsString + parentPackage.name + ".")
 	}
 	update {
 		if (matchingPackages.empty) {
@@ -1007,7 +1006,7 @@ routine removeParameterToFieldAssignmentFromConstructor(java::Constructor ctor, 
 routine removeCorrespondingParameterFromConstructor(java::Constructor ctor, pcm::NamedElement correspondenceSource) {
 	match {
 		val param = retrieve java::OrdinaryParameter corresponding to correspondenceSource with ctor.parameters.
-			contains(param)
+			contains(it)
 	}
 	update {
 		removeObject(param)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/pcm2uml/PcmRepository.reactions
@@ -187,9 +187,9 @@ routine bootstrapPrimitiveDatatypes(pcm::Repository pcmRepo) {
 routine addPrimitiveDatatypeCorrespondence(pcm::PrimitiveDataType pcmPrimitiveType, uml::PrimitiveType umlPrimitiveType) {
 	match {
 		require absence of uml::PrimitiveType corresponding to pcmPrimitiveType tagged TagLiterals.
-			DATATYPE__TYPE with potentialTarget == umlPrimitiveType
+			DATATYPE__TYPE with it == umlPrimitiveType
 		require absence of pcm::PrimitiveDataType corresponding to umlPrimitiveType tagged TagLiterals.
-			DATATYPE__TYPE with potentialTarget == pcmPrimitiveType
+			DATATYPE__TYPE with it == pcmPrimitiveType
 	}
 	update {
 		addCorrespondenceBetween(pcmPrimitiveType, umlPrimitiveType, TagLiterals.DATATYPE__TYPE)

--- a/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
+++ b/bundles/tools.vitruv.applications.pcmumlclass/src/tools/vitruv/applications/pcmumlclass/uml2pcm/UmlRepositoryAndSystemPackage.reactions
@@ -100,7 +100,7 @@ routine createOrFindCorrespondingRepository(uml::Package umlPkg, uml::Package um
 	match {
 		require absence of pcm::Repository corresponding to umlPkg tagged TagLiterals.REPOSITORY_TO_REPOSITORY_PACKAGE
 		val foundRepository = retrieve optional pcm::Repository corresponding to RepositoryPackage.Literals.
-			REPOSITORY with umlPkg.isPackageFor(foundRepository)
+			REPOSITORY with umlPkg.isPackageFor(it)
 	}
 	update {
 		if (foundRepository.isPresent) {
@@ -165,7 +165,7 @@ routine createOrFindCorrespondingSystem(uml::Package umlPkg, uml::Package umlPar
 	match {
 		require absence of pcm::System corresponding to umlPkg tagged TagLiterals.SYSTEM__SYSTEM_PACKAGE
 		val foundSystem = retrieve optional pcm::System corresponding to SystemPackage.Literals.SYSTEM with umlPkg.
-			isPackageFor(foundSystem)
+			isPackageFor(it)
 	}
 	update {
 		if (foundSystem.isPresent) {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/java2uml/JavaToUmlMethod.reactions
@@ -34,7 +34,7 @@ reaction JavaClassMethodCreated {
 
 routine createOrFindUmlClassMethod(java::ClassMethod jMethod, java::ConcreteClassifier jClassifier) {
 	match {
-		val uClassifier = retrieve uml::Classifier corresponding to jClassifier with uClassifier instanceof OperationOwner
+		val uClassifier = retrieve uml::Classifier corresponding to jClassifier with it instanceof OperationOwner
 		require absence of uml::Operation corresponding to jMethod
 		require absence of uml::Property corresponding to jMethod tagged UmlJavaCorrespondenceTag.GETTER
 		require absence of uml::Property corresponding to jMethod tagged UmlJavaCorrespondenceTag.SETTER

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaClassifier.reactions
@@ -512,8 +512,7 @@ routine createOrFindJavaPackage(uml::Package uPackage) {
 	match {
 		require absence of java::Package corresponding to uPackage
 		val matchingPackages = retrieve many java::Package corresponding to ContainersPackage.Literals.
-			PACKAGE with matchingPackages.namespacesAsString + matchingPackages.name ==
-			getUmlNamespaceAsString(uPackage)
+			PACKAGE with namespacesAsString + name == getUmlNamespaceAsString(uPackage)
 	}
 	update {
 		if (matchingPackages.empty) {

--- a/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
+++ b/bundles/tools.vitruv.applications.umljava/src/tools/vitruv/applications/umljava/uml2java/UmlToJavaMethod.reactions
@@ -145,8 +145,8 @@ routine addMethodCorrespondence(java::Member javaMethodOrConstructor, uml::Opera
 
 routine insertJavaMethod(uml::Operation umlOperation, uml::Classifier umlClassifier) {
 	match {
-		val javaMethod = retrieve java::Member corresponding to umlOperation with javaMethod instanceof Constructor ||
-			javaMethod instanceof Method
+		val javaMethod = retrieve java::Member corresponding to umlOperation with it instanceof Constructor ||
+			it instanceof Method
 		val javaClassifier = retrieve java::ConcreteClassifier corresponding to umlClassifier
 	}
 	update {
@@ -161,8 +161,8 @@ reaction UmlMethodDeleted {
 
 routine deleteJavaMethod(uml::Operation umlOperation) {
 	match {
-		val javaMethod = retrieve java::Member corresponding to umlOperation with javaMethod instanceof Constructor ||
-			javaMethod instanceof Method
+		val javaMethod = retrieve java::Member corresponding to umlOperation with it instanceof Constructor ||
+			it instanceof Method
 	}
 	update {
 		removeObject(javaMethod)


### PR DESCRIPTION
Adapts to referencing a potentially corresponding element in the precondition `with` block of a correspondence retrieval with the name `it` introduced in vitruv-tools/Vitruv-DSLs#49.