### PR TITLE
Remove unicode character

### DIFF
--- a/bundles/tools.vitruv.applications.cbs.testutils/src/tools/vitruv/applications/cbs/testutils/equivalencetest/DefaultEquivalenceTestBuilder.xtend
+++ b/bundles/tools.vitruv.applications.cbs.testutils/src/tools/vitruv/applications/cbs/testutils/equivalencetest/DefaultEquivalenceTestBuilder.xtend
@@ -148,7 +148,7 @@ package class DefaultEquivalenceTestBuilder extends DefaultBuilderCommon impleme
 				val testStep = modifyIfNecessary(args.value)
 					
 				val referenceSteps = testStep.determineReferenceSteps(steps)
-				var testName = '''«testMetamodel.name» «'\u2192' /* right arrow */ » {«FOR rd : referenceSteps.keySet SEPARATOR ', '»«rd.name»«ENDFOR»}'''
+				var testName = '''«testMetamodel.name» «'-x' » {«FOR rd : referenceSteps.keySet SEPARATOR ', '»«rd.name»«ENDFOR»}'''
 				if (testStep.name !== null) {
 					testName += ''' — «testStep.name»'''
 				}


### PR DESCRIPTION
The CI build for windows fails, for example [here](https://github.com/vitruv-tools/Vitruv-Applications-ComponentBasedSystems/runs/7721049043?check_suite_focus=true). The reason for the build to fail on windows exclusively may be the usage of the unicode character "U+2192" in the xtend file below. The character is rendered in the generated java file as "→". The github actions windows container seems not to support this character and renders it as "?". As the character is appended to a file path and "?" is not allowed in windows file paths, the file cannot be found. On Linux and Mac "?" is allowed in paths and may even be supported by the container which results in the tests success.